### PR TITLE
Fix for #526

### DIFF
--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1043,7 +1043,14 @@ const char *Toolkit::GetHumdrumBuffer()
 bool Toolkit::Drag(std::string elementId, int x, int y)
 {
     if (!m_doc.GetDrawingPage()) return false;
+    
+    // Try to get the element on the current drawing page
     Object *element = m_doc.GetDrawingPage()->FindChildByUuid(elementId);
+
+    // If it wasn't there, go back up to the whole doc
+    if (!element) {
+        element = m_doc.FindChildByUuid(elementId);
+    }
     if (element->Is(NOTE)) {
         Note *note = dynamic_cast<Note *>(element);
         assert(note);


### PR DESCRIPTION
There seems to be a bug in the current develop branch where running Toolkit::Drag and then calling toolkit.renderPage returns the same SVG (without reflecting the pitch change). Running a git bisect right now to see if I can get you any more information.

I've nonetheless verified the first commit by testing it with toolkit.getMEI() - the PName/Oct change is reflected correctly and there's no console error, so it gets past the assertion in 1049 (old line number) fine.