### PR TITLE
refining rests

### DIFF
--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -20,7 +20,7 @@ namespace vrv {
 /**
  * This class models the MEI <multiRest> element.
  */
-class MultiRest : public LayerElement, public AttNumbered {
+class MultiRest : public LayerElement, public AttMultiRestVis, public AttNumbered {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -65,11 +65,6 @@ public:
     wchar_t GetRestGlyph() const;
 
     /**
-     * Get the default loc for a doc when neither oloc or loc are provided.
-     */
-    int GetRestDefaultLoc(bool hasMultipleLayer, bool isFirstLayer);
-
-    /**
      * Get the vertical offset for each glyph.
      */
     int GetRestLocOffset(int loc);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1158,6 +1158,7 @@ void MeiOutput::WriteMeiMultiRest(pugi::xml_node currentNode, MultiRest *multiRe
     assert(multiRest);
 
     WriteLayerElement(currentNode, multiRest);
+    multiRest->WriteMultiRestVis(currentNode);
     multiRest->WriteNumbered(currentNode);
 }
 
@@ -3097,6 +3098,7 @@ bool MeiInput::ReadMeiMultiRest(Object *parent, pugi::xml_node multiRest)
     MultiRest *vrvMultiRest = new MultiRest();
     ReadLayerElement(multiRest, vrvMultiRest);
 
+    vrvMultiRest->ReadMultiRestVis(multiRest);
     vrvMultiRest->ReadNumbered(multiRest);
 
     parent->AddChild(vrvMultiRest);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -727,15 +727,21 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
         }
         // Automatically calculate rest position
         else {
+            // set default location to the middle of the staff
+            Staff *staff = dynamic_cast<Staff *>(this->GetFirstParent(STAFF));
+            assert(staff);
+            loc = staff->m_drawingLines - 1;
             // Limitation: GetLayerCount does not take into account editorial markup
+            // should be refined later
             bool hasMultipleLayer = (staffY->GetLayerCount() > 1);
-            bool isFirstLayer = false;
             if (hasMultipleLayer) {
                 Layer *firstLayer = dynamic_cast<Layer *>(staffY->FindChildByType(LAYER));
                 assert(firstLayer);
-                if (firstLayer->GetN() == layerY->GetN()) isFirstLayer = true;
+                if (firstLayer->GetN() == layerY->GetN())
+                    loc += 2;
+                else
+                    loc -= 2;
             }
-            loc = rest->GetRestDefaultLoc(hasMultipleLayer, isFirstLayer);
         }
         loc = rest->GetRestLocOffset(loc);
         rest->SetDrawingLoc(loc);

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -13,8 +13,9 @@ namespace vrv {
 // MultiRest
 //----------------------------------------------------------------------------
 
-MultiRest::MultiRest() : LayerElement("multirest-"), AttNumbered()
+MultiRest::MultiRest() : LayerElement("multirest-"), AttMultiRestVis(), AttNumbered()
 {
+    RegisterAttClass(ATT_MULTIRESTVIS);
     RegisterAttClass(ATT_NUMBERED);
     Reset();
 }
@@ -26,6 +27,7 @@ MultiRest::~MultiRest()
 void MultiRest::Reset()
 {
     LayerElement::Reset();
+    ResetMultiRestVis();
     ResetNumbered();
 }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -96,21 +96,6 @@ wchar_t Rest::GetRestGlyph() const
     return symc;
 }
 
-int Rest::GetRestDefaultLoc(bool hasMultipleLayer, bool isFirstLayer)
-{
-    // only works if staff has 5 lines
-    int loc = 4;
-
-    if (hasMultipleLayer) {
-        if (isFirstLayer)
-            loc += 2;
-        else
-            loc -= 2;
-    }
-
-    return loc;
-}
-
 int Rest::GetRestLocOffset(int loc)
 {
     switch (this->GetActualDur()) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -883,7 +883,8 @@ void View::DrawMeterSig(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    int y = staff->GetDrawingY() - (m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 4);
+    int y = staff->GetDrawingY()
+        - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * (staff->m_drawingLines - 1);
     int x = element->GetDrawingX();
 
     if (meterSig->GetForm() == meterSigVis_FORM_invis) {
@@ -1015,7 +1016,8 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         x2 = xCentered + length / 2;
 
         // Position centered in staff
-        y1 = staff->GetDrawingY() - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * staff->m_drawingLines;
+        y1 = staff->GetDrawingY()
+            - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * staff->m_drawingLines;
         y2 = y1 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
         // Draw the base rect
@@ -1026,8 +1028,10 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         // Draw two lines at beginning and end
         // make it 8 pixels longer, and 4 pixels width
         int border = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        DrawFilledRectangle(dc, x1, y1 - border, x1 + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y2 + border);
-        DrawFilledRectangle(dc, x2 - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y1 - border, x2, y2 + border);
+        DrawFilledRectangle(
+            dc, x1, y1 - border, x1 + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y2 + border);
+        DrawFilledRectangle(
+            dc, x2 - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y1 - border, x2, y2 + border);
     }
     else {
         // Draw the base rect
@@ -1037,9 +1041,10 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         // Position centered in third line
         y1 = staff->GetDrawingY() - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * 4;
         y2 = y1 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-        if (num == 2) DrawFilledRectangle(dc, x1, y2 - 4, x2, y1 + 4);
-        else DrawRestWhole(dc, xCentered, y2, DUR_1, false, staff);
-
+        if (num == 2)
+            DrawFilledRectangle(dc, x1, y2 - 4, x2, y1 + 4);
+        else
+            DrawRestWhole(dc, xCentered, y2, DUR_1, false, staff);
     }
 
     // Draw the text above

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -884,7 +884,7 @@ void View::DrawMeterSig(DeviceContext *dc, LayerElement *element, Layer *layer, 
     dc->StartGraphic(element, "", element->GetUuid());
 
     int y = staff->GetDrawingY()
-        - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * (staff->m_drawingLines - 1);
+        - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
     int x = element->GetDrawingX();
 
     if (meterSig->GetForm() == meterSigVis_FORM_invis) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -883,8 +883,7 @@ void View::DrawMeterSig(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    int y = staff->GetDrawingY()
-        - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
+    int y = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
     int x = element->GetDrawingX();
 
     if (meterSig->GetForm() == meterSigVis_FORM_invis) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1006,7 +1006,7 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
     // We do not support more than three chars
     int num = std::min(multiRest->GetNum(), 999);
 
-    if (num > 2) {
+    if (num > 2 || multiRest->GetBlock() == true) {
         // This is 1/2 the length of the black rectangle
         length = width - 2 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
@@ -1014,8 +1014,8 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         x1 = xCentered - length / 2;
         x2 = xCentered + length / 2;
 
-        // Position centered in third line
-        y1 = staff->GetDrawingY() - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * 5;
+        // Position centered in staff
+        y1 = staff->GetDrawingY() - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * staff->m_drawingLines;
         y2 = y1 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
         // Draw the base rect
@@ -1026,8 +1026,8 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         // Draw two lines at beginning and end
         // make it 8 pixels longer, and 4 pixels width
         int border = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        DrawVerticalLine(dc, y1 - border, y2 + border, x1, m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2);
-        DrawVerticalLine(dc, y1 - border, y2 + border, x2, m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2);
+        DrawFilledRectangle(dc, x1, y1 - border, x1 + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y2 + border);
+        DrawFilledRectangle(dc, x2 - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y1 - border, x2, y2 + border);
     }
     else {
         // Draw the base rect
@@ -1037,7 +1037,9 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         // Position centered in third line
         y1 = staff->GetDrawingY() - (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2) * 4;
         y2 = y1 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-        DrawFilledRectangle(dc, x1, y2 - 4, x2, y1 + 4);
+        if (num == 2) DrawFilledRectangle(dc, x1, y2 - 4, x2, y1 + 4);
+        else DrawRestWhole(dc, xCentered, y2, DUR_1, false, staff);
+
     }
 
     // Draw the text above


### PR DESCRIPTION
* makes sure rests and multiRest get centered in staff
* adding initial support for `@block` on `<multiRest>`

![multirests](https://cloud.githubusercontent.com/assets/7693447/26559648/38e3b1ee-44b1-11e7-9663-d2c89bbe0def.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title />
      </titleStmt>
      <pubStmt>
      </pubStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef>
            <staffGrp>
              <staffDef clef.shape="C" clef.line="1" meter.count="4" meter.unit="4" n="1" lines="5" />
            </staffGrp>
          </scoreDef>
          <section>
            <measure n="1">
              <staff n="1">
                <layer n="1">
                  <multiRest num="2" />
                </layer>
              </staff>
            </measure>
            <measure n="2">
              <staff n="1">
                <layer n="1">
                  <multiRest num="1" block="false"/>
                </layer>
              </staff>
            </measure>
            <measure n="3">
              <staff n="1">
                <layer n="1">
                  <multiRest num="2" block="false"/>
                </layer>
              </staff>
            </measure>
            <measure n="4">
              <staff n="1">
                <layer n="1">
                  <multiRest num="1" block="true"/>
                </layer>
              </staff>
            </measure>
            <measure n="5">
              <staff n="1">
                <layer n="1">
                  <multiRest num="2" block="true"/>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```