### PR TITLE
changed DrawStem and added color to beam

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -63,7 +63,7 @@ public:
 // Beam
 //----------------------------------------------------------------------------
 
-class Beam : public LayerElement, public ObjectListInterface, public DrawingListInterface {
+class Beam : public LayerElement, public ObjectListInterface, public DrawingListInterface, public AttColor {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -303,8 +303,10 @@ void BeamDrawingParams::CalcBeam(
 // Beam
 //----------------------------------------------------------------------------
 
-Beam::Beam() : LayerElement("beam-"), ObjectListInterface()
+Beam::Beam() : LayerElement("beam-"), ObjectListInterface(), AttColor()
 {
+    RegisterAttClass(ATT_COLOR);
+
     Reset();
 }
 
@@ -316,6 +318,7 @@ Beam::~Beam()
 void Beam::Reset()
 {
     LayerElement::Reset();
+    ResetColor();
 
     ClearCoords();
 }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1010,6 +1010,7 @@ void MeiOutput::WriteMeiBeam(pugi::xml_node currentNode, Beam *beam)
     assert(beam);
 
     WriteLayerElement(currentNode, beam);
+    beam->WriteColor(currentNode);
 }
 
 void MeiOutput::WriteMeiBeatRpt(pugi::xml_node currentNode, BeatRpt *beatRpt)
@@ -2850,6 +2851,8 @@ bool MeiInput::ReadMeiBeam(Object *parent, pugi::xml_node beam)
 {
     Beam *vrvBeam = new Beam();
     ReadLayerElement(beam, vrvBeam);
+
+    vrvBeam->ReadColor(beam);
 
     parent->AddChild(vrvBeam);
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -200,7 +200,6 @@ void SvgDeviceContext::StartGraphic(Object *object, std::string gClass, std::str
         assert(att);
         if (att->HasColor()) {
             m_currentNode.append_attribute("fill") = att->GetColor().c_str();
-            m_currentNode.append_attribute("stroke") = att->GetColor().c_str();
         }
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -307,7 +307,7 @@ void View::DrawArticPart(DeviceContext *dc, LayerElement *element, Layer *layer,
         xCorr = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, drawingCueSize) / 2;
         // The position of the next glyph (and for correcting the baseline if necessary
         int glyphHeight = m_doc->GetGlyphHeight(code, staff->m_drawingStaffSize, drawingCueSize);
-        
+
         // Center the glyh if necessary
         if (Artic::IsCentered(*articIter)) {
             y += (articPart->GetPlace() == STAFFREL_above) ? -(glyphHeight / 2) : (glyphHeight / 2);
@@ -1227,8 +1227,9 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    DrawVerticalLine(dc, stem->GetDrawingY(), stem->GetDrawingY() - stem->GetDrawingStemLen(), stem->GetDrawingX(),
-        m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize));
+    DrawFilledRectangle(dc, stem->GetDrawingX() + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
+        stem->GetDrawingY(), stem->GetDrawingX() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
+        stem->GetDrawingY() - stem->GetDrawingStemLen());
 
     DrawLayerChildren(dc, stem, layer, staff, measure);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1227,8 +1227,8 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    DrawFilledRectangle(dc, stem->GetDrawingX() + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
-        stem->GetDrawingY(), stem->GetDrawingX() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
+    DrawFilledRectangle(dc, stem->GetDrawingX() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
+        stem->GetDrawingY(), stem->GetDrawingX() + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
         stem->GetDrawingY() - stem->GetDrawingStemLen());
 
     DrawLayerChildren(dc, stem, layer, staff, measure);


### PR DESCRIPTION
This changes stems from SVG `path` to `rect` to address #596 
Additionally it adds missing color support to beam and removes the no longer needed `stroke` from SVG.

![drawstem_001](https://cloud.githubusercontent.com/assets/7693447/26148741/064c5dac-3af8-11e7-85e9-73ce3a9df2f9.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://www.music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://www.music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title/>
      </titleStmt>
      <pubStmt/>
      <seriesStmt>
        <title>Brawing stems</title>
      </seriesStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef meter.count="3" meter.unit="8">
            <staffGrp>
              <staffDef n="1" clef.line="3" clef.shape="C" lines="5"/>
            </staffGrp>
          </scoreDef>
          <section>
            <measure n="1">
              <staff n="1">
                <layer n="1">
                  <note dur="4" oct="4" pname="c" color="blue"/>
                  <note dur="8" oct="4" pname="c" color="red"/>
                </layer>
              </staff>
            </measure>
            <measure n="2">
              <staff n="1">
                <layer n="1">
                  <beam color="lightgray">
                    <note dur="8" oct="4" pname="c" color="green"/>
                    <note dur="8" oct="4" pname="c"/>
                    <note dur="8" oct="4" pname="c"/>
                  </beam>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```