### PR TITLE
finishing SVG cleaning

### DIFF
--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -175,7 +175,7 @@ void SvgDeviceContext::StartGraphic(Object *object, std::string gClass, std::str
             m_currentNode.append_attribute("visibility") = "hidden";
         }
     }
-    
+
     // m_currentNode.append_attribute("style") = StringFormat("stroke: #%s; stroke-opacity: %f; fill: #%s; fill-opacity:
     // %f;",
     // GetColour(currentPen.GetColour()).c_str(), currentPen.GetOpacity(), GetColour(currentBrush.GetColour()).c_str(),
@@ -240,9 +240,10 @@ void SvgDeviceContext::StartPage()
     // default styles
     m_currentNode = m_currentNode.append_child("style");
     m_currentNode.append_attribute("type") = "text/css";
-    m_currentNode.append_child(pugi::node_pcdata).set_value("g.page-margin{font-family:Times;} g.tempo{font-weight:bold;} g.dir, g.dynam {font-style:italic;}");
+    m_currentNode.append_child(pugi::node_pcdata)
+        .set_value("g.page-margin{font-family:Times;} g.tempo{font-weight:bold;} g.dir, g.dynam {font-style:italic;}");
     m_currentNode = m_svgNodeStack.back();
-    
+
     // a graphic for definition scaling
     m_currentNode = m_currentNode.append_child("svg");
     m_svgNodeStack.push_back(m_currentNode);
@@ -325,13 +326,12 @@ void SvgDeviceContext::DrawComplexBezierPath(Point bezier1[4], Point bezier2[4])
     pugi::xml_node pathChild = AppendChild("path");
     pathChild.append_attribute("d")
         = StringFormat("M%d,%d C%d,%d %d,%d %d,%d C%d,%d %d,%d %d,%d", bezier1[0].x, bezier1[0].y, // M command
-              bezier1[1].x, bezier1[1].y, bezier1[2].x, bezier1[2].y, bezier1[3].x, bezier1[3].y, // First bezier
-              bezier2[2].x, bezier2[2].y, bezier2[1].x, bezier2[1].y, bezier2[0].x, bezier2[0].y // Second Bezier
-              )
-              .c_str();
+            bezier1[1].x, bezier1[1].y, bezier1[2].x, bezier1[2].y, bezier1[3].x, bezier1[3].y, // First bezier
+            bezier2[2].x, bezier2[2].y, bezier2[1].x, bezier2[1].y, bezier2[0].x, bezier2[0].y // Second Bezier
+            ).c_str();
     // pathChild.append_attribute("fill") = "#000000";
     // pathChild.append_attribute("fill-opacity") = "1";
-    // pathChild.append_attribute("stroke") = "#000000";
+    pathChild.append_attribute("stroke") = StringFormat("#%s", GetColour(m_penStack.top().GetColour()).c_str()).c_str();
     pathChild.append_attribute("stroke-linecap") = "round";
     pathChild.append_attribute("stroke-linejoin") = "round";
     // pathChild.append_attribute("stroke-opacity") = "1";
@@ -426,8 +426,8 @@ void SvgDeviceContext::DrawEllipticArc(int x, int y, int width, int height, doub
 
     pugi::xml_node pathChild = AppendChild("path");
     pathChild.append_attribute("d") = StringFormat("M%d %d A%d %d 0.0 %d %d %d %d", int(xs), int(ys), abs(int(rx)),
-                                          abs(int(ry)), fArc, fSweep, int(xe), int(ye))
-                                          .c_str();
+        abs(int(ry)), fArc, fSweep, int(xe),
+        int(ye)).c_str();
     // pathChild.append_attribute("fill") = "#000000";
     if (currentBrush.GetOpacity() != 1.0) pathChild.append_attribute("fill-opacity") = currentBrush.GetOpacity();
     // pathChild.append_attribute("stroke") = "#000000";
@@ -461,7 +461,8 @@ void SvgDeviceContext::DrawPolygon(int n, Point points[], int xoffset, int yoffs
     if (currentPen.GetColour() != AxBLACK)
         polygonChild.append_attribute("stroke")
             = StringFormat("#%s", GetColour(currentPen.GetColour()).c_str()).c_str();
-    if (currentPen.GetWidth() > 1) polygonChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
+    if (currentPen.GetWidth() > 1)
+        polygonChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
     if (currentPen.GetOpacity() != 1.0)
         polygonChild.append_attribute("stroke-opacity") = StringFormat("%f", currentPen.GetOpacity()).c_str();
     if (currentBrush.GetColour() != AxBLACK)


### PR DESCRIPTION
removes more unnecessary initial values:
* `@fill="black"`
* `@fill-rule="nonzero"`

for `<rect>` `@rx` now gets only set if it’s non zero:
> If neither ‘rx’ nor ‘ry’ are properly specified, then set both rx and
ry to 0.
(https://www.w3.org/TR/SVG/shapes.html)

And finally every path now gets a proper `stroke`. This seems to blow up
the SVG again, but setting black in stroke as a default value gives every sub
element an outline, which is bad SVG. And that way we would basically have to set
stroke-width to zero for every non-path element. Rendering text gets so
cleaner and coloring text gets easier as we only have to set `fill`. 
With that the last `@style` vanished. 

If #278 is addressed `stroke` and `stroke-width` may get moved up in the surrounding `g`. 