### PR TITLE
Removed unused warnings by adding a UNUSED define

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -413,7 +413,7 @@ public:
     /**
      * Retrieve the time spanning layer elements between two points
      */
-    virtual int FindTimeSpanningLayerElements(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int FindTimeSpanningLayerElements(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     ///@}
 
@@ -425,8 +425,8 @@ public:
     /**
      * Convert top-level all container (section, endings) and editorial elements to boundary elements.
      */
-    virtual int ConvertToPageBased(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int ConvertToPageBased(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Save the content of any object by calling the appropriate FileOutputStream method.
@@ -444,22 +444,22 @@ public:
     /**
      * Adjust the position the outside articulations.
      */
-    virtual int AdjustArtic(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AdjustArtic(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Adjust the position the outside articulations with slur.
      */
-    virtual int AdjustArticWithSlurs(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AdjustArticWithSlurs(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Adjust the position of all floating positionner, staff by staff.
      */
-    virtual int AdjustFloatingPostioners(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AdjustFloatingPostioners(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Adjust the position of all floating positionner that are grouped, staff by staff.
      */
-    virtual int AdjustFloatingPostionerGrps(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AdjustFloatingPostionerGrps(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Align horizontally the content of a page.
@@ -467,38 +467,38 @@ public:
      * It creates it if no other note or event occurs at its position.
      * At the end, for each Layer, align the grace note stacked in GraceAlignment.
      */
-    virtual int AlignHorizontally(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int AlignHorizontallyEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AlignHorizontally(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int AlignHorizontallyEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Align the measures by adjusting the m_drawingXRel position looking at the MeasureAligner.
      * At the end, store the width of the system in the MeasureAligner for justification.
      */
-    virtual int AlignMeasures(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int AlignMeasuresEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AlignMeasures(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int AlignMeasuresEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Correct the X alignment once the content of a system has been aligned and laid out
      * See Measure::IntegrateBoundingBoxXShift for actual implementation
      */
-    virtual int IntegrateBoundingBoxGraceXShift(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int IntegrateBoundingBoxGraceXShift(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Correct the X alignment once the content of a system has been aligned and laid out
      * See Measure::IntegrateBoundingBoxXShift for actual implementation
      */
-    virtual int IntegrateBoundingBoxXShift(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int IntegrateBoundingBoxXShift(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Reset the horizontal alignment environment for various types for object.
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int ResetHorizontalAlignment(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Set the position of the Alignment.
      * Looks at the time difference from the previous Alignment.
      */
-    virtual int SetAlignmentXPos(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int SetAlignmentXPos(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Lay out the X positions of the grace notes looking at the bounding boxes.
@@ -525,33 +525,33 @@ public:
      * Align vertically the content of a page.
      * For each Staff, instanciate its StaffAlignment.
      */
-    virtual int AlignVertically(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AlignVertically(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Align the system by adjusting the m_drawingYRel position looking at the SystemAligner.
      */
-    virtual int AlignSystems(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int AlignSystems(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Calculate the overlap of the staff aligmnents by looking at the overflow bounding boxes
      */
-    virtual int CalcStaffOverlap(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int CalcStaffOverlap(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Correct the Y alignment once the content of a system has been aligned and laid out
      * See System::IntegrateBoundingBoxYShift for actual implementation
      */
-    virtual int IntegrateBoundingBoxYShift(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int IntegrateBoundingBoxYShift(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Reset the verticall alignment environment for various types for object.
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int ResetVerticalAlignment(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Set the position of the StaffAlignment.
      */
-    virtual int SetAligmentYPos(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int SetAligmentYPos(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Fill the arrays of bounding boxes (above and below) for each staff alignment for which the box overflows.
@@ -575,7 +575,7 @@ public:
      * Set the current / drawing clef, key signature, etc. to the StaffDef
      * Called form ScoreDef::ReplaceDrawingValues.
      */
-    virtual int ReplaceDrawingValuesInStaffDef(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int ReplaceDrawingValuesInStaffDef(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Set the current scoreDef wherever need.
@@ -593,7 +593,7 @@ public:
     /**
      * Unset the initial scoreDef of each system and measure
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Set drawing flags for the StaffDef for indicating whether clefs, keysigs, etc. need
@@ -601,7 +601,7 @@ public:
      * This typically occurs when a new System or a new  ScoreDef is encountered.
      * See implementation and Object::SetStaffDefRedrawFlags for the parameters.
      */
-    virtual int SetStaffDefRedrawFlags(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int SetStaffDefRedrawFlags(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     ///@}
 
@@ -613,29 +613,29 @@ public:
     /**
      * Builds a tree of ints (IntTree) with the staff/layer/verse numbers and for staff/layer to be then processed.
      */
-    virtual int PrepareProcessingLists(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareProcessingLists(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Match start for TimePointingInterface elements (such as fermata or harm).
      */
-    virtual int PrepareTimePointing(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int PrepareTimePointingEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareTimePointing(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int PrepareTimePointingEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Match start and end for TimeSpanningInterface elements (such as tie or slur).
      * If fillList is set to false, only the remaining elements will be matched.
      * This is used when processing a second time in the other direction
      */
-    virtual int PrepareTimeSpanning(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int PrepareTimeSpanningEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareTimeSpanning(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int PrepareTimeSpanningEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Match start and end for TimeSpanningInterface elements with tstamp(2) attributes.
      * It is performed only on TimeSpanningInterface elements withouth @startid (or @endid).
      * It adds to the start (and end) measure a TimeStampAttr to the Measure::m_tstamps.
      */
-    virtual int PrepareTimestamps(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int PrepareTimestampsEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareTimestamps(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int PrepareTimestampsEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Process Chord and Note for matching @tie by processing by Layer and by looking
@@ -643,63 +643,63 @@ public:
      * At the end, processes Chord and Note for matching @tie by processing by Layer; resets the
      * Chord pointer to NULL at the end of a chord.
      */
-    virtual int PrepareTieAttr(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int PrepareTieAttrEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareTieAttr(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int PrepareTieAttrEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Process by Layer and set drawing pointers.
      * Set Dot::m_drawingNote for Dot elements in mensural mode
      * Set Note::m_drawingAccid for Note elements having an Accid child
      */
-    virtual int PreparePointersByLayer(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PreparePointersByLayer(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Set wordpos and connector ends
      * The functor is processed by staff/layer/verse using an ArrayOfAttComparisons filter.
      * At the end, the functor is processed by doc at the end of a document of closing opened syl.
      */
-    virtual int PrepareLyrics(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int PrepareLyricsEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareLyrics(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int PrepareLyricsEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Functor for setting the artic parts.
      * Splits the artic content into different artic parts if necessary
      */
-    virtual int PrepareArtic(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareArtic(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Functor for setting mRpt drawing numbers (if required)
      * The functor is processed by staff/layer using an ArrayOfAttComparisons filter.
      */
-    virtual int PrepareRpt(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareRpt(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Functor for setting Measure of Ending
      */
-    virtual int PrepareBoundaries(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareBoundaries(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Functor for grouping FloatingObject by drawingGrpId
      */
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareFloatingGrps(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Go through all the TimeSpanningInterface elements and set them a current to each staff
      * where required. For Note with DrawingTieAttr, the functor is redirected to the tie object.
      * At the end, remove the TimeSpanningInterface element from the list when the last measure is reached.
      */
-    virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int FillStaffCurrentTimeSpanningEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int FillStaffCurrentTimeSpanningEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Reset the drawing values before calling PrepareDrawing after changes.
      */
-    virtual int ResetDrawing(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int ResetDrawing(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Set the drawing position (m_drawingX and m_drawingY) values for objects
      */
-    virtual int SetDrawingXY(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int SetDrawingXY(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     ///@}
 
@@ -711,12 +711,12 @@ public:
     /**
      * Justify the X positions
      */
-    virtual int JustifyX(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int JustifyX(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Justify the Y positions
      */
-    virtual int JustifyY(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int JustifyY(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     ///@}
 
@@ -729,24 +729,24 @@ public:
      * Fill a page by adding systems with the appropriate length.
      * At the end, add all the pending objects where reaching the end
      */
-    virtual int CastOffSystems(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int CastOffSystemsEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int CastOffSystems(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int CastOffSystemsEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      *
      */
-    virtual int CastOffPages(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int CastOffPages(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Cast off the document according to the encoding provided (pb and sb)
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int CastOffEncoding(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Undo the cast of both pages and system.
      * This is used by Doc::ContinuousLayout for putting all pages / systems continously.
      */
-    virtual int UnCastOff(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int UnCastOff(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     ///@}
 
@@ -758,13 +758,13 @@ public:
     /**
      * Export the object to a MidiFile
      */
-    virtual int GenerateMIDI(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
-    virtual int GenerateMIDIEnd(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int GenerateMIDI(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
+    virtual int GenerateMIDIEnd(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     /**
      * Calculate the maximum duration of each measure.
      */
-    virtual int CalcMaxMeasureDuration(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int CalcMaxMeasureDuration(FunctorParams *functorParams) { UNUSED(functorParams); return FUNCTOR_CONTINUE; }
 
     ///@}
 
@@ -891,7 +891,7 @@ protected:
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    virtual void FilterList(ListOfObjects *childList){};
+    virtual void FilterList(ListOfObjects *childList) { UNUSED(childList); }
 
 public:
     /**

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -233,6 +233,8 @@ typedef std::vector<BoundingBox *> ArrayOfBoundingBoxes;
  */
 enum FunctorCode { FUNCTOR_CONTINUE = 0, FUNCTOR_SIBLINGS, FUNCTOR_STOP };
 
+#define UNUSED(x) {(void)x;}
+
 //----------------------------------------------------------------------------
 // Maximum number of levels between parent and children for optimizing search
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Using a UNUSED define to 'hide' warnings of unused variables. I usually like to compile with -Wall and these unused variables generate > 700 warnings.