### PR TITLE
Alternate emscripten build flag for WebWorker compatibility

### DIFF
--- a/emscripten/build.sh
+++ b/emscripten/build.sh
@@ -3,6 +3,7 @@
 function print_help {
 	 echo "Usage:
 -l		Light version without ASM and no increased memory allocation
+-w 		WebWorker-compatible build.
 -v N		Version number (e.g., 1.0.0); no number by default
 -c		Turns on \"Chatty\" compiling; Will print the compiler progress" >&2 ; 
 } 
@@ -36,8 +37,9 @@ ASM_NAME=""
 VERSION=""
 VERSION_NAME=""
 CHATTY=""
+WEBWORKER=false
 
-while getopts "lv:h:c" opt; do
+while getopts "lwv:h:c" opt; do
 	case $opt in
 		l)
 			echo "light version (-l)"
@@ -54,6 +56,10 @@ while getopts "lv:h:c" opt; do
 		c)
 			CHATTY="-v"
 			echo $EMCC
+			;;
+		w)
+			WEBWORKER=true
+			echo "building with webworker compatibility"
 			;;
 		h)
 			print_help
@@ -154,7 +160,11 @@ python $EMCC $CHATTY \
 if [ $? -eq 0 ]; then 
 	echo "Done."
 	# the wrapper is necessary with closure 1 for avoiding to conflict with globals
-	cat verovio-wrapper-start.js build/verovio.js verovio-wrapper-end.js verovio-proxy.js > "build/$FILENAME"
+	if [ "$WEBWORKER" = true ]; then
+		cat build/verovio.js verovio-webworker-proxy.js > "build/$FILENAME"
+	else
+		cat verovio-wrapper-start.js build/verovio.js verovio-wrapper-end.js verovio-proxy.js > "build/$FILENAME"
+	fi
 	# all good
 	echo "build/$FILENAME written"
 	# create also a zip file if version name is given

--- a/emscripten/verovio-webworker-proxy.js
+++ b/emscripten/verovio-webworker-proxy.js
@@ -1,0 +1,108 @@
+
+var verovio = verovio || {};
+
+/***************************************************************************************************************************/
+// Proxy the exported c++ methods
+verovio.vrvToolkit = verovio.vrvToolkit || {};
+
+// Constructor and destructor
+// Toolkit *constructor()
+verovio.vrvToolkit.constructor = Module.cwrap('vrvToolkit_constructor', 'number', []);
+
+// void destructor(Toolkit *ic)
+verovio.vrvToolkit.destructor = Module.cwrap('vrvToolkit_destructor', null, ['number']);
+
+// char *getLog(Toolkit *ic)
+verovio.vrvToolkit.getLog = Module.cwrap('vrvToolkit_getLog', 'string', ['number']);
+
+// int getPageCount(Toolkit *ic)
+verovio.vrvToolkit.getPageCount = Module.cwrap('vrvToolkit_getPageCount', 'number', ['number']);
+
+// int getPageWithElement(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getPageWithElement = Module.cwrap('vrvToolkit_getPageWithElement', 'number', ['number', 'string']);
+
+// bool loadData(Toolkit *ic, const char *data )
+verovio.vrvToolkit.loadData = Module.cwrap('vrvToolkit_loadData', 'number', ['number', 'string']);
+
+// void redoLayout(Toolkit *ic)
+verovio.vrvToolkit.redoLayout = Module.cwrap('vrvToolkit_redoLayout', null, ['number']);
+
+// char *renderData(Toolkit *ic, const char *data, const char *options )
+verovio.vrvToolkit.renderData = Module.cwrap('vrvToolkit_renderData', 'string', ['number', 'string', 'string']);
+
+// char *renderPage(Toolkit *ic, int pageNo, const char *rendering_options )
+verovio.vrvToolkit.renderPage = Module.cwrap('vrvToolkit_renderPage', 'string', ['number', 'number', 'string']);
+
+
+// char *getMEI(Toolkit *ic, int pageNo )
+verovio.vrvToolkit.getMEI = Module.cwrap('vrvToolkit_getMEI', 'string', ['number', 'number']);
+
+// void setOptions(Toolkit *ic, const char *options) 
+verovio.vrvToolkit.setOptions = Module.cwrap('vrvToolkit_setOptions', null, ['number', 'string']);
+
+// A pointer to the object - only one instance can be created for now
+verovio.ptr = 0;
+
+// add a listener that will delete the object (if necessary) when the page is left
+/*window.addEventListener ("unload", function () {
+	if (verovio.ptr != 0) {
+		verovio.vrvToolkit.destructor( verovio.ptr );
+	}
+});*/
+
+/***************************************************************************************************************************/
+
+verovio.toolkit = function() {
+	// check if we already have one instance
+	if (verovio.ptr != 0) {
+		console.log("For now only one instance of the toolkit can be created");
+		this.ptr = verovio.ptr;
+		return;
+	}
+	// if not, then create it
+	this.ptr = verovio.vrvToolkit.constructor();
+	verovio.ptr = this.ptr;
+}
+
+verovio.toolkit.prototype.destroy = function () {
+  	verovio.vrvToolkit.destructor(this.ptr);
+	verovio.ptr = 0;
+};
+
+verovio.toolkit.prototype.getLog = function () {
+  	return verovio.vrvToolkit.getLog(this.ptr);
+};
+
+verovio.toolkit.prototype.getPageCount = function () {
+  	return verovio.vrvToolkit.getPageCount(this.ptr);
+};
+
+verovio.toolkit.prototype.getPageWithElement = function (xmlId) {
+  	return verovio.vrvToolkit.getPageWithElement(this.ptr, xmlId);
+};
+
+verovio.toolkit.prototype.loadData = function (data) {
+  	return verovio.vrvToolkit.loadData(this.ptr, data);
+};
+
+verovio.toolkit.prototype.redoLayout = function () {
+  	verovio.vrvToolkit.redoLayout(this.ptr);
+}
+
+verovio.toolkit.prototype.renderData = function (data, options) {
+  	return verovio.vrvToolkit.renderData(this.ptr, data, options);
+};
+
+verovio.toolkit.prototype.renderPage = function (page_no, options) {
+  	return verovio.vrvToolkit.renderPage(this.ptr, page_no, options);
+};
+
+verovio.toolkit.prototype.getMEI = function (page_no) {
+  	return verovio.vrvToolkit.getMEI(this.ptr, page_no);
+};
+
+verovio.toolkit.prototype.setOptions = function (options) {
+	verovio.vrvToolkit.setOptions(this.ptr, options);
+};
+
+/***************************************************************************************************************************/


### PR DESCRIPTION
When trying to compile using Emscripten, the resulting .js file fails as a webworker for two reasons.

-First, the "Module" variable is not accessible outside the function wrapper created by verovio-wrapper-start/end.js.

-Second, the "window" variable is not accessible in the isolated WebWorker environment, thus the "unload" listener in verovio-proxy.js can not be included.

The pull request solves this by adding a "-w" flag for the build.sh script that triggers these two changes. Included is also a "verovio-webworker-proxy.js" file that has the "unload" listener commented out. I'm not sure how safe the latter fix is, and whether everything will be removed from memory, but I'm fairly certain the only way to communicate with a webworker is via the "onmessage" event. Thus, this can be implemented by developers, but in a file other than verovio-toolkit.js.
