### PR TITLE
Bugfix 649 - Tuplet Chord Interaction

### DIFF
--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -127,8 +127,15 @@ data_STEMDIRECTION View::GetTupletCoordinates(Tuplet *tuplet, Layer *layer, Poin
 
     // Return the start and end position for the brackets
     // starting from the first edge and last of the BBoxes
-    start->x = firstElement->GetSelfX1() + firstElement->GetDrawingX();
-    end->x = lastElement->GetSelfX2() + lastElement->GetDrawingX();
+    if (firstElement->HasSelfBB())
+        start->x = firstElement->GetSelfLeft();
+    else
+        start->x = firstElement->GetContentLeft();
+
+    if (lastElement->HasSelfBB())
+        end->x = lastElement->GetSelfRight();
+    else
+        end->x = lastElement->GetContentRight();
 
     // The first step is to calculate all the stem directions
     // cycle into the elements and count the up and down dirs


### PR DESCRIPTION
Chord elements don't have a SelfBB since they are not actually rendered, so `GetSelfX1()` and `GetSelfX2()` were returning `VRV_UNSET`. Instead, we check if it's a chord by calling `HasSelfBB` or reverting to ContentBB if it is a chord.

Proposed fix for #649 

Before:
![image](https://user-images.githubusercontent.com/2824685/35190733-11ae59a8-fe2e-11e7-98e8-3110bf917966.png)

After:
![image](https://user-images.githubusercontent.com/2824685/35190701-13179666-fe2d-11e7-86f7-037a15cfee3c.png)