### PR TITLE
Fixed: Improvements to the emscripten build script

### DIFF
--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -61,7 +61,7 @@ FILENAME="verovio-toolkit$ASM_NAME$VERSION_NAME.js"
 echo "Sync svg resources"
 cp -r ../data/svg data/
 
-echo "Compliling"
+echo "Compiling"
 
 python $EMCC --closure 1 -O2 \
 	-I./lib/jsonxx \


### PR DESCRIPTION
Previously the build script would fail with a python error if the emscripten compiler was not found. This commit adds support for checking if the compiler exists on the path, and failing with an error message if it does not.

Also fixed the shebang to use /usr/bin/env bash in case bash was not at /bin/bash.
