### PR TITLE
Adding language support

### DIFF
--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -20,7 +20,11 @@ class TextElement;
 // Dir
 //----------------------------------------------------------------------------
 
-class Dir : public ControlElement, public TextListInterface, public TextDirInterface, public TimeSpanningInterface {
+class Dir : public ControlElement,
+            public TextListInterface,
+            public TextDirInterface,
+            public TimeSpanningInterface,
+            public AttLang {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -30,6 +30,7 @@ class TextElement;
 class Syl : public LayerElement,
             public TextListInterface,
             public TimeSpanningInterface,
+            public AttLang,
             public AttTypography,
             public AttSylLog {
 public:

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -24,7 +24,11 @@ class TextElement;
 /**
  * This class is an interface for <tempo> elements at the measure level
  */
-class Tempo : public ControlElement, public TextDirInterface, public TimePointInterface, public AttMiditempo {
+class Tempo : public ControlElement,
+              public TextDirInterface,
+              public TimePointInterface,
+              public AttLang,
+              public AttMiditempo {
 public:
     /**
      * @name Constructors, destructors, reset methods

--- a/include/vrv/text.h
+++ b/include/vrv/text.h
@@ -20,7 +20,7 @@ namespace vrv {
 /**
  * This class models the MEI <rend>
  */
-class Rend : public TextElement, public AttColor, public AttCommon, public AttTypography {
+class Rend : public TextElement, public AttColor, public AttCommon, public AttLang, public AttTypography {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -19,7 +19,7 @@ class Syl;
 // Verse
 //----------------------------------------------------------------------------
 
-class Verse : public LayerElement, public AttColor, public AttCommon {
+class Verse : public LayerElement, public AttColor, public AttCommon, public AttLang {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -24,10 +24,11 @@ namespace vrv {
 // Dir
 //----------------------------------------------------------------------------
 
-Dir::Dir() : ControlElement("dir-"), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
+Dir::Dir() : ControlElement("dir-"), TextListInterface(), TextDirInterface(), TimeSpanningInterface(), vrv::AttLang()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    RegisterAttClass(ATT_LANG);
 
     Reset();
 }
@@ -41,6 +42,7 @@ void Dir::Reset()
     ControlElement::Reset();
     TextDirInterface::Reset();
     TimeSpanningInterface::Reset();
+    ResetLang();
 }
 
 void Dir::AddChild(Object *child)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1085,6 +1085,7 @@ void MeiOutput::WriteMeiSyl(pugi::xml_node currentNode, Syl *syl)
     assert(syl);
 
     WriteLayerElement(currentNode, syl);
+    syl->WriteLang(currentNode);
     syl->WriteTypography(currentNode);
     syl->WriteSylLog(currentNode);
 }
@@ -2770,6 +2771,7 @@ bool MeiInput::ReadMeiSyl(Object *parent, pugi::xml_node syl)
     Syl *vrvSyl = new Syl();
     ReadLayerElement(syl, vrvSyl);
 
+    vrvSyl->ReadLang(syl);
     vrvSyl->ReadTypography(syl);
     vrvSyl->ReadSylLog(syl);
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -717,6 +717,7 @@ void MeiOutput::WriteMeiDir(pugi::xml_node currentNode, Dir *dir)
     WriteXmlId(currentNode, dir);
     WriteTextDirInterface(currentNode, dir);
     WriteTimeSpanningInterface(currentNode, dir);
+    dir->WriteLang(currentNode);
 };
 
 void MeiOutput::WriteMeiDynam(pugi::xml_node currentNode, Dynam *dynam)
@@ -810,6 +811,7 @@ void MeiOutput::WriteMeiTempo(pugi::xml_node currentNode, Tempo *tempo)
     WriteXmlId(currentNode, tempo);
     WriteTextDirInterface(currentNode, tempo);
     WriteTimePointInterface(currentNode, tempo);
+    tempo->WriteLang(currentNode);
     tempo->WriteMiditempo(currentNode);
 }
 
@@ -1074,6 +1076,7 @@ void MeiOutput::WriteMeiVerse(pugi::xml_node currentNode, Verse *verse)
 
     WriteLayerElement(currentNode, verse);
     verse->WriteColor(currentNode);
+    verse->WriteLang(currentNode);
     verse->WriteCommon(currentNode);
 }
 
@@ -2142,6 +2145,7 @@ bool MeiInput::ReadMeiDir(Object *parent, pugi::xml_node dir)
 
     ReadTextDirInterface(dir, vrvDir);
     ReadTimeSpanningInterface(dir, vrvDir);
+    vrvDir->ReadLang(dir);
 
     parent->AddChild(vrvDir);
     return ReadMeiTextChildren(vrvDir, dir);
@@ -2247,6 +2251,7 @@ bool MeiInput::ReadMeiTempo(Object *parent, pugi::xml_node tempo)
 
     ReadTextDirInterface(tempo, vrvTempo);
     ReadTimePointInterface(tempo, vrvTempo);
+    vrvTempo->ReadLang(tempo);
     vrvTempo->ReadMiditempo(tempo);
 
     parent->AddChild(vrvTempo);
@@ -2791,6 +2796,7 @@ bool MeiInput::ReadMeiVerse(Object *parent, pugi::xml_node verse)
     ReadLayerElement(verse, vrvVerse);
 
     vrvVerse->ReadColor(verse);
+    vrvVerse->ReadLang(verse);
     vrvVerse->ReadCommon(verse);
 
     parent->AddChild(vrvVerse);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1097,6 +1097,7 @@ void MeiOutput::WriteMeiRend(pugi::xml_node currentNode, Rend *rend)
     WriteXmlId(currentNode, rend);
     rend->WriteColor(currentNode);
     rend->WriteCommon(currentNode);
+    rend->WriteLang(currentNode);
     rend->WriteTypography(currentNode);
 }
 
@@ -2851,6 +2852,7 @@ bool MeiInput::ReadMeiRend(Object *parent, pugi::xml_node rend)
 
     vrvRend->ReadColor(rend);
     vrvRend->ReadCommon(rend);
+    vrvRend->ReadLang(rend);
     vrvRend->ReadTypography(rend);
 
     parent->AddChild(vrvRend);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -133,7 +133,6 @@ bool MusicXmlInput::HasContent(pugi::xml_node node)
 
 std::string MusicXmlInput::GetAttributeValue(pugi::xml_node node, std::string attribute)
 {
-    LogWarning("Attr: %s", attribute.c_str());
     assert(node);
 
     if (node.attribute(attribute.c_str())) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1172,6 +1172,7 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, int 
                     std::string lang = GetAttributeValue(textNode.node(), "xml:lang");
                     std::string textStr = GetContentOfChild(lyric, "text");
                     Syl *syl = new Syl();
+                    if (!lang.empty()) syl->SetLang(lang.c_str());
                     if (lyric.select_single_node("extend")) {
                         syl->SetCon(sylLog_CON_u);
                     }
@@ -1188,7 +1189,6 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, int 
                     }
                     if (!textStyle.empty()) syl->SetFontstyle(syl->AttTypography::StrToFontstyle(textStyle.c_str()));
                     if (!textWeight.empty()) syl->SetFontweight(syl->AttTypography::StrToFontweight(textWeight.c_str()));
-                    if (!lang.empty()) syl->SetLang(lang.c_str());
                     
                     Text *text = new Text();
                     text->SetText(UTF8to16(textStr));

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -794,11 +794,13 @@ void MusicXmlInput::ReadMusicXmlDirection(pugi::xml_node node, Measure *measure,
 
     pugi::xpath_node type = node.select_single_node("direction-type");
     std::string placeStr = GetAttributeValue(node, "placement");
+    std::string lang = GetAttributeValue(node, "xml:lang");
 
     // Directive
     pugi::xpath_node_set words = type.node().select_nodes("words");
     if (words.size() != 0 && !node.select_single_node("sound[@tempo]")) {
         Dir *dir = new Dir();
+        if (!lang.empty()) dir->SetLang(lang.c_str());
         if (!placeStr.empty()) dir->SetPlace(dir->AttPlacement::StrToStaffrel(placeStr.c_str()));
         TextRendition(words, dir);
         m_controlElements.push_back(std::make_pair(measureNum, dir));
@@ -866,6 +868,7 @@ void MusicXmlInput::ReadMusicXmlDirection(pugi::xml_node node, Measure *measure,
     pugi::xpath_node metronome = type.node().select_single_node("metronome");
     if (node.select_single_node("sound[@tempo]") || metronome) {
         Tempo *tempo = new Tempo();
+        if (!lang.empty()) tempo->SetLang(lang.c_str());
         if (!placeStr.empty()) tempo->SetPlace(tempo->AttPlacement::StrToStaffrel(placeStr.c_str()));
         int midiTempo = atoi(GetAttributeValue(node.select_single_node("sound").node(), "tempo").c_str());
         if (midiTempo) tempo->SetMidiBpm(midiTempo);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -335,6 +335,9 @@ void MusicXmlInput::TextRendition(pugi::xpath_node_set words, ControlElement *el
         text->SetText(UTF8to16(textStr));
         if (!textColor.empty() || !textFont.empty() || !textStyle.empty() || !textWeight.empty()) {
             Rend *rend = new Rend();
+            if (words.size() > 1 && !lang.empty()) {
+                rend->SetLang(lang.c_str());
+            }
             if (!textColor.empty()) rend->SetColor(textColor.c_str());
             if (!textFont.empty()) rend->SetFontfam(textFont.c_str());
             if (!textStyle.empty()) rend->SetFontstyle(rend->AttTypography::StrToFontstyle(textStyle.c_str()));

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -168,6 +168,14 @@ void SvgDeviceContext::StartGraphic(Object *object, std::string gClass, std::str
         }
     }
 
+    if (object->HasAttClass(ATT_LANG)) {
+        AttLang *att = dynamic_cast<AttLang *>(object);
+        assert(att);
+        if (att->HasLang()) {
+            m_currentNode.append_attribute("xml:lang") = att->GetLang().c_str();
+        }
+    }
+    
     if (object->HasAttClass(ATT_VISIBILITY)) {
         AttVisibility *att = dynamic_cast<AttVisibility *>(object);
         assert(att);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -208,6 +208,14 @@ void SvgDeviceContext::StartTextGraphic(Object *object, std::string gClass, std:
         assert(att);
         if (att->HasColor()) m_currentNode.append_attribute("fill") = att->GetColor().c_str();
     }
+    
+    if (object->HasAttClass(ATT_LANG)) {
+        AttLang *att = dynamic_cast<AttLang *>(object);
+        assert(att);
+        if (att->HasLang()) {
+            m_currentNode.append_attribute("xml:lang") = att->GetLang().c_str();
+        }
+    }
 }
 
 void SvgDeviceContext::ResumeGraphic(Object *object, std::string gId)

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -27,9 +27,10 @@ namespace vrv {
 // Syl
 //----------------------------------------------------------------------------
 
-Syl::Syl() : LayerElement("syl-"), TextListInterface(), TimeSpanningInterface(), AttTypography(), AttSylLog()
+Syl::Syl() : LayerElement("syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_TYPOGRAPHY);
     RegisterAttClass(ATT_SYLLOG);
 
@@ -44,6 +45,7 @@ void Syl::Reset()
 {
     LayerElement::Reset();
     TimeSpanningInterface::Reset();
+    ResetLang();
     ResetTypography();
     ResetSylLog();
 

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -13,8 +13,8 @@
 
 //----------------------------------------------------------------------------
 
-#include "editorial.h"
 #include "controlelement.h"
+#include "editorial.h"
 #include "text.h"
 #include "vrv.h"
 
@@ -24,10 +24,11 @@ namespace vrv {
 // Tempo
 //----------------------------------------------------------------------------
 
-Tempo::Tempo() : ControlElement("tempo-"), TextDirInterface(), TimePointInterface(), AttMiditempo()
+Tempo::Tempo() : ControlElement("tempo-"), TextDirInterface(), TimePointInterface(), AttLang(), AttMiditempo()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
+    RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_MIDITEMPO);
 
     Reset();
@@ -42,6 +43,7 @@ void Tempo::Reset()
     ControlElement::Reset();
     TextDirInterface::Reset();
     TimePointInterface::Reset();
+    ResetLang();
     ResetMiditempo();
 }
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -22,11 +22,12 @@ namespace vrv {
 // Rend
 //----------------------------------------------------------------------------
 
-Rend::Rend() : TextElement("rend-"), AttColor(), AttCommon(), AttTypography()
+Rend::Rend() : TextElement("rend-"), AttColor(), AttCommon(), AttLang(), AttTypography()
 
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_COMMON);
+    RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_TYPOGRAPHY);
 
     Reset();
@@ -41,6 +42,7 @@ void Rend::Reset()
     TextElement::Reset();
     ResetColor();
     ResetCommon();
+    ResetLang();
     ResetTypography();
 }
 

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -27,10 +27,11 @@ namespace vrv {
 // Verse
 //----------------------------------------------------------------------------
 
-Verse::Verse() : LayerElement("verse-"), AttColor(), AttCommon()
+Verse::Verse() : LayerElement("verse-"), AttColor(), AttCommon(), AttLang()
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_COMMON);
+    RegisterAttClass(ATT_LANG);
 
     Reset();
 }
@@ -44,6 +45,7 @@ void Verse::Reset()
     LayerElement::Reset();
     ResetColor();
     ResetCommon();
+    ResetLang();
 }
 
 void Verse::AddChild(Object *child)


### PR DESCRIPTION
This adds support for `@xml:lang` on `<dir>`, `<rend>`, `<syl>`, `<tempo>`, and `<verse>` in MEI and MusicXML import.  It gets written to the corresponding g node in the SVG rendering and thus can be styled with CSS. 
