### PR TITLE
copying complete meiHead

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -355,7 +355,6 @@ public:
 
 private:
     bool ReadMei(pugi::xml_node root);
-    bool ReadMeiHeader(pugi::xml_node meihead);
 
     /**
      * @name Methods for reading MEI score-based elements

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -556,9 +556,10 @@ void HumdrumInput::createHeader(void)
     vector<hum::HumdrumLine *> references = infile.getReferenceRecords();
     vector<vector<string> > respPeople;
     getRespPeople(respPeople, references);
+    pugi::xml_node fileDesc = m_doc->m_header.append_child("meiHead");
 
     // <fileDesc> /////////////
-    pugi::xml_node fileDesc = m_doc->m_header.append_child("fileDesc");
+    pugi::xml_node fileDesc = meiHead.append_child("fileDesc");
     pugi::xml_node fileTitle = fileDesc.append_child("titleStmt");
 
     std::string OTL = getReferenceValue("OTL", references);
@@ -608,7 +609,7 @@ void HumdrumInput::createHeader(void)
     }
 
     // <encodingDesc> /////////
-    pugi::xml_node encodingDesc = m_doc->m_header.append_child("encodingDesc");
+    pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
 
     // <appInfo> /////////
     pugi::xml_node appInfo = encodingDesc.append_child("appInfo");
@@ -658,7 +659,7 @@ void HumdrumInput::createHeader(void)
     // <sourceDesc> /////////
 
     // <workDesc> /////////////
-    pugi::xml_node workDesc = m_doc->m_header.append_child("workDesc");
+    pugi::xml_node workDesc = meiHead.append_child("workDesc");
     pugi::xml_node work = workDesc.append_child("work");
 
     std::string SCT = getReferenceValue("SCT", references);
@@ -816,7 +817,7 @@ void HumdrumInput::insertExtMeta(vector<hum::HumdrumLine *> &references)
         return;
     }
 
-    m_doc->m_header.append_copy(tmpdoc.document_element());
+    meiHead.append_copy(tmpdoc.document_element());
 }
 
 //////////////////////////////

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -544,14 +544,11 @@ bool MeiOutput::WriteMeiDoc(Doc *doc)
 
     // ---- header ----
 
-    pugi::xml_node meiHead = m_mei.append_child("meiHead");
-
     if (m_doc->m_header.first_child()) {
-        for (pugi::xml_node child = m_doc->m_header.first_child(); child; child = child.next_sibling()) {
-            meiHead.append_copy(child);
-        }
+        m_mei.append_copy(m_doc->m_header.first_child());
     }
     else {
+        pugi::xml_node meiHead = m_mei.append_child("meiHead");
         pugi::xml_node fileDesc = meiHead.append_child("fileDesc");
         pugi::xml_node titleStmt = fileDesc.append_child("titleStmt");
         titleStmt.append_child("title");
@@ -1640,7 +1637,9 @@ bool MeiInput::ReadMei(pugi::xml_node root)
     m_readingScoreBased = false;
 
     if (!root.empty() && (current = root.child("meiHead"))) {
-        ReadMeiHeader(current);
+        m_doc->m_header.reset();
+        // copy the complete header into the master document
+        m_doc->m_header.append_copy(current);
     }
     // music
     pugi::xml_node music;
@@ -1705,16 +1704,6 @@ bool MeiInput::ReadMei(pugi::xml_node root)
         }
     }
     return success;
-}
-
-bool MeiInput::ReadMeiHeader(pugi::xml_node meiHead)
-{
-    m_doc->m_header.reset();
-    // copy all the nodes inside into the master document
-    for (pugi::xml_node child = meiHead.first_child(); child; child = child.next_sibling()) {
-        m_doc->m_header.append_copy(child);
-    }
-    return true;
 }
 
 bool MeiInput::ReadMeiSection(Object *parent, pugi::xml_node section)

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -498,9 +498,10 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     assert(root);
     pugi::xpath_node workTitle = root.select_single_node("/score-partwise/work/work-title");
     pugi::xpath_node movementTitle = root.select_single_node("/score-partwise/movement-title");
+    pugi::xml_node meiHead = m_doc->m_header.append_child("meiHead");
 
     // <fileDesc> /////////////
-    pugi::xml_node fileDesc = m_doc->m_header.append_child("fileDesc");
+    pugi::xml_node fileDesc = meiHead.append_child("fileDesc");
     pugi::xml_node titleStmt = fileDesc.append_child("titleStmt");
     pugi::xml_node meiTitle = titleStmt.append_child("title");
     if (movementTitle)
@@ -511,7 +512,7 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     pugi::xml_node pubStmt = fileDesc.append_child("pubStmt");
     pubStmt.append_child(pugi::node_pcdata);
 
-    pugi::xml_node encodingDesc = m_doc->m_header.append_child("encodingDesc");
+    pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
     pugi::xml_node appInfo = encodingDesc.append_child("appInfo");
     pugi::xml_node app = appInfo.append_child("application");
     pugi::xml_node appName = app.append_child("name");


### PR DESCRIPTION
It seems to make more sense to copy the whole header while reading the MEI file instead of copying every child losing the attributes on `<meiHead>`.
I changed humdrum and musxml importer respectively.
