### PR TITLE
Removed webworker fork in build process

### DIFF
--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -43,7 +43,7 @@ $FLAGS .= " -s OUTLINING_LIMIT=10000";
 $FLAGS .= " -s TOTAL_MEMORY=128*1024*1024";
 $FLAGS .= " -s TOTAL_STACK=64*1024*1024";
 
-my ($FLAGS_NAME, $WEBWORKER, $WEBWORKER_NAME, $VERSION, $CHATTY);
+my ($FLAGS_NAME, $VERSION, $CHATTY);
 
 
 sub print_help {
@@ -55,7 +55,6 @@ Options:
 -l      Light version with no increased memory allocation
 -r DIR  Verovio root directory
 -v N    Version number (e.g., 1.0.0); no number by default
--w      WebWorker-compatible build
 -x      Font exclusion list (case-sensitive)
 -D      Disable DARMS importer
 -H      Disable Humdrum importer
@@ -113,9 +112,7 @@ if ($chattyQ) {
 }
 
 if ($webworkerQ) {
-	print "Building with webworker compatibility.\n";
-	$WEBWORKER = 1;
-	$WEBWORKER_NAME = "-webworker";
+	print "Warning: the -w flag for WebWorker compatibility is no longer necessary.\n";
 }
 
 if (!$nohumdrum) {
@@ -127,7 +124,7 @@ if ($helpQ) {
 	exit 2;
 }
 
-my $FILENAME = "verovio-toolkit$FLAGS_NAME$WEBWORKER_NAME.js";
+my $FILENAME = "verovio-toolkit$FLAGS_NAME.js";
 
 my $DATA_DIR  = "data";
 my $BUILD_DIR = "build";
@@ -197,11 +194,7 @@ if ($? == 0) {
 	print " Done.\n";
 
 	# the wrapper is necessary with closure 1 for avoiding to conflict with globals
-	if ($WEBWORKER) {
-		`cat $BUILD_DIR/verovio.js verovio-proxy.js > $BUILD_DIR/$FILENAME`;
-	} else {
-		`cat $BUILD_DIR/verovio.js verovio-proxy.js verovio-unload-listener.js > $BUILD_DIR/$FILENAME`;
-	}
+	`cat $BUILD_DIR/verovio.js verovio-proxy.js > $BUILD_DIR/$FILENAME`;
 
 	# create a gzip version
 	`(cd $BUILD_DIR && gzip -c $FILENAME > $FILENAME.gz)`;

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -172,3 +172,14 @@ verovio.toolkit.prototype.getElementAttr = function (xmlId) {
 };
 
 /***************************************************************************************************************************/
+
+// If the window object is defined (if we are not within a WebWorker)...
+if ((typeof window !== "undefined") && (window.addEventListener))
+{
+	// Add a listener that will delete the object (if necessary) when the page is closed
+	window.addEventListener ("unload", function () {
+		if (verovio.ptr != 0) {
+			verovio.vrvToolkit.destructor( verovio.ptr );
+		}
+	});
+}

--- a/emscripten/verovio-unload-listener.js
+++ b/emscripten/verovio-unload-listener.js
@@ -1,6 +1,0 @@
-// add a listener that will delete the object (if necessary) when the page is left
-window.addEventListener ("unload", function () {
-	if (verovio.ptr != 0) {
-		verovio.vrvToolkit.destructor( verovio.ptr );
-	}
-});


### PR DESCRIPTION
Was fooling around with Vida and realized, for WebWorker compatibility, Verovio only needs an `if` clause to make sure the `window` object is accessible for the unload listener.

This commit implements that and strips most of the WebWorker code from buildToolkit, leaving a warning message if someone tries to request that compilation. Tested in a WebWorker in Safari/Firefox/Chrome with no problems for the normal toolkit or the `-l` compilation. Have also verified that the onunload listener still functions correctly when the toolkit is included outside of a WebWorker.

I'm not sure if this is actually desired at this point or if you'd rather maintain the `if/else` fork in case some other WebWorker compatibility is needed in the future, but this might make the build script a bit easier to maintain for now.