### PR TITLE
adding examples for fermatas and trills

### DIFF
--- a/_includes/doc.html
+++ b/_includes/doc.html
@@ -20,7 +20,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/accid" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/accid" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -83,7 +83,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/app" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/app" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -140,7 +140,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/beam" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/beam" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -162,7 +162,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/barLine" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/barLine" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -213,7 +213,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/chord" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/chord" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -342,7 +342,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/clef" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/clef" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -411,7 +411,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/custos" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/custos" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -468,7 +468,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/dot" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/dot" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -525,7 +525,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/layer" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/layer" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -582,7 +582,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/lem" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/lem" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -639,7 +639,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/mensur" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/mensur" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -714,7 +714,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/measure" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/measure" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -783,7 +783,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/mensur" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/mensur" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -846,7 +846,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/meterSig" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/meterSig" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -903,7 +903,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/mRest" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/mRest" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -925,7 +925,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/multiRest" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/multiRest" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -976,7 +976,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/note" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/note" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1129,7 +1129,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/rdg" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/rdg" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1192,7 +1192,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/rest" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/rest" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1291,7 +1291,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/scoreDef" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/scoreDef" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1414,7 +1414,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/slur" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/slur" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1471,7 +1471,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/staff" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/staff" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1534,7 +1534,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/staffDef" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/staffDef" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1663,7 +1663,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/staffGrp" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/staffGrp" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1720,7 +1720,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/space" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/space" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1771,7 +1771,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/syl" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/syl" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1828,7 +1828,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/tie" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/tie" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1885,7 +1885,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/tuplet" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/tuplet" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -1936,7 +1936,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/verse" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/verse" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -2167,7 +2167,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/pb" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/pb" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -2196,7 +2196,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/sb" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/sb" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -2225,7 +2225,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/score" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/score" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -2247,7 +2247,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/section" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/section" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -2277,7 +2277,7 @@
             </div>
             <div class="col-xs-2">
                 
-                <a href="http://music-encoding.org/documentation/guidelines2013/tupletSpan" target="_blank">
+                <a href="http://music-encoding.org/documentation/3.0.0/tupletSpan" target="_blank">
                     <button type="button" class="btn btn-default btn-xs btn-heading pull-right">
                         MEI-doc <span class="glyphicon glyphicon-new-window"></span>
                     </button>
@@ -2297,3 +2297,4 @@
     
 </div>
     
+

--- a/_includes/features/fermata1.txt
+++ b/_includes/features/fermata1.txt
@@ -1,0 +1,25 @@
+<section>
+  <measure n="1">
+    <staff n="1">
+      <layer n="1">
+        <note dur="4" oct="3" pname="f" stem.dir="down" fermata="above"/>
+        <chord dur="4" stem.dir="up" fermata="below">
+          <note oct="2" pname="e"/>
+          <note oct="3" pname="c"/>
+          <note oct="3" pname="f"/>
+          <note oct="3" pname="a"/>
+          <note oct="4" pname="d"/>
+        </chord>
+        <rest dur="4"/>
+        <rest dur="4" fermata="above"/>
+      </layer>
+    </staff>
+  </measure>
+  <measure n="2" right="end">
+    <staff n="1">
+      <layer n="1">
+        <mRest fermata="above"/>
+      </layer>
+    </staff>
+  </measure>
+</section>

--- a/_includes/features/fermata2.txt
+++ b/_includes/features/fermata2.txt
@@ -1,0 +1,31 @@
+<section>
+  <measure n="1">
+    <staff n="1">
+      <layer n="1">
+        <note xml:id="note-000000191714646" dur="4" oct="3" pname="f" stem.dir="down"/>
+        <chord xml:id="chord-000000067789064" dur="4" stem.dir="up">
+          <note xml:id="note-000000002150297" oct="2" pname="e"/>
+          <note xml:id="note-000000188536483" oct="3" pname="c"/>
+          <note xml:id="note-000000214724163" oct="3" pname="f"/>
+          <note xml:id="note-000000055724040" oct="3" pname="a"/>
+          <note xml:id="note-000000001818902" oct="4" pname="d"/>
+        </chord>
+        <rest xml:id="rest-000000131319457" dur="4"/>
+        <rest xml:id="rest-000000070546468" dur="4"/>
+      </layer>
+    </staff>
+    <fermata staff="1" startid="#note-000000191714646"/>
+    <fermata staff="1" startid="#chord-000000067789064" form="inv" place="below" shape="angular"/>
+    <fermata staff="1" startid="#rest-000000131319457" form="norm" place="above" shape="square"/>
+    <fermata staff="1" startid="#rest-000000070546468" form="inv" place="above" shape="square"/>
+    <fermata staff="1" tstamp="5" place="above"/>
+    <fermata staff="1" tstamp="5" place="below"/>
+  </measure>
+  <measure xml:id="measure-000000189229453" n="2" right="end">
+    <staff xml:id="staff-000000199557099" n="1">
+      <layer xml:id="layer-000000065308385" n="1">
+        <mRest xml:id="mrest-000000001988686" fermata="above"/>
+      </layer>
+    </staff>
+  </measure>
+</section>

--- a/_includes/features/multilingual.txt
+++ b/_includes/features/multilingual.txt
@@ -1,0 +1,215 @@
+<section>
+  <measure n="1">
+    <staff n="1">
+      <layer n="1">
+        <beam>
+          <note dots="1" dur="8" oct="4" pname="a" stem.dir="up">
+            <verse xml:lang="de" n="1">
+              <syl con="d" wordpos="i">Stil</syl>
+            </verse>
+            <verse xml:lang="en" n="2">
+              <syl con="d" wordpos="i">Sil</syl>
+            </verse>
+            <verse xml:lang="sv" n="3">
+              <syl con="d" wordpos="i">Stil</syl>
+            </verse>
+          </note>
+          <note dur="16" oct="4" pname="b" stem.dir="up"/>
+        </beam>
+        <note dur="8" oct="4" pname="a" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>le</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl wordpos="t">ent</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl>la</syl>
+          </verse>
+        </note>
+        <note dur="4" oct="4" pname="f" accid.ges="s" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>Nacht!</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl>night,</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl>natt,</syl>
+          </verse>
+        </note>
+        <rest dur="8" ploc="e" oloc="4"/>
+      </layer>
+      <layer n="2">
+        <beam>
+          <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+          <note dur="16" oct="4" pname="g" stem.dir="down"/>
+        </beam>
+        <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+        <note dur="4" oct="4" pname="d" stem.dir="down"/>
+      </layer>
+    </staff>
+  </measure>
+  <measure n="2">
+    <staff n="1">
+      <layer n="1">
+        <beam>
+          <note dots="1" dur="8" oct="4" pname="a" stem.dir="up">
+            <verse xml:lang="de" n="1">
+              <syl con="d" wordpos="i">Hei</syl>
+            </verse>
+            <verse xml:lang="en" n="2">
+              <syl con="d" wordpos="i">ho</syl>
+            </verse>
+            <verse xml:lang="sv" n="3">
+              <syl con="d" wordpos="i">he</syl>
+            </verse>
+          </note>
+          <note dur="16" oct="4" pname="b" stem.dir="up">
+            <verse xml:lang="de" n="1">
+              <syl wordpos="t">li</syl>
+            </verse>
+            <verse xml:lang="sv" n="3">
+              <syl con="d" wordpos="m">li</syl>
+            </verse>
+          </note>
+        </beam>
+        <note dur="8" oct="4" pname="a" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>ge</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl wordpos="t">ly</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl wordpos="t">ga</syl>
+          </verse>
+        </note>
+        <note dur="4" oct="4" pname="f" accid.ges="s" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>Nacht!</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl>night,</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl>natt,</syl>
+          </verse>
+        </note>
+        <rest dur="8" ploc="e" oloc="4"/>
+      </layer>
+      <layer n="2">
+        <beam>
+          <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+          <note dur="16" oct="4" pname="g" stem.dir="down"/>
+        </beam>
+        <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+        <note dur="4" oct="4" pname="d" stem.dir="down"/>
+      </layer>
+    </staff>
+  </measure>
+  <measure n="3">
+    <staff n="1">
+      <layer n="1">
+        <beam>
+          <note dots="1" dur="8" oct="5" pname="e" stem.dir="up">
+            <verse xml:lang="de" n="1">
+              <syl con="d" wordpos="i">Al</syl>
+            </verse>
+            <verse xml:lang="en" n="2">
+              <syl>All</syl>
+            </verse>
+            <verse xml:lang="sv" n="3">
+              <syl>Alt</syl>
+            </verse>
+          </note>
+          <note dur="16" oct="5" pname="d" stem.dir="up">
+            <accid accid="s"/>
+          </note>
+        </beam>
+        <note dur="8" oct="5" pname="e" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>les</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl>is</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl>var</syl>
+          </verse>
+        </note>
+        <note dur="4" oct="5" pname="c" accid.ges="s" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>schläft,</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl>calm,</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl>tyst,</syl>
+          </verse>
+        </note>
+        <rest dur="8" ploc="e" oloc="4"/>
+      </layer>
+      <layer n="2">
+        <beam>
+          <note dots="1" dur="8" oct="4" pname="g" stem.dir="down"/>
+          <note dur="16" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+        </beam>
+        <note dur="8" oct="4" pname="g" stem.dir="down"/>
+        <note dur="4" oct="4" pname="e" stem.dir="down"/>
+      </layer>
+    </staff>
+  </measure>
+  <measure n="4">
+    <staff n="1">
+      <layer n="1">
+        <beam>
+          <note dots="1" dur="8" oct="5" pname="d" stem.dir="up">
+            <verse xml:lang="de" n="1">
+              <syl con="d" wordpos="i">ein</syl>
+            </verse>
+            <verse xml:lang="en" n="2">
+              <syl>all</syl>
+            </verse>
+            <verse xml:lang="sv" n="3">
+              <syl con="d" wordpos="i">en</syl>
+            </verse>
+          </note>
+          <note dur="16" oct="5" pname="c" accid.ges="s" stem.dir="up"/>
+        </beam>
+        <note dur="8" oct="5" pname="d" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>sam</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl>is</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl wordpos="t">samt</syl>
+          </verse>
+        </note>
+        <note dur="4" oct="4" pname="a" stem.dir="up">
+          <verse xml:lang="de" n="1">
+            <syl>wacht</syl>
+          </verse>
+          <verse xml:lang="en" n="2">
+            <syl>bright</syl>
+          </verse>
+          <verse xml:lang="sv" n="3">
+            <syl>satt</syl>
+          </verse>
+        </note>
+        <rest dur="8" ploc="e" oloc="4"/>
+      </layer>
+      <layer n="2">
+        <beam>
+          <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+          <note dur="16" oct="4" pname="e" stem.dir="down"/>
+        </beam>
+        <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+        <note dur="4" oct="4" pname="c" accid.ges="s" stem.dir="down"/>
+      </layer>
+    </staff>
+  </measure>
+</section>

--- a/_includes/features/multilingual.txt
+++ b/_includes/features/multilingual.txt
@@ -1,215 +1,51 @@
-<section>
-  <measure n="1">
-    <staff n="1">
-      <layer n="1">
-        <beam>
-          <note dots="1" dur="8" oct="4" pname="a" stem.dir="up">
-            <verse xml:lang="de" n="1">
-              <syl con="d" wordpos="i">Stil</syl>
-            </verse>
-            <verse xml:lang="en" n="2">
-              <syl con="d" wordpos="i">Sil</syl>
-            </verse>
-            <verse xml:lang="sv" n="3">
-              <syl con="d" wordpos="i">Stil</syl>
-            </verse>
-          </note>
-          <note dur="16" oct="4" pname="b" stem.dir="up"/>
-        </beam>
-        <note dur="8" oct="4" pname="a" stem.dir="up">
+<measure n="1">
+  <staff n="1">
+    <layer n="1">
+      <beam>
+        <note dots="1" dur="8" oct="4" pname="a" stem.dir="up">
           <verse xml:lang="de" n="1">
-            <syl>le</syl>
+            <syl con="d" wordpos="i">Stil</syl>
           </verse>
           <verse xml:lang="en" n="2">
-            <syl wordpos="t">ent</syl>
+            <syl con="d" wordpos="i">Sil</syl>
           </verse>
           <verse xml:lang="sv" n="3">
-            <syl>la</syl>
+            <syl con="d" wordpos="i">Stil</syl>
           </verse>
         </note>
-        <note dur="4" oct="4" pname="f" accid.ges="s" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>Nacht!</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl>night,</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl>natt,</syl>
-          </verse>
-        </note>
-        <rest dur="8" ploc="e" oloc="4"/>
-      </layer>
-      <layer n="2">
-        <beam>
-          <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-          <note dur="16" oct="4" pname="g" stem.dir="down"/>
-        </beam>
-        <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-        <note dur="4" oct="4" pname="d" stem.dir="down"/>
-      </layer>
-    </staff>
-  </measure>
-  <measure n="2">
-    <staff n="1">
-      <layer n="1">
-        <beam>
-          <note dots="1" dur="8" oct="4" pname="a" stem.dir="up">
-            <verse xml:lang="de" n="1">
-              <syl con="d" wordpos="i">Hei</syl>
-            </verse>
-            <verse xml:lang="en" n="2">
-              <syl con="d" wordpos="i">ho</syl>
-            </verse>
-            <verse xml:lang="sv" n="3">
-              <syl con="d" wordpos="i">he</syl>
-            </verse>
-          </note>
-          <note dur="16" oct="4" pname="b" stem.dir="up">
-            <verse xml:lang="de" n="1">
-              <syl wordpos="t">li</syl>
-            </verse>
-            <verse xml:lang="sv" n="3">
-              <syl con="d" wordpos="m">li</syl>
-            </verse>
-          </note>
-        </beam>
-        <note dur="8" oct="4" pname="a" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>ge</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl wordpos="t">ly</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl wordpos="t">ga</syl>
-          </verse>
-        </note>
-        <note dur="4" oct="4" pname="f" accid.ges="s" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>Nacht!</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl>night,</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl>natt,</syl>
-          </verse>
-        </note>
-        <rest dur="8" ploc="e" oloc="4"/>
-      </layer>
-      <layer n="2">
-        <beam>
-          <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-          <note dur="16" oct="4" pname="g" stem.dir="down"/>
-        </beam>
-        <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-        <note dur="4" oct="4" pname="d" stem.dir="down"/>
-      </layer>
-    </staff>
-  </measure>
-  <measure n="3">
-    <staff n="1">
-      <layer n="1">
-        <beam>
-          <note dots="1" dur="8" oct="5" pname="e" stem.dir="up">
-            <verse xml:lang="de" n="1">
-              <syl con="d" wordpos="i">Al</syl>
-            </verse>
-            <verse xml:lang="en" n="2">
-              <syl>All</syl>
-            </verse>
-            <verse xml:lang="sv" n="3">
-              <syl>Alt</syl>
-            </verse>
-          </note>
-          <note dur="16" oct="5" pname="d" stem.dir="up">
-            <accid accid="s"/>
-          </note>
-        </beam>
-        <note dur="8" oct="5" pname="e" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>les</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl>is</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl>var</syl>
-          </verse>
-        </note>
-        <note dur="4" oct="5" pname="c" accid.ges="s" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>schläft,</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl>calm,</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl>tyst,</syl>
-          </verse>
-        </note>
-        <rest dur="8" ploc="e" oloc="4"/>
-      </layer>
-      <layer n="2">
-        <beam>
-          <note dots="1" dur="8" oct="4" pname="g" stem.dir="down"/>
-          <note dur="16" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-        </beam>
-        <note dur="8" oct="4" pname="g" stem.dir="down"/>
-        <note dur="4" oct="4" pname="e" stem.dir="down"/>
-      </layer>
-    </staff>
-  </measure>
-  <measure n="4">
-    <staff n="1">
-      <layer n="1">
-        <beam>
-          <note dots="1" dur="8" oct="5" pname="d" stem.dir="up">
-            <verse xml:lang="de" n="1">
-              <syl con="d" wordpos="i">ein</syl>
-            </verse>
-            <verse xml:lang="en" n="2">
-              <syl>all</syl>
-            </verse>
-            <verse xml:lang="sv" n="3">
-              <syl con="d" wordpos="i">en</syl>
-            </verse>
-          </note>
-          <note dur="16" oct="5" pname="c" accid.ges="s" stem.dir="up"/>
-        </beam>
-        <note dur="8" oct="5" pname="d" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>sam</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl>is</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl wordpos="t">samt</syl>
-          </verse>
-        </note>
-        <note dur="4" oct="4" pname="a" stem.dir="up">
-          <verse xml:lang="de" n="1">
-            <syl>wacht</syl>
-          </verse>
-          <verse xml:lang="en" n="2">
-            <syl>bright</syl>
-          </verse>
-          <verse xml:lang="sv" n="3">
-            <syl>satt</syl>
-          </verse>
-        </note>
-        <rest dur="8" ploc="e" oloc="4"/>
-      </layer>
-      <layer n="2">
-        <beam>
-          <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-          <note dur="16" oct="4" pname="e" stem.dir="down"/>
-        </beam>
-        <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
-        <note dur="4" oct="4" pname="c" accid.ges="s" stem.dir="down"/>
-      </layer>
-    </staff>
-  </measure>
-</section>
+        <note dur="16" oct="4" pname="b" stem.dir="up"/>
+      </beam>
+      <note dur="8" oct="4" pname="a" stem.dir="up">
+        <verse xml:lang="de" n="1">
+          <syl>le</syl>
+        </verse>
+        <verse xml:lang="en" n="2">
+          <syl wordpos="t">ent</syl>
+        </verse>
+        <verse xml:lang="sv" n="3">
+          <syl>la</syl>
+        </verse>
+      </note>
+      <note dur="4" oct="4" pname="f" accid.ges="s" stem.dir="up">
+        <verse xml:lang="de" n="1">
+          <syl>Nacht!</syl>
+        </verse>
+        <verse xml:lang="en" n="2">
+          <syl>night,</syl>
+        </verse>
+        <verse xml:lang="sv" n="3">
+          <syl>natt,</syl>
+        </verse>
+      </note>
+      <rest dur="8" ploc="e" oloc="4"/>
+    </layer>
+    <layer n="2">
+      <beam>
+        <note dots="1" dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+        <note dur="16" oct="4" pname="g" stem.dir="down"/>
+      </beam>
+      <note dur="8" oct="4" pname="f" accid.ges="s" stem.dir="down"/>
+      <note dur="4" oct="4" pname="d" stem.dir="down"/>
+    </layer>
+  </staff>
+</measure>

--- a/_includes/features/trills.txt
+++ b/_includes/features/trills.txt
@@ -1,0 +1,85 @@
+<score>
+  <scoreDef>
+    <staffGrp>
+      <staffDef clef.shape="C" clef.line="1" n="1" lines="5"/>
+    </staffGrp>
+  </scoreDef>
+  <section>
+    <measure n="1" right="dbl">
+      <staff n="1">
+        <layer n="1">
+          <note dur="4" oct="4" pname="g" stem.dir="down"/>
+        </layer>
+      </staff>
+      <trill staff="1" tstamp="1"/>
+    </measure>
+    <measure n="2" right="dbl">
+      <staff n="1">
+        <layer n="1">
+          <beam>
+            <note dur="32" oct="4" pname="a" stem.dir="down"/>
+            <note dur="32" oct="4" pname="g" stem.dir="down"/>
+            <note dur="32" oct="4" pname="a" stem.dir="down"/>
+            <note dur="32" oct="4" pname="g" stem.dir="down"/>
+            <note dur="32" oct="4" pname="a" stem.dir="down"/>
+            <note dur="32" oct="4" pname="g" stem.dir="down"/>
+            <note dur="32" oct="4" pname="a" stem.dir="down"/>
+            <note dur="32" oct="4" pname="g" stem.dir="down"/>
+          </beam>
+        </layer>
+      </staff>
+    </measure>
+    <scoreDef key.sig="2s"/>
+    <measure n="3" right="dbl">
+      <staff n="1">
+        <layer n="1">
+          <note dur="4" oct="4" pname="b" stem.dir="down"/>
+        </layer>
+      </staff>
+      <trill staff="1" tstamp="1" place="above"/>
+    </measure>
+    <measure n="4" right="dbl">
+      <staff n="1">
+        <layer n="1">
+          <beam>
+            <note dur="32" oct="5" pname="c" stem.dir="down">
+              <accid accid="s"/>
+            </note>
+            <note dur="32" oct="4" pname="b" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+            <note dur="32" oct="4" pname="b" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+            <note dur="32" oct="4" pname="b" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+            <note dur="32" oct="4" pname="b" stem.dir="down"/>
+          </beam>
+        </layer>
+      </staff>
+    </measure>
+    <scoreDef key.sig="2s"/>
+    <measure n="5" right="dbl">
+      <staff n="1">
+        <layer n="1">
+          <note dur="4" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+        </layer>
+      </staff>
+      <trill staff="1" tstamp="1" place="below" color="orange"/>
+    </measure>
+    <measure n="6" right="dbl">
+      <staff n="1">
+        <layer n="1">
+          <beam>
+            <note dur="32" oct="5" pname="d" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid="s" stem.dir="down"/>
+            <note dur="32" oct="5" pname="d" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+            <note dur="32" oct="5" pname="d" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+            <note dur="32" oct="5" pname="d" stem.dir="down"/>
+            <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down"/>
+          </beam>
+        </layer>
+      </staff>
+    </measure>
+  </section>
+</score>

--- a/doc.html
+++ b/doc.html
@@ -1,5 +1,5 @@
 ---
-mei-doc-root: http://music-encoding.org/documentation/guidelines2013/ 
+mei-doc-root: http://music-encoding.org/documentation/3.0.0/
 ---
 {% comment %}
 {_% mei_supported_to_liquid supported-mei.yml %_}
@@ -8,11 +8,11 @@ mei-doc-root: http://music-encoding.org/documentation/guidelines2013/
 <p>
     This page documents the elements and attributes that are currently supported by Verovio. It is also important to note that the hierarchy of elements supported by Verovio is limited and that it will also determine wherether an MEI document can be rendered or not.
 </p>
-                    
+
 <h4>MEI elements</h4>
 <p>
     Verovio supports a subset of MEI elements and attributes that are documented here. Additional elements and attributes will be added in the future.
-</p>                
+</p>
 
     {% for class in page.doc.classes %}
         {% include mei-class.html %}
@@ -21,18 +21,18 @@ mei-doc-root: http://music-encoding.org/documentation/guidelines2013/
 <h4>Page-based customization elements</h4>
 <p>
     A few elements supported by Verovio are defined in the page-based customization describe on the <a href="{{ site.baseurl}}/structure.xhtml">structure</a> page.
-</p>                    
+</p>
     {% for class in page.doc.page-based-classes %}
         {% include mei-class.html %}
     {% endfor %}
-    
+
 <h4>Load-only MEI elements</h4>
 <p>
     Verovio can load both page-based customized and uncustomized MEI documents. When loading uncustomized MEI documents, some MEI elements are loaded by Verovio and converted to a page-based representation. Typically, <code>&lt;pb&gt;</code> milestone elements are converted to <code>&lt;page&gt;</code> container elements. Oppositely, <code>&lt;section&gt;</code> container elements are converted to <code>&lt;secb&gt;</code> milestone elements.
 </p>
 <p>
     There are also some MEI elements that Verovio can load but only if they can be converted to an alternate MEI representation. For example, Verovio can load <code>&lt;tupletSpan&gt;</code> elements but only when then can be appropriately converted to <code>&lt;tuplet&gt;</code> elements. Verovio tries to perfom the convertions when loading the document. This has nothing to do with the page-based customization.
-</p>                    
+</p>
     {% for class in page.doc.loaded-classes %}
         {% include mei-class.html %}
     {% endfor %}

--- a/examples/features/fermata1.mei
+++ b/examples/features/fermata1.mei
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+<meiHead>
+    <fileDesc>
+        <titleStmt>
+            <title>Fermata attribute example</title>
+        </titleStmt>
+        <pubStmt/>
+        <seriesStmt>
+            <title>Verovio feature examples</title>
+        </seriesStmt>
+    </fileDesc>
+</meiHead>
+    <music>
+        <body>
+            <mdiv>
+                <score>
+                    <scoreDef key.sig="1f" meter.count="4" meter.unit="4" meter.sym="common">
+                        <staffGrp>
+                            <staffDef clef.shape="F" clef.line="4" n="1" lines="5" />
+                        </staffGrp>
+                    </scoreDef>
+                    <section label="feature-example">
+                        <measure n="1">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note dur="4" oct="3" pname="f" stem.dir="down" fermata="above" />
+                                    <chord dur="4" stem.dir="up" fermata="below">
+                                        <note oct="2" pname="e" />
+                                        <note oct="3" pname="c" />
+                                        <note oct="3" pname="f" />
+                                        <note oct="3" pname="a" />
+                                        <note oct="4" pname="d" />
+                                    </chord>
+                                    <rest dur="4" />
+                                    <rest dur="4" fermata="above"/>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <measure n="2" right="end">
+                            <staff n="1">
+                                <layer n="1">
+                                    <mRest fermata="above" />
+                                </layer>
+                            </staff>
+                        </measure>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/examples/features/fermata2.mei
+++ b/examples/features/fermata2.mei
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+<meiHead>
+    <fileDesc>
+        <titleStmt>
+            <title>Fermata element example</title>
+        </titleStmt>
+        <pubStmt/>
+        <seriesStmt>
+            <title>Verovio feature examples</title>
+        </seriesStmt>
+    </fileDesc>
+</meiHead>
+    <music>
+        <body>
+            <mdiv>
+                <score>
+                    <scoreDef key.sig="1f" meter.count="4" meter.unit="4" meter.sym="common">
+                        <staffGrp>
+                            <staffDef clef.shape="F" clef.line="4" n="1" lines="5" />
+                        </staffGrp>
+                    </scoreDef>
+                    <section label="feature-example">
+                        <measure n="1">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note xml:id="note-000000191714646" dur="4" oct="3" pname="f" stem.dir="down" />
+                                    <chord xml:id="chord-000000067789064" dur="4" stem.dir="up">
+                                        <note xml:id="note-000000002150297" oct="2" pname="e" />
+                                        <note xml:id="note-000000188536483" oct="3" pname="c" />
+                                        <note xml:id="note-000000214724163" oct="3" pname="f" />
+                                        <note xml:id="note-000000055724040" oct="3" pname="a" />
+                                        <note xml:id="note-000000001818902" oct="4" pname="d" />
+                                    </chord>
+                                    <rest xml:id="rest-000000131319457" dur="4" />
+                                    <rest xml:id="rest-000000070546468" dur="4" />
+                                </layer>
+                            </staff>
+                            <fermata staff="1" startid="#note-000000191714646"/>
+                            <fermata staff="1" startid="#chord-000000067789064" form="inv" place="below" shape="angular" />
+                            <fermata staff="1" startid="#rest-000000131319457" form="norm" place="above" shape="square" />
+                            <fermata staff="1" startid="#rest-000000070546468" form="inv" place="above" shape="square" />
+                            <fermata staff="1" tstamp="5" place="above" />
+                            <fermata staff="1" tstamp="5" place="below" />
+                        </measure>
+                        <measure xml:id="measure-000000189229453" n="2" right="end">
+                            <staff xml:id="staff-000000199557099" n="1">
+                                <layer xml:id="layer-000000065308385" n="1">
+                                    <mRest xml:id="mrest-000000001988686" fermata="above" />
+                                </layer>
+                            </staff>
+                        </measure>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/examples/features/trills.mei
+++ b/examples/features/trills.mei
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title>Trills example</title>
+            </titleStmt>
+            <pubStmt/>
+            <seriesStmt>
+                <title>Verovio feature examples</title>
+            </seriesStmt>
+        </fileDesc>
+    </meiHead>
+    <music>
+        <body>
+            <mdiv>
+                <score label="feature-example">
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef clef.shape="C" clef.line="1" n="1" lines="5" />
+                        </staffGrp>
+                    </scoreDef>
+                    <section>
+                        <measure n="1" right="dbl">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note dur="4" oct="4" pname="g" stem.dir="down" />
+                                </layer>
+                            </staff>
+                            <trill staff="1" tstamp="1" />
+                        </measure>
+                        <measure n="2" right="dbl">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="32" oct="4" pname="a" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="g" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="a" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="g" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="a" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="g" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="a" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="g" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <scoreDef key.sig="2s" />
+                        <measure n="3" right="dbl">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note dur="4" oct="4" pname="b" stem.dir="down" />
+                                </layer>
+                            </staff>
+                            <trill staff="1" tstamp="1" place="above" />
+                        </measure>
+                        <measure n="4" right="dbl">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="32" oct="5" pname="c" stem.dir="down">
+                                            <accid accid="s" />
+                                        </note>
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                        <note dur="32" oct="4" pname="b" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                        <scoreDef key.sig="2s" />
+                        <measure n="5" right="dbl">
+                            <staff n="1">
+                                <layer n="1">
+                                    <note dur="4" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                </layer>
+                            </staff>
+                            <trill staff="1" tstamp="1" place="below" color="orange" />
+                        </measure>
+                        <measure n="6" right="dbl">
+                            <staff n="1">
+                                <layer n="1">
+                                    <beam>
+                                        <note dur="32" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid="s" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="d" stem.dir="down" />
+                                        <note dur="32" oct="5" pname="c" accid.ges="s" stem.dir="down" />
+                                    </beam>
+                                </layer>
+                            </staff>
+                        </measure>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>

--- a/features.xhtml
+++ b/features.xhtml
@@ -31,6 +31,8 @@ features:
       name: "Tuplets"
     - id: "tremolos"
       name: "Tremolos"
+    - id: "fermatas"
+      name: "Fermatas"
     - id: "octave-shift"
       name: "Octave shift"
     - id: "piano-pedals"
@@ -41,6 +43,10 @@ features:
       menu: "Mensural notation"
     - id: "mensural"
       name: "Mensural notation"
+    - id: "cmn_ornam"
+      menu: "Common Music Notation Ornaments"
+    - id: "trills"
+      name: "Trills"
     - id: "app_menu"
       menu: "Critical apparatus"
     - id: "app"
@@ -82,7 +88,7 @@ version-footer: true
             </div>
         </div>
     </div>
-    
+
     <div class="col-md-9">
         <div class="panel-body">
             <h3>Features</h3>
@@ -95,7 +101,7 @@ version-footer: true
 
             <div id="feature">
             </div>
-            
+
         </div>
     </div>
 </div>
@@ -130,30 +136,30 @@ version-footer: true
         var svg = vrvToolkit.renderData( data, options );
         output_div.html(svg);
     }
-    
+
     function getParameterByName(name) {
         var match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
         return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
     }
 
     $( document ).ready(function() {
-        
+
         var id = getParameterByName("id");
         if (!id) {
             id = "{{ page.features[1].id }}";
         }
-        var file = "features/" + id + ".html";    
-        // load the file    
-        $( "#feature" ).load( file, function() {          
+        var file = "features/" + id + ".html";
+        // load the file
+        $( "#feature" ).load( file, function() {
               $(".toggle_code").click(function(){
                   $( "#" + $(this).attr("id") + "-xml" ).toggle();
                     $("span", this).toggleClass("glyphicon-eye-open glyphicon-eye-close");
               });
-          
+
         });
         // activate the link menu
         $( "#link-" + id ).addClass( "active" );
-                
+
     });
 //]]>
 </script>

--- a/features/dynams-hairpins.html
+++ b/features/dynams-hairpins.html
@@ -3,7 +3,7 @@
 <h4>Dynamics</h4>
 
 <p>
-    Verovio supports <code>&lt;dynam&gt;</code> elements. Horizontal positioning can be specified using either the <code>@startid</code> or <code>@tstamp</code> attribute. 
+    Verovio supports <code>&lt;dynam&gt;</code> elements. Horizontal positioning can be specified using either the <code>@startid</code> or <code>@tstamp</code> attribute.
 </p>
 <p>
     When the text of the dynamic has corresponding code in SMUFL, the music font will be used. For example, for  <code>&lt;dynam&gt;p&lt;/dynam&gt;</code>, the SMuFL character U+E520 (dynamicPiano) will be used. Dynamics with corresponding SMuFL code are centered under the horizontal alignment points.
@@ -87,14 +87,14 @@
 //<![CDATA[
     zoom = 40;
     pageWidth = 1450;
-    
-    
+
+
     // adjust the zoom for small screens
     width = $('#feature').width();
     if ( width < zoom * pageWidth / 100 ) {
         zoom = width * 100 / pageWidth;
     }
-    
+
     $.get( "{{ site.baseurl }}/examples/features/dynam1.mei" , function( data ) {
         load_data( data, $('#svg_output-1') );
     });
@@ -102,16 +102,16 @@
     $.get( "{{ site.baseurl }}/examples/features/dynam2.mei" , function( data ) {
         load_data( data, $('#svg_output-2') );
     });
-    
+
     $.get( "{{ site.baseurl }}/examples/features/dynam3.mei" , function( data ) {
         load_data( data, $('#svg_output-3') );
     });
-    
+
     $.get( "{{ site.baseurl }}/examples/features/hairpin1.mei" , function( data ) {
         pageWidth = 1000;
         load_data( data, $('#svg_output-4') );
     });
-    
+
     $.get( "{{ site.baseurl }}/examples/features/hairpin2.mei" , function( data ) {
         spacingStaff = 8;
         pageWidth = 1450;

--- a/features/fermatas.html
+++ b/features/fermatas.html
@@ -11,7 +11,7 @@
 {% include mei-excerpt.html id="code-fermata1" file="fermata1.mei" %}
 <div id="code-fermata1" style="display: none">
 {% highlight xml %}
-{% include features/btrem.txt %}
+{% include features/fermata1.txt %}
 {% endhighlight %}
 </div>
 
@@ -25,7 +25,7 @@
 {% include mei-excerpt.html id="code-fermata2" file="fermata2.mei" %}
 <div id="code-fermata2" style="display: none">
 {% highlight xml %}
-{% include features/ftrem.txt %}
+{% include features/fermata2.txt %}
 {% endhighlight %}
 </div>
 <br/>

--- a/features/fermatas.html
+++ b/features/fermatas.html
@@ -1,0 +1,53 @@
+---
+---
+<h4>Fermatas</h4>
+
+<p>
+    Verovio supports <code>@fermata</code> on <code>&lt;chord&gt;</code>, <code>&lt;note&gt;</code>, and <code>&lt;rest&gt;</code> elements.
+</p>
+
+<div id="svg_output-fermata1" style="overflow:auto;"/>
+
+{% include mei-excerpt.html id="code-fermata1" file="fermata1.mei" %}
+<div id="code-fermata1" style="display: none">
+{% highlight xml %}
+{% include features/btrem.txt %}
+{% endhighlight %}
+</div>
+
+<p>
+    For more control over fermatas the <code>&lt;fermata&gt;</code> element may be used.
+    Verovio takes <code>@form</code>, <code>@place</code>, and <code>@shape</code> into account.
+</p>
+
+<div id="svg_output-fermata2" style="overflow:auto;"/>
+
+{% include mei-excerpt.html id="code-fermata2" file="fermata2.mei" %}
+<div id="code-fermata2" style="display: none">
+{% highlight xml %}
+{% include features/ftrem.txt %}
+{% endhighlight %}
+</div>
+<br/>
+
+<script type="text/javascript">
+//<![CDATA[
+    zoom = 40;
+    pageWidth = 1000;
+    spacingStaff = 6;
+
+    // adjust the zoom for small screens
+    width = $('#feature').width();
+    if ( width < zoom * pageWidth / 100 ) {
+        zoom = width * 100 / pageWidth;
+    }
+
+    $.get( "{{ site.baseurl }}/examples/features/fermata1.mei" , function( data ) {
+        load_data( data, $('#svg_output-fermata1') );
+    });
+
+    $.get( "{{ site.baseurl }}/examples/features/fermata2.mei" , function( data ) {
+        load_data( data, $('#svg_output-fermata2') );
+    });
+//]]>
+</script>

--- a/features/tempi-directives.html
+++ b/features/tempi-directives.html
@@ -57,14 +57,14 @@
 //<![CDATA[
     zoom = 40;
     pageWidth = 1450;
-    
-    
+
+
     // adjust the zoom for small screens
     width = $('#feature').width();
     if ( width < zoom * pageWidth / 100 ) {
         zoom = width * 100 / pageWidth;
     }
-    
+
     $.get( "{{ site.baseurl }}/examples/features/tempo1.mei" , function( data ) {
         load_data( data, $('#svg_output-1') );
     });
@@ -72,7 +72,7 @@
     $.get( "{{ site.baseurl }}/examples/features/tempo2.mei" , function( data ) {
         load_data( data, $('#svg_output-2') );
     });
-    
+
     $.get( "{{ site.baseurl }}/examples/features/dir1.mei" , function( data ) {
         load_data( data, $('#svg_output-3') );
     });

--- a/features/trills.html
+++ b/features/trills.html
@@ -1,0 +1,35 @@
+---
+---
+<h4>Trills</h4>
+
+<p>
+    Verovio brings simple support for <code>&lt;trill&gt;</code> elements. By default, trills are placed above the staff.
+</p>
+
+<div id="svg_output-trills" style="overflow:auto;"/>
+
+{% include mei-excerpt.html id="code-trills" file="trills.mei" %}
+<div id="code-btrem-xml" style="display: none">
+{% highlight xml %}
+{% include features/trills.txt %}
+{% endhighlight %}
+</div>
+<br/>
+
+<script type="text/javascript">
+//<![CDATA[
+    zoom = 40;
+    pageWidth = 1000;
+    spacingStaff = 6;
+
+    // adjust the zoom for small screens
+    width = $('#feature').width();
+    if ( width < zoom * pageWidth / 100 ) {
+        zoom = width * 100 / pageWidth;
+    }
+
+    $.get( "{{ site.baseurl }}/examples/features/trills.mei" , function( data ) {
+        load_data( data, $('#svg_output-trills') );
+    });
+//]]>
+</script>

--- a/musicxml.html
+++ b/musicxml.html
@@ -38,19 +38,19 @@ examples:
       link: "Waldteufel_Op.138_Les_Patineurs.xml"
 ---
 <div class="row">
-    
+
     <div class="col-md-3 sidebar-offcanvas" id="sidebar" role="navigation">
         <div class="panel panel-default">
             {% include other-sidebar.html %}
         </div>
     </div>
-    
+
     <div class="col-md-9">
         <div class="panel-body">
             <h3>MusicXML Converter</h3>
-            
+
             <p>
-                Verovio supports basic conversion from MusicXML to MEI. When converting from this web interface, the resulting MEI data will be displayed directly in the MEI-Viewer. The MEI file can be saved through the 
+                Verovio supports basic conversion from MusicXML to MEI. When converting from this web interface, the resulting MEI data will be displayed directly in the MEI-Viewer. The MEI file can be saved through the
                 <button type="button" class="btn btn-default btn-xs">
                   <span class="glyphicon glyphicon-download" aria-hidden="true"></span> MEI
                 </button>
@@ -59,13 +59,13 @@ examples:
             <p>
                 This feature is highly experimental at this stage, and only the features supported by Verovio will be converted. Everything else will be lost. For a more complete conversion from MusicXML to MEI we strongly recommend to use the <a href="https://github.com/music-encoding/encoding-tools" target="_blank">MEI XSL stylesheets</a>.
             </p>
-            
+
             <h4>Try it!</h4>
             <p>
                 The files below are converted to MEI in your browser and directly displayed with Verovio.
             </p>
-            
-            <div class="conainer"> 
+
+            <div class="conainer">
                 {% for d in page.examples %}
                  <div class="row">
                     <div class="col-xs-7">
@@ -102,12 +102,12 @@ examples:
                 Important known limitations:
             </p>
             <ul>
-                 <li>The MusicXML &lt;backup&gt; element will always go back to the beginning of the measure.</li>
-                 <li>The MusicXML &lt;forward&gt; element is currently ignored.</li>
+                 <li>The MusicXML <code>&lt;backup&gt;</code> element will always go back to the beginning of the measure.</li>
+                 <li>The MusicXML <code>&lt;forward&gt;</code> element isn't fully supported.</li>
                  <li>The file size with this web interface is limited to the size of the local storage of your browser, which is typically 5Mb.</li>
             </ul>
         </div>
-            
+
     </div>
 </div>
 
@@ -115,7 +115,7 @@ examples:
 <script type="text/javascript">
 //<![CDATA[
     function convert_file() {
-        
+
         $('#submit-btn').popover('hide');
         var f = $("#mei_files").prop('files')[0];
         var reader = new FileReader();
@@ -133,16 +133,16 @@ examples:
         // Read in the image file as a data URL.
         reader.readAsText(f);
     };
-    
+
     $( document ).ready(function() {
         $("#mei_files").fileinput({
             'initialCaption': 'Select a MusicXML file ...',
-            'showPreview': true, 
+            'showPreview': true,
             'previewFileType': 'xml'
         });
         $(".fileinput-upload-button span").html('Convert to MEI');
         $(".fileinput-upload-button i").removeClass( "glyphicon-download" ).addClass( "glyphicon-circle-arrow-right" );
     });
-    
+
 //]]>
 </script>

--- a/supported-mei.yml
+++ b/supported-mei.yml
@@ -1,7 +1,10 @@
 att-classes:
   - id: "accidental"
     attributes:
-    - ["accid", "Supported values are 's', 'f', 'n', 'x', 'ff', 'ns' and 'nf'.", ""]
+    - ["accid", "Supported values: 's', 'f', 'n', 'x', 'ff', 'ns' and 'nf'.", ""]
+  - id: "articulation"
+    attributes:
+    - ["artic", "", ""]
   - id: "augmentdots"
     attributes:
     - ["dots", "", ""]
@@ -10,7 +13,10 @@ att-classes:
     - ["breaksec", "", ""]
   - id: "barLine.log"
     attributes:
-    - ["rend", "Supported values are: 'single', 'rptboth', 'rptstart', 'rptend', 'dbl', and 'end'.", ""]
+    - ["rend", "Supported values: 'single', 'rptboth', 'rptstart', 'rptend', 'dbl', and 'end'.", ""]
+  - id: "color"
+    attributes:
+    - ["color", "", ""]
   - id: "coloration"
     attributes:
     - ["colored", "", ""]
@@ -22,7 +28,7 @@ att-classes:
     - ["clef.place", "Supported values: 'below'", ""]
   - id: "clefshape"
     attributes:
-    - ["shape", "Supported values are 'C', 'F' and 'G'.", ""]
+    - ["shape", "Supported values: 'C', 'F' and 'G'.", ""]
   - id: "common"
     attributes:
     - ["label", "", ""]
@@ -39,36 +45,46 @@ att-classes:
     - ["numbase", "", ""]
   - id: "fermatapresent"
     attributes:
-    - ["fermata", "Currently always place above", ""]
+    - ["fermata", "", ""]
+  - id: "fermata.vis"
+    attributes:
+    - ["form", "", ""]
+    - ["shape", "", ""]
   - id: "keySigDefault.log"
     attributes:
-    - ["key.accid", "", ""] 
-    - ["key.mode", "", ""] 
-    - ["key.pname", "", ""] 
+    - ["key.accid", "", ""]
+    - ["key.mode", "", ""]
+    - ["key.pname", "", ""]
     - ["key.sig", "Mixed key signatures are not supported.", ""]
+  - id: "lang"
+    attributes:
+    - ["xml:lang", "", ""]
   - id: "lineloc"
     attributes:
-    - ["line", "Supported values are 1-5 for shape 'C', 1-2 for 'G' and 3-5 for 'F'.", ""]
+    - ["line", "Supported values are 1–5 for shape 'C', 1–2 for 'G' and 3–5 for 'F'.", ""]
   - id: "measure.log"
     attributes:
-    - ["left", "", ""] 
-    - ["right", "", ""] 
+    - ["left", "", ""]
+    - ["right", "", ""]
   - id: "mensur.log"
     attributes:
-    - ["dot", "", ""] 
-    - ["sign", "", ""] 
+    - ["dot", "", ""]
+    - ["sign", "", ""]
   - id: "meterSig.log"
     attributes:
-    - ["count", "", ""] 
-    - ["sym", "", ""] 
-    - ["unit", "", ""] 
+    - ["count", "", ""]
+    - ["sym", "", ""]
+    - ["unit", "", ""]
   - id: "meterSigDefault.log"
     attributes:
-    - ["meter.count", "", ""] 
-    - ["meter.unit", "", ""] 
+    - ["meter.count", "", ""]
+    - ["meter.unit", "", ""]
   - id: "meterSigDefault.vis"
     attributes:
-    - ["meter.sym", "", ""] 
+    - ["meter.sym", "", ""]
+  - id: "miditempo"
+    attributes:
+    - ["midi.bpm", "", ""]
   - id: "numbered"
     attributes:
       - ["num", "", ""]
@@ -82,13 +98,19 @@ att-classes:
   - id: "pitch"
     attributes:
     - ["pitch", "", ""]
+  - id: "placement"
+    attributes:
+    - ["place", "Supported values: 'above' and 'below'", ""]
   - id: "slashcount"
     attributes:
-    - ["slash", "", ""] 
+    - ["slash", "", ""]
   - id: "staffloc.pitched"
     attributes:
     - ["oloc", "", ""]
     - ["ploc", "", ""]
+  - id: "staffident"
+    attributes:
+    - ["staff", "", ""]
   - id: "startendid"
     attributes:
     - ["endid", "", ""]
@@ -97,30 +119,44 @@ att-classes:
     - ["startid", "", ""]
   - id: "stemmed"
     attributes:
-    - ["stem.dir", "", ""] 
-    - ["stem.len", "Not supported yet", ""] 
-    - ["stem.pos", "Not supported yet", ""] 
-    - ["stem.x", "Not supported yet", ""] 
-    - ["stem.y", "Not supported yet", ""] 
+    - ["stem.dir", "", ""]
+    - ["stem.len", "Supported values: 0", ""]
+    - ["stem.pos", "Not supported yet", ""]
+    - ["stem.x", "Not supported yet", ""]
+    - ["stem.y", "Not supported yet", ""]
+  - id: "linerend.base"
+    attributes:
+    - ["lform", "Supported values: 'dashed' and 'solid'", ""]
+    - ["lwidth", "Supported values: 'narrow', 'medium', and 'wide'", ""]
   - id: "syl.log"
     attributes:
-    - ["con", "Not supported yet", ""] 
-    - ["wordpos", "Not supported yet", ""] 
+    - ["con", "Not supported yet", ""]
+    - ["wordpos", "Not supported yet", ""]
   - id: "tiepresent"
     attributes:
-    - ["tie", "", ""] 
-
+    - ["tie", "", ""]
+  - id: "timestamp.musical"
+    attributes:
+    - ["tstamp", "", ""]
+  - id: "timestamp2.musical"
+    attributes:
+    - ["tstamp2", "", ""]
+  - id: "typography"
+    attributes:
+    - ["fontname", "", ""]
+    - ["fontstyle", "", ""]
+    - ["fontweight", "", ""]
   - id: "note.log.mensural"
     attributes:
-    - ["lig", "", ""] 
+    - ["lig", "", ""]
   - id: "mensural.log"
     attributes:
-    - ["mensur.dot", "", ""] 
-    - ["mensur.sign", "", ""] 
-    - ["mensur.slash", "Only 1 slash is supported.", ""] 
+    - ["mensur.dot", "", ""]
+    - ["mensur.sign", "", ""]
+    - ["mensur.slash", "Only 1 slash is supported.", ""]
   - id: "mensur.vis"
     attributes:
-    - ["orient", "Only reversed is supported.", ""] 
+    - ["orient", "Only reversed is supported.", ""]
 
 classes:
   - id: "accid"
@@ -132,7 +168,18 @@ classes:
     att-classes:
       - common
     attributes: []
+  - id: "artic"
+    att-classes:
+      - articulation
+      - color
+      - placement
+    attributes: []
   - id: "beam"
+  - id: "beatRpt"
+    att-classes:
+      - color
+    attributes:
+      - ["form", "", ""]
   - id: "barLine"
     att-classes:
       - barLine.log
@@ -142,9 +189,11 @@ classes:
       - augmentdots # durationInterface
       - beamsecondary # durationInterface
       - duration.musical # durationInterface
-      - duration.performed # durationInterface      
+      - duration.performed # durationInterface
       - duration.ratio # durationInterface
       - fermatapresent # durationInterface
+      - articulation
+      - color
       - common
       - stemmed
       - tiepresent
@@ -159,9 +208,50 @@ classes:
     att-classes:
       - staffloc.pitched # postionInterface
     attributes: []
+  - id: "dir"
+    att-classes:
+      - lang
+      - staffident
+      - startid
+      - timestamp.musical
+    attributes: []
   - id: "dot"
     att-classes:
       - staffloc.pitched # postionInterface
+    attributes: []
+  - id: "dynam"
+    att-classes:
+      - lang
+      - staffident
+      - startid
+      - timestamp.musical
+    attributes: []
+  - id: "fermata"
+    att-classes:
+      - color
+      - fermata.vis
+      - placement
+      - staffident
+      - startid
+      - timestamp.musical
+    attributes: []
+  - id: "harm"
+    att-classes:
+      - lang
+      - placement
+      - staffident
+      - startid
+      - timestamp.musical
+    attributes: []
+  - id: "hairpin"
+    att-classes:
+      - color
+      - placement
+      - staffident
+      - startendid
+      - startid
+      - timestamp.musical
+      - timestamp2.musical
     attributes: []
   - id: "layer"
     att-classes:
@@ -177,12 +267,12 @@ classes:
       - mensural.shared
       - mensur.log
       - mensur.vis
-      - slash.count  
+      - slash.count
     attributes: []
   - id: "measure"
     att-classes:
       - common
-      - measure.log  
+      - measure.log
     attributes: []
   - id: "mensur"
     att-classes:
@@ -203,31 +293,58 @@ classes:
       - augmentdots # durationInterface
       - beamsecondary # durationInterface
       - duration.musical # durationInterface
-      - duration.performed # durationInterface      
+      - duration.performed # durationInterface
       - duration.ratio # durationInterface
       - fermatapresent # durationInterface
       - accidental # pitchInterface
       - octave # pitchInterface
       - pitch # pitchInterface
+      - articulation
+      - color
       - coloration
       - note.log.mensural
       - stemmed
       - tiepresent
     attributes:
       - ["grace", "Currently all values will be treated undifferently", ""]
+  - id: "octave"
+    att-classes:
+      - color
+      - linerend.base
+      - staffident
+      - startendid
+      - startid
+      - timestamp.musical
+      - timestamp2.musical
+    attributes: []
+  - id: "pedal"
+    att-classes:
+      - color
+      - staffident
+      - startid
+      - timestamp.musical
+    attributes: []
   - id: "rdg"
     att-classes:
       - common
     attributes:
       - ["source", "Only for selection with the --rdg-xpath-query option", ""]
+  - id: "rend"
+    att-classes:
+      - color
+      - common
+      - lang
+      - typography
+    attributes: []
   - id: "rest"
     att-classes:
       - augmentdots # durationInterface
       - beamsecondary # durationInterface
       - duration.musical # durationInterface
-      - duration.performed # durationInterface      
+      - duration.performed # durationInterface
       - duration.ratio # durationInterface
       - fermatapresent # durationInterface
+      - color
     attributes:
       - ["dur.ges", "Gestural duration, for logical durations (e.g. display a breve but space it as a quarter).", ""]
       - ["oloc", "", ""]
@@ -241,6 +358,8 @@ classes:
     attributes: []
   - id: "slur"
     att-classes:
+      - color
+      - staffident
       - startendid
       - startid
     attributes: []
@@ -255,6 +374,7 @@ classes:
       - keySigDefault.log
       - meterSigDefault.log
       - mensural.log
+      - miditempo
     attributes:
       - ["n", "The order of the <code>&lt;staffDef&gt;</code> elements must correspond to the values (1-based).", ""]
   - id: "staffGrp"
@@ -267,19 +387,40 @@ classes:
     attributes: []
   - id: "syl"
     att-classes:
+      - lang
       - syl.log
+      - typography
+    attributes: []
+  - id: "tempo"
+    att-classes:
+      - lang
+      - miditempo
+      - staffident
     attributes: []
   - id: "tie"
     att-classes:
+      - color
+      - staffident
       - startendid
       - startid
     attributes: []
+  - id: "trill"
+    att-classes:
+      - color
+      - placement
+      - staffident
+      - startid
+      - timestamp.musical
+    attributes: []
   - id: "tuplet"
-    attributes:   
+    att-classes:
       - duration.ratio
+    attributes: []
   - id: "verse"
     att-classes:
+      - color
       - common
+      - lang
     attributes: []
 
 page-based-classes:


### PR DESCRIPTION
This PR adds examples for fermatas and trills to the feature list. Yet the code snippets have to be extracted.