### PR TITLE
better positioning of rests

### DIFF
--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -67,7 +67,12 @@ public:
     /**
      * Get the default loc for a doc when neither oloc or loc are provided.
      */
-    int GetDefaultLoc(bool hasMultipleLayer, bool isFirstLayer);
+    int GetRestDefaultLoc(bool hasMultipleLayer, bool isFirstLayer);
+
+    /**
+     * Get the vertical offset for each glyph.
+     */
+    int GetRestLocOffset(int loc);
 
     //----------//
     // Functors //

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1125,6 +1125,7 @@ void MeiOutput::WriteMeiMeterSig(pugi::xml_node currentNode, MeterSig *meterSig)
 
     WriteLayerElement(currentNode, meterSig);
     meterSig->WriteMeterSigLog(currentNode);
+    meterSig->WriteMeterSigVis(currentNode);
 }
 
 void MeiOutput::WriteMeiMRest(pugi::xml_node currentNode, MRest *mRest)
@@ -3040,6 +3041,7 @@ bool MeiInput::ReadMeiMeterSig(Object *parent, pugi::xml_node meterSig)
     ReadLayerElement(meterSig, vrvMeterSig);
 
     vrvMeterSig->ReadMeterSigLog(meterSig);
+    vrvMeterSig->ReadMeterSigVis(meterSig);
 
     parent->AddChild(vrvMeterSig);
     return true;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -735,8 +735,9 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 assert(firstLayer);
                 if (firstLayer->GetN() == layerY->GetN()) isFirstLayer = true;
             }
-            loc = rest->GetDefaultLoc(hasMultipleLayer, isFirstLayer);
+            loc = rest->GetRestDefaultLoc(hasMultipleLayer, isFirstLayer);
         }
+        loc = rest->GetRestLocOffset(loc);
         rest->SetDrawingLoc(loc);
         this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, loc));
     }
@@ -809,7 +810,7 @@ int LayerElement::AdjustLayers(FunctorParams *functorParams)
 
             // Nothing to do if we have no vertical overlap
             if (!this->VerticalSelfOverlap(*iter, verticalMargin)) continue;
-            
+
             // Nothing to do either if we have no horizontal overlap
             if (!this->HorizontalSelfOverlap(*iter, horizontalMargin)) continue;
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -96,10 +96,23 @@ wchar_t Rest::GetRestGlyph() const
     return symc;
 }
 
-int Rest::GetDefaultLoc(bool hasMultipleLayer, bool isFirstLayer)
+int Rest::GetRestDefaultLoc(bool hasMultipleLayer, bool isFirstLayer)
 {
+    // only works if staff has 5 lines
     int loc = 4;
 
+    if (hasMultipleLayer) {
+        if (isFirstLayer)
+            loc += 2;
+        else
+            loc -= 2;
+    }
+
+    return loc;
+}
+
+int Rest::GetRestLocOffset(int loc)
+{
     switch (this->GetActualDur()) {
         case DUR_MX: loc -= 0; break;
         case DUR_LG: loc -= 0; break;
@@ -114,12 +127,6 @@ int Rest::GetDefaultLoc(bool hasMultipleLayer, bool isFirstLayer)
         case DUR_128: loc -= 2; break;
         case DUR_256: loc -= 2; break;
         default: loc -= 1; break;
-    }
-    if (hasMultipleLayer) {
-        if (isFirstLayer)
-            loc += 2;
-        else
-            loc -= 2;
     }
 
     return loc;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -901,7 +901,7 @@ void View::DrawMeterSig(DeviceContext *dc, LayerElement *element, Layer *layer, 
     else if (meterSig->GetForm() == meterSigVis_FORM_num) {
         DrawMeterSigFigures(dc, x, staff->GetDrawingY(), meterSig->GetCount(), NONE, staff);
     }
-    else if (meterSig->GetCount()) {
+    else if (meterSig->HasCount()) {
         DrawMeterSigFigures(dc, x, staff->GetDrawingY(), meterSig->GetCount(), meterSig->GetUnit(), staff);
     }
 


### PR DESCRIPTION
This PR brings correct positioning of rests when using `@loc` or `@ploc` and `@oloc`.

![rests](https://cloud.githubusercontent.com/assets/7693447/26409949/39759428-40a2-11e7-9937-8f7c175b7879.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="3.0.0">
  <meiHead>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef>
            <staffGrp n="1" >
              <staffDef n="1" lines="5" clef.line="2" clef.shape="G"/>
            </staffGrp>
          </scoreDef>
          <section>
            <measure right="dbl">
              <staff n="1">
                <layer n="1">
                  <rest dur="4"/>
                  <rest dur="4" loc="0"/>
                  <rest dur="4" loc="2"/>
                  <rest dur="4" loc="4"/>
                  <rest dur="4" loc="6"/>
                  <rest dur="4" loc="8"/>
                  <rest dur="4" oloc="4" ploc="c"/>
                  <rest dur="4" oloc="4" ploc="e"/>
                  <rest dur="4" oloc="4" ploc="g"/>
                  <rest dur="4" oloc="4" ploc="b"/>
                  <rest dur="4" oloc="5" ploc="d"/>
                  <rest dur="4" oloc="5" ploc="f"/>
                  <rest dur="4" oloc="5" ploc="a"/>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```

NB:
`GetRestDefaultLoc` sets default position of rest to `@loc="4"`. But this only works if we have a staff with 5 lines. Instead for default `staffDef@lines - 1` should be used, to center the rest vertically on the staff. Additionally applying an layer specific offset seems to me better suited somewhere else as in `rest.cpp`. 