### PR TITLE
adding support for rest positioning in MusicXML importer

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -190,6 +190,7 @@ private:
     data_ACCIDENTAL_EXPLICIT ConvertAlterToAccid(std::string value);
     data_DURATION ConvertTypeToDur(std::string value);
     data_PITCHNAME ConvertStepToPitchName(std::string value);
+    data_PLACE ConvertTypeToPlace(std::string value);
     ///@}
 
 private:

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -10,6 +10,7 @@
 
 #include "atts_shared.h"
 #include "layerelement.h"
+#include "positioninterface.h"
 
 namespace vrv {
 
@@ -20,7 +21,7 @@ namespace vrv {
 /**
  * This class models the MEI <mRest>
  */
-class MRest : public LayerElement, public AttVisibility, public AttFermatapresent {
+class MRest : public LayerElement, public PositionInterface, public AttVisibility, public AttFermatapresent {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods
@@ -33,6 +34,8 @@ public:
     virtual std::string GetClassName() const { return "MRest"; }
     virtual ClassId Is() const { return MREST; }
     ///@}
+
+    virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }
 
 private:
     //

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -936,6 +936,7 @@ void MeiOutput::WriteMeiMRest(pugi::xml_node currentNode, MRest *mRest)
     assert(mRest);
 
     WriteLayerElement(currentNode, mRest);
+    WritePositionInterface(currentNode, mRest);
     mRest->WriteVisibility(currentNode);
     mRest->WriteFermatapresent(currentNode);
 }
@@ -2552,6 +2553,7 @@ bool MeiInput::ReadMeiMRest(Object *parent, pugi::xml_node mRest)
 {
     MRest *vrvMRest = new MRest();
     ReadLayerElement(mRest, vrvMRest);
+    ReadPositionInterface(mRest, vrvMRest);
 
     vrvMRest->ReadVisibility(mRest);
     vrvMRest->ReadFermatapresent(mRest);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -267,7 +267,7 @@ void MusicXmlInput::RemoveLastFromStack(ClassId classId)
 
 void MusicXmlInput::OpenTie(Staff *staff, Layer *layer, Note *note, Tie *tie)
 {
-    tie->SetStartid(StringFormat("#%s",note->GetUuid().c_str()));
+    tie->SetStartid("#" + note->GetUuid());
     musicxml::OpenTie openTie(staff->GetN(), layer->GetN(), note->GetPname(), note->GetOct());
     m_tieStack.push_back(std::make_pair(tie, openTie));
 }
@@ -278,7 +278,7 @@ void MusicXmlInput::CloseTie(Staff *staff, Layer *layer, Note *note, bool isClos
     for (iter = m_tieStack.begin(); iter != m_tieStack.end(); iter++) {
         if ((iter->second.m_staffN == staff->GetN()) && (iter->second.m_layerN == layer->GetN())
             && (iter->second.m_pname == note->GetPname()) && iter->second.m_oct == note->GetOct()) {
-            iter->first->SetEndid(StringFormat("#%s",note->GetUuid().c_str()));
+            iter->first->SetEndid("#" + note->GetUuid());
             m_tieStack.erase(iter);
             if (!isClosingTie) {
                 LogWarning("Closing tie for note '%s' even thought tie /tie@[type='stop'] is missing in the MusicXML",
@@ -290,8 +290,8 @@ void MusicXmlInput::CloseTie(Staff *staff, Layer *layer, Note *note, bool isClos
 }
 
 void MusicXmlInput::OpenSlur(Staff *staff, Layer *layer, int number, LayerElement *element, Slur *slur)
-    {
-        slur->SetStartid(StringFormat("#%s",element->GetUuid().c_str()));
+{
+    slur->SetStartid("#" + element->GetUuid());
     musicxml::OpenSlur openSlur(staff->GetN(), layer->GetN(), number);
     m_slurStack.push_back(std::make_pair(slur, openSlur));
 }
@@ -302,7 +302,7 @@ void MusicXmlInput::CloseSlur(Staff *staff, Layer *layer, int number, LayerEleme
     for (iter = m_slurStack.begin(); iter != m_slurStack.end(); iter++) {
         if ((iter->second.m_staffN == staff->GetN()) && (iter->second.m_layerN == layer->GetN())
             && (iter->second.m_number == number)) {
-            iter->first->SetEndid(StringFormat("#%s",element->GetUuid().c_str()));
+            iter->first->SetEndid("#" + element->GetUuid());
             m_slurStack.erase(iter);
             return;
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -27,6 +27,7 @@
 #include "score.h"
 #include "section.h"
 #include "slur.h"
+#include "space.h"
 #include "staff.h"
 #include "syl.h"
 #include "text.h"
@@ -721,8 +722,14 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, int 
     if (rest) {
         std::string stepStr = GetContentOfChild(rest.node(), "display-step");
         std::string octaveStr = GetContentOfChild(rest.node(), "display-octave");
+        if (GetAttributeValue(node, "print-object") == "no") {
+            Space *space = new Space();
+            element = space;
+            space->SetDur(ConvertTypeToDur(typeStr));
+            AddLayerElement(layer, space);
+        }
         // we assume /note without /type to be mRest
-        if (typeStr.empty()) {
+        else if (typeStr.empty()) {
             MRest *mRest = new MRest();
             layer->AddChild(mRest);
             if (!stepStr.empty()) mRest->SetPloc(ConvertStepToPitchName(stepStr));
@@ -741,6 +748,7 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, int 
     else {
         Note *note = new Note();
         element = note;
+        if (GetAttributeValue(node, "print-object") == "no") note->SetVisible(BOOLEAN_false);
 
         // Accidental
         std::string accidentalStr = GetContentOfChild(node, "accidental");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -511,8 +511,9 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
                 std::string value;
                 if (key < 0)
                     value = StringFormat("%df", abs(key));
-                else
+                else if (key > 0)
                     value = StringFormat("%ds", key);
+                else value = "0";
                 staffDef->SetKeySig(staffDef->AttKeySigDefaultLog::StrToKeysignature(value));
             }
             // time
@@ -716,17 +717,24 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, int 
         }
     }
 
-    if (node.select_single_node("rest")) {
+    pugi::xpath_node rest = node.select_single_node("rest");
+    if (rest) {
+        std::string stepStr = GetContentOfChild(rest.node(), "display-step");
+        std::string octaveStr = GetContentOfChild(rest.node(), "display-octave");
         // we assume /note without /type to be mRest
         if (typeStr.empty()) {
             MRest *mRest = new MRest();
             layer->AddChild(mRest);
+            if (!stepStr.empty()) mRest->SetPloc(ConvertStepToPitchName(stepStr));
+            if (!octaveStr.empty()) mRest->SetOloc(atoi(octaveStr.c_str()));
         }
         else {
             Rest *rest = new Rest();
             element = rest;
             rest->SetDur(ConvertTypeToDur(typeStr));
             if (dots > 0) rest->SetDots(dots);
+            if (!stepStr.empty()) rest->SetPloc(ConvertStepToPitchName(stepStr));
+            if (!octaveStr.empty()) rest->SetOloc(atoi(octaveStr.c_str()));
             AddLayerElement(layer, rest);
         }
     }

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -13,7 +13,7 @@ namespace vrv {
 // MRest
 //----------------------------------------------------------------------------
 
-MRest::MRest() : LayerElement("mrest-"), AttVisibility(), AttFermatapresent(), PositionInterface()
+MRest::MRest() : LayerElement("mrest-"), PositionInterface(), AttVisibility(), AttFermatapresent()
 {
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_VISIBILITY);

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -13,8 +13,9 @@ namespace vrv {
 // MRest
 //----------------------------------------------------------------------------
 
-MRest::MRest() : LayerElement("mrest-"), AttVisibility(), AttFermatapresent()
+MRest::MRest() : LayerElement("mrest-"), AttVisibility(), AttFermatapresent(), PositionInterface()
 {
+    RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_VISIBILITY);
     RegisterAttClass(ATT_FERMATAPRESENT);
 
@@ -28,6 +29,7 @@ MRest::~MRest()
 void MRest::Reset()
 {
     LayerElement::Reset();
+    PositionInterface::Reset();
     ResetVisibility();
     ResetFermatapresent();
 }


### PR DESCRIPTION
This brings the capability of reading and converting positions of rests and measure rests to the MusicXML importer. 

Also this fixes the annoying
> Unsupported key signature '0s'