### PR TITLE
Allow <ending> as sub-element of <score>.

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4058,6 +4058,9 @@ bool MeiInput::ReadScoreBasedMei(pugi::xml_node element, Score *parent)
             else if (elementName == "section") {
                 success = ReadMeiSection(parent, current);
             }
+            else if (elementName == "ending") {
+                success = ReadMeiEnding(parent, current);
+            }
             else {
                 LogWarning("Element <%s> within <score> is not supported and will be ignored ", elementName.c_str());
             }

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "editorial.h"
+#include "ending.h"
 #include "scoredef.h"
 #include "section.h"
 #include "vrv.h"
@@ -45,6 +46,9 @@ void Score::AddChild(Object *child)
     }
     else if (child->Is(SECTION)) {
         assert(dynamic_cast<Section *>(child));
+    }
+    else if (child->Is(ENDING)) {
+        assert(dynamic_cast<Ending *>(child));
     }
     else if (child->IsEditorialElement()) {
         assert(dynamic_cast<EditorialElement *>(child));


### PR DESCRIPTION
Converting the MusicXML example [45b-RepeatWithAlternatives](https://github.com/music-encoding/encoding-tools/blob/master/musicxml2mei/Lilypond-MusicXML-TestSuite-0.1/partwise/45b-RepeatWithAlternatives.xml) to MEI with the [musicxml2mei-3.0.xsl](https://github.com/music-encoding/encoding-tools/blob/master/musicxml2mei/musicxml2mei-3.0.xsl) stylesheet results in the following schema valid file: [45b-RepeatWithAlternatives.mei.txt](https://github.com/rism-ch/verovio/files/1322135/45b-RepeatWithAlternatives.mei.txt)

Verovio renders this as follows:
![ending-old](https://user-images.githubusercontent.com/26634658/30708715-213e54c8-9f00-11e7-8beb-a6c1791b68c7.png)
and outputs two warnings:

    [Warning] Element <ending> within <score> is not supported and will be ignored
    [Warning] Element <ending> within <score> is not supported and will be ignored

This pull request fixes this, which results in the following rendering:
![ending-new](https://user-images.githubusercontent.com/26634658/30708819-68c5cd8a-9f00-11e7-8dbe-2c2be26e6050.png)
