### PR TITLE
cleaning up svg output

### DIFF
--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -96,7 +96,6 @@ void Doc::Reset()
 
     m_drawingSmuflFontSize = 0;
     m_drawingLyricFontSize = 0;
-    m_drawingLyricFont.SetFaceName("Times");
 }
 
 void Doc::SetType(DocType type)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -159,14 +159,6 @@ void SvgDeviceContext::StartGraphic(Object *object, std::string gClass, std::str
         m_currentNode.append_attribute("id") = gId.c_str();
     }
 
-    if (object->HasAttClass(ATT_VISIBILITY)) {
-        AttVisibility *att = dynamic_cast<AttVisibility *>(object);
-        assert(att);
-        if (att->GetVisible() == BOOLEAN_false) {
-            m_currentNode.append_attribute("visibility") = "hidden";
-        }
-    }
-
     if (object->HasAttClass(ATT_COLOR)) {
         AttColor *att = dynamic_cast<AttColor *>(object);
         assert(att);
@@ -176,6 +168,14 @@ void SvgDeviceContext::StartGraphic(Object *object, std::string gClass, std::str
         }
     }
 
+    if (object->HasAttClass(ATT_VISIBILITY)) {
+        AttVisibility *att = dynamic_cast<AttVisibility *>(object);
+        assert(att);
+        if (att->GetVisible() == BOOLEAN_false) {
+            m_currentNode.append_attribute("visibility") = "hidden";
+        }
+    }
+    
     // m_currentNode.append_attribute("style") = StringFormat("stroke: #%s; stroke-opacity: %f; fill: #%s; fill-opacity:
     // %f;",
     // GetColour(currentPen.GetColour()).c_str(), currentPen.GetOpacity(), GetColour(currentBrush.GetColour()).c_str(),
@@ -240,6 +240,11 @@ void SvgDeviceContext::StartPage()
     // Initialize the flag to false because we want to know if the font needs to be included in the SVG
     m_vrvTextFont = false;
 
+    // default styles
+    m_currentNode = m_currentNode.append_child("style");
+    m_currentNode.append_child(pugi::node_pcdata).set_value("g.page-margin{font-family:Times;} g.tempo{font-weight:bold;} g.dir, g.dynam {font-style:italic;}");
+    m_currentNode = m_svgNodeStack.back();
+    
     // a graphic for definition scaling
     m_currentNode = m_currentNode.append_child("svg");
     m_svgNodeStack.push_back(m_currentNode);
@@ -253,7 +258,7 @@ void SvgDeviceContext::StartPage()
     m_currentNode.append_attribute("class") = "page-margin";
     m_currentNode.append_attribute("transform")
         = StringFormat("translate(%d, %d)", (int)((double)m_originX), (int)((double)m_originY)).c_str();
-    m_currentNode.append_attribute("style") = "stroke: #000; stroke-opacity: 1.0; fill: #000; fill-opacity: 1.0";
+    m_currentNode.append_attribute("style") = "stroke: #000; fill: #000;";
 }
 
 void SvgDeviceContext::EndPage()
@@ -327,15 +332,13 @@ void SvgDeviceContext::DrawComplexBezierPath(Point bezier1[4], Point bezier2[4])
               bezier2[2].x, bezier2[2].y, bezier2[1].x, bezier2[1].y, bezier2[0].x, bezier2[0].y // Second Bezier
               )
               .c_str();
-    // pathChild.append_attribute("style") = StringFormat("fill:#000; fill-opacity:1.0; stroke:#000000;
-    // stroke-linecap:round; stroke-linejoin:round;
-    // stroke-opacity:1.0; stroke-width: %d", m_penStack.top().GetWidth()).c_str();
-    // without colour
-    pathChild.append_attribute("style")
-        = StringFormat(
-              "fill-opacity:1.0; stroke-linecap:round; stroke-linejoin:round; stroke-opacity:1.0; stroke-width: %d",
-              m_penStack.top().GetWidth())
-              .c_str();
+    // pathChild.append_attribute("fill") = "#000000";
+    // pathChild.append_attribute("fill-opacity") = "1";
+    // pathChild.append_attribute("stroke") = "#000000";
+    pathChild.append_attribute("stroke-linecap") = "round";
+    pathChild.append_attribute("stroke-linejoin") = "round";
+    // pathChild.append_attribute("stroke-opacity") = "1";
+    pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
 void SvgDeviceContext::DrawCircle(int x, int y, int radius)
@@ -359,16 +362,11 @@ void SvgDeviceContext::DrawEllipse(int x, int y, int width, int height)
     ellipseChild.append_attribute("cy") = y + rh;
     ellipseChild.append_attribute("rx") = rw;
     ellipseChild.append_attribute("ry") = rh;
-
-    // ellipseChild.append_attribute("style") = StringFormat("stroke: #%s; stroke-opacity: %f; stroke-width: %d; fill:
-    // #%s; fill-opacity: %f;",
-    // GetColour(currentPen.GetColour()).c_str(), currentPen.GetOpacity(), currentPen.GetWidth(),
-    //    GetColour(currentBrush.GetColour()).c_str(), currentBrush.GetOpacity()).c_str();
-    // without colour
-    ellipseChild.append_attribute("style")
-        = StringFormat("stroke-opacity: %f; stroke-width: %d; fill-opacity: %f;", currentPen.GetOpacity(),
-              currentPen.GetWidth(), currentBrush.GetOpacity())
-              .c_str();
+    // ellipseChild.append_attribute("fill") = "#000000";
+    if (currentBrush.GetOpacity() != 1.0) ellipseChild.append_attribute("fill-opacity") = currentBrush.GetOpacity();
+    // ellipseChild.append_attribute("stroke") = "#000000";
+    if (currentPen.GetOpacity() != 1.0) ellipseChild.append_attribute("stroke-opacity") = currentPen.GetOpacity();
+    if (currentPen.GetWidth() != 1) ellipseChild.append_attribute("stroke-width") = currentPen.GetWidth();
 }
 
 void SvgDeviceContext::DrawEllipticArc(int x, int y, int width, int height, double start, double end)
@@ -433,25 +431,21 @@ void SvgDeviceContext::DrawEllipticArc(int x, int y, int width, int height, doub
     pathChild.append_attribute("d") = StringFormat("M%d %d A%d %d 0.0 %d %d %d %d", int(xs), int(ys), abs(int(rx)),
                                           abs(int(ry)), fArc, fSweep, int(xe), int(ye))
                                           .c_str();
-    // pathChild.append_attribute("style") = StringFormat("stroke: #%s; stroke-opacity: %f; stroke-width: %d; fill: #%s;
-    // fill-opacity: %f;",
-    // GetColour(currentPen.GetColour()).c_str(), currentPen.GetOpacity(), currentPen.GetWidth(),
-    //                                                        GetColour(currentBrush.GetColour()).c_str(),
-    //                                                        currentBrush.GetOpacity()).c_str();
-    // without colour
-    pathChild.append_attribute("style") = StringFormat("stroke-opacity: %f; stroke-width: %d; fill-opacity: %f;",
-                                              currentPen.GetOpacity(), currentPen.GetWidth(), currentBrush.GetOpacity())
-                                              .c_str();
+    // pathChild.append_attribute("fill") = "#000000";
+    if (currentBrush.GetOpacity() != 1.0) pathChild.append_attribute("fill-opacity") = currentBrush.GetOpacity();
+    // pathChild.append_attribute("stroke") = "#000000";
+    if (currentPen.GetOpacity() != 1.0) pathChild.append_attribute("stroke-opacity") = currentPen.GetOpacity();
+    if (currentPen.GetWidth() != 1) pathChild.append_attribute("stroke-width") = currentPen.GetWidth();
 }
 
 void SvgDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
 {
     pugi::xml_node pathChild = AppendChild("path");
     pathChild.append_attribute("d") = StringFormat("M%d %d L%d %d", x1, y1, x2, y2).c_str();
-    pathChild.append_attribute("style") = StringFormat("stroke-width: %d;", m_penStack.top().GetWidth()).c_str();
     if (m_penStack.top().GetDashLenght() > 0)
         pathChild.append_attribute("stroke-dasharray")
             = StringFormat("%d, %d", m_penStack.top().GetDashLenght(), m_penStack.top().GetDashLenght()).c_str();
+    if (m_penStack.top().GetWidth() != 1) pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
 void SvgDeviceContext::DrawPolygon(int n, Point points[], int xoffset, int yoffset, int fill_style)
@@ -508,10 +502,10 @@ void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height,
     pugi::xml_node rectChild = AppendChild("rect");
     rectChild.append_attribute("x") = x;
     rectChild.append_attribute("y") = y;
-    rectChild.append_attribute("width") = width;
     rectChild.append_attribute("height") = height;
+    rectChild.append_attribute("width") = width;
     rectChild.append_attribute("rx") = radius;
-    rectChild.append_attribute("style") = StringFormat("stroke-width: %d;", m_penStack.top().GetWidth()).c_str();
+    rectChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
     // rectChild.append_attribute("fill-opacity") = "0.0"; // for empty rectangles with bounding boxes
 }
 
@@ -531,8 +525,9 @@ void SvgDeviceContext::StartText(int x, int y, char alignment)
     m_svgNodeStack.push_back(m_currentNode);
     m_currentNode.append_attribute("x") = x;
     m_currentNode.append_attribute("y") = y;
-    m_currentNode.append_attribute("dx") = 0;
-    m_currentNode.append_attribute("dy") = 0;
+    // unless dx, dy have a value they don't need to be set
+    // m_currentNode.append_attribute("dx") = 0;
+    // m_currentNode.append_attribute("dy") = 0;
     if (!anchor.empty()) {
         m_currentNode.append_attribute("text-anchor") = anchor.c_str();
     }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -242,6 +242,7 @@ void SvgDeviceContext::StartPage()
 
     // default styles
     m_currentNode = m_currentNode.append_child("style");
+    m_currentNode.append_attribute("type") = "text/css";
     m_currentNode.append_child(pugi::node_pcdata).set_value("g.page-margin{font-family:Times;} g.tempo{font-weight:bold;} g.dir, g.dynam {font-style:italic;}");
     m_currentNode = m_svgNodeStack.back();
     

--- a/src/view_floating.cpp
+++ b/src/view_floating.cpp
@@ -1444,10 +1444,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
 
     dc->StartGraphic(dir, "", dir->GetUuid());
 
-    // Use Romam bold for tempo
     FontInfo dirTxt;
-    dirTxt.SetFaceName("Times");
-    dirTxt.SetStyle(FONTSTYLE_italic);
 
     // If we have not timestamp
     int x = dir->GetStart()->GetDrawingX();
@@ -1496,10 +1493,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
         dynamSymbol = dynam->GetSymbolStr();
     }
 
-    // Use Romam bold for tempo
     FontInfo dynamTxt;
-    dynamTxt.SetFaceName("Times");
-    dynamTxt.SetStyle(FONTSTYLE_italic);
 
     // If we have not timestamp
     int x = dynam->GetStart()->GetDrawingX();
@@ -1551,9 +1545,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
 
     dc->StartGraphic(harm, "", harm->GetUuid());
 
-    // Use Romam bold for tempo
     FontInfo dirTxt;
-    dirTxt.SetFaceName("Times");
 
     // If we have not timestamp
     int x = harm->GetStart()->GetDrawingX();
@@ -1633,10 +1625,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
 
     dc->StartGraphic(tempo, "", tempo->GetUuid());
 
-    // Use Romam bold for tempo
     FontInfo tempoTxt;
-    tempoTxt.SetFaceName("Times");
-    tempoTxt.SetWeight(FONTWEIGHT_bold);
 
     // If we have not timestamp
     int x = measure->GetDrawingX();


### PR DESCRIPTION
This basically removes the Verovio font defaults and puts them into a single style element. That makes styling text elements with CSS much easier and more intuitive. Also it reduces and clears up the output, as things like `@font-family` don't have to be printed over and over again. 

Additionally all style attributes have been replaced by the proper properties, again for easier access via CSS. Also this is more as SVG (Tiny) is meant to be. 

At last, attributes that just carry the SVG default values (e.g. stroke-opacity="1") are no longer printed, resulting in a much lesser cluttered SVG. 

This reduces the size of the rendered Schubert_Lindenbaum.mei by 9% (22149 bytes) and the Chopin Etude by 5% (27039 bytes).

**This all doesn't change the look of the rendering!**
