### PR TITLE
Note chord visibility ledgers

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -125,6 +125,9 @@ public:
     virtual Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize);
     ///@}
 
+    // Calculates if the chord and all of its children are visible
+    bool IsVisible();
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -156,6 +156,8 @@ public:
      */
     wchar_t GetMensuralSmuflNoteHead();
 
+    bool IsVisible();
+
     /**
      * MIDI timing information
      */

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -320,6 +320,39 @@ Point Chord::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     return topNote->GetStemDownNW(doc, staffSize, isCueSize);
 }
 
+bool Chord::IsVisible()
+{
+    if (this->HasVisible())
+    {
+        return this->GetVisible() == BOOLEAN_true;
+    }
+    // if the chord doens't have it, see if all the children are invisible
+    else
+    {
+        ListOfObjects::const_iterator iter;
+        const ListOfObjects *notes = this->GetList(this);
+        assert(notes);
+
+        for (iter = notes->begin(); iter != notes->end(); iter++) {
+            Note *note = dynamic_cast<Note *>(*iter);
+            assert(note);
+
+            // If it doesn't have a visibility tag, then it's default value is that it's visible, so return that the chord is visible
+            if (!note->HasVisible()) 
+            {
+                return true;
+            }
+            else if(note->GetVisible() == BOOLEAN_true)
+            {
+                return true;
+            }
+            // if it's visibility is false, continue on and see if any of hte others are false
+            else {}
+        }
+        return false;
+    }
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------
@@ -368,6 +401,11 @@ int Chord::CalcStem(FunctorParams *functorParams)
     // Stems have been calculated previously in Beam or FTrem - siblings becasue flags do not need to
     // be processed either
     if (this->IsInBeam() || this->IsInFTrem()) {
+        return FUNCTOR_SIBLINGS;
+    }
+
+    // if the chord isn't visible, carry on
+    if (!this->IsVisible()) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -434,6 +472,10 @@ int Chord::CalcDots(FunctorParams *functorParams)
     CalcDotsParams *params = dynamic_cast<CalcDotsParams *>(functorParams);
     assert(params);
 
+    // if the chord isn't visible, carry on
+    if (!this->IsVisible()) {
+        return FUNCTOR_SIBLINGS;
+    }
     if (!this->HasDots()) {
         return FUNCTOR_SIBLINGS;
     }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -338,16 +338,15 @@ bool Chord::IsVisible()
             assert(note);
 
             // If it doesn't have a visibility tag, then it's default value is that it's visible, so return that the chord is visible
-            if (!note->HasVisible()) 
+            if (!note->HasVisible() || note->GetVisible() == BOOLEAN_true)
             {
                 return true;
             }
-            else if(note->GetVisible() == BOOLEAN_true)
+            else
             {
-                return true;
+                // if it's visibility is false, continue on and see if any of the other notes are false.
+                // All of the notes must not be visible in order for the chord to not be visible.
             }
-            // if it's visibility is false, continue on and see if any of hte others are false
-            else {}
         }
         return false;
     }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -446,6 +446,10 @@ int Note::CalcStem(FunctorParams *functorParams)
 {
     CalcStemParams *params = dynamic_cast<CalcStemParams *>(functorParams);
     assert(params);
+    
+    if (this->HasVisible() && this->GetVisible() == BOOLEAN_false) {
+        return FUNCTOR_SIBLINGS;
+    }
 
     // Stems have been calculated previously in Beam or FTrem - siblings becasue flags do not need to
     // be processed either
@@ -582,6 +586,9 @@ int Note::CalcDots(FunctorParams *functorParams)
     if (this->IsMensural()) {
         return FUNCTOR_SIBLINGS;
     }
+    if (this->HasVisible() && this->GetVisible() == BOOLEAN_false) {
+        return FUNCTOR_SIBLINGS;
+    }
 
     Staff *staff = dynamic_cast<Staff *>(this->GetFirstParent(STAFF));
     assert(staff);
@@ -653,6 +660,10 @@ int Note::CalcLedgerLines(FunctorParams *functorParams)
 
     Staff *staff = dynamic_cast<Staff *>(this->GetFirstParent(STAFF));
     assert(staff);
+
+    if (this->HasVisible() && this->GetVisible() == BOOLEAN_false) {
+        return FUNCTOR_SIBLINGS;
+    }
 
     if (this->m_crossStaff) staff = this->m_crossStaff;
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -327,6 +327,22 @@ wchar_t Note::GetMensuralSmuflNoteHead()
     return code;
 }
 
+bool Note::IsVisible()
+{
+    if (this->HasVisible())
+    {
+        return this->GetVisible() == BOOLEAN_true;
+    }
+    // if the chord doens't have it, see if all the children are invisible
+    else if (GetParent()->Is(CHORD))
+    {
+        Chord *chord = dynamic_cast<Chord *>(GetParent());
+        assert(chord);
+        return chord->IsVisible();
+    }
+    return true;
+}
+
 void Note::SetScoreTimeOnset(double scoreTime)
 {
     m_scoreTimeOnset = scoreTime;
@@ -447,7 +463,7 @@ int Note::CalcStem(FunctorParams *functorParams)
     CalcStemParams *params = dynamic_cast<CalcStemParams *>(functorParams);
     assert(params);
     
-    if (this->HasVisible() && this->GetVisible() == BOOLEAN_false) {
+    if (!this->IsVisible()) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -586,7 +602,7 @@ int Note::CalcDots(FunctorParams *functorParams)
     if (this->IsMensural()) {
         return FUNCTOR_SIBLINGS;
     }
-    if (this->HasVisible() && this->GetVisible() == BOOLEAN_false) {
+    if (!this->IsVisible()) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -661,7 +677,7 @@ int Note::CalcLedgerLines(FunctorParams *functorParams)
     Staff *staff = dynamic_cast<Staff *>(this->GetFirstParent(STAFF));
     assert(staff);
 
-    if (this->HasVisible() && this->GetVisible() == BOOLEAN_false) {
+    if (!this->IsVisible()) {
         return FUNCTOR_SIBLINGS;
     }
 


### PR DESCRIPTION
In MEI, `<chord>` and `<note>` elements can both possess the `visible` attribute. In verovio, a check is not done to see if the note or chord is actually visible before calculating dots, ledger lines and chord stems, leading to exports like this:

![image](https://user-images.githubusercontent.com/2824685/35198913-9a386b00-febb-11e7-97ed-945552cf6a91.png)


After fix:

![image](https://user-images.githubusercontent.com/2824685/35198902-6f16bda0-febb-11e7-9c97-8ddd1529e8fd.png)

MEI test data:

```
<measure xml:id="m-19" label="1" n="1">
	<staff xml:id="m-21" n="1">
		<layer xml:id="m-22" n="1">
			<chord xml:id="m-23" dur="4" dur.ges="256p" stem.dir="down" visible="false">
				<note xml:id="m-24" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
				<note xml:id="m-25" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
			</chord>
			<chord xml:id="m-26" dur="4" dur.ges="256p" stem.dir="down">
				<note xml:id="m-27" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
				<note xml:id="m-28" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
			</chord>
			<chord xml:id="m-29" dur="4" dur.ges="256p" stem.dir="down">
				<note xml:id="m-30" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
				<note xml:id="m-31" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
			</chord>
			<chord xml:id="m-32" dur="4" dur.ges="256p" stem.dir="down">
				<note xml:id="m-33" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
				<note xml:id="m-34" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
			</chord>
		</layer>
	</staff>
</measure>
<measure xml:id="m-35" n="2">
	<staff xml:id="m-36" n="1">
		<layer xml:id="m-37" n="1">
			<chord xml:id="m-38" dur="4" dur.ges="256p" stem.dir="down" visible="false">
				<note xml:id="m-39" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
				<note xml:id="m-40" dur="4" dur.ges="256p" oct="6" pname="f" pnum="89"/>
			</chord>
			<chord xml:id="m-41" dur="4" dur.ges="256p" stem.dir="down">
				<note xml:id="m-42" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
				<note xml:id="m-43" dur="4" dur.ges="256p" oct="6" pname="f" pnum="89"/>
			</chord>
			<chord xml:id="m-44" dur="4" dur.ges="256p" stem.dir="down">
				<note xml:id="m-45" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
				<note xml:id="m-46" dur="4" dur.ges="256p" oct="6" pname="f" pnum="89"/>
			</chord>
			<chord xml:id="m-47" dur="4" dur.ges="256p" stem.dir="down">
				<note xml:id="m-48" dur="4" dur.ges="256p" oct="5" pname="f" pnum="77"/>
				<note xml:id="m-49" dur="4" dur.ges="256p" oct="6" pname="f" pnum="89"/>
			</chord>
		</layer>
	</staff>
</measure>
<measure xml:id="m-50" n="3" right="end">
	<staff xml:id="m-51" n="1">
		<layer xml:id="m-52" n="1">
			<chord xml:id="m-53" dur="4" dur.ges="256p" stem.dir="up" visible="false">
				<note xml:id="m-54" dur="4" dur.ges="256p" oct="3" pname="f" pnum="53"/>
				<note xml:id="m-55" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
			</chord>
			<chord xml:id="m-56" dur="4" dur.ges="256p" stem.dir="up">
				<note xml:id="m-57" dur="4" dur.ges="256p" oct="3" pname="f" pnum="53"/>
				<note xml:id="m-58" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
			</chord>
			<chord xml:id="m-59" dur="4" dur.ges="256p" stem.dir="up">
				<note xml:id="m-60" dur="4" dur.ges="256p" oct="3" pname="f" pnum="53"/>
				<note xml:id="m-61" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
			</chord>
			<chord xml:id="m-62" dur="4" dur.ges="256p" stem.dir="up">
				<note xml:id="m-63" dur="4" dur.ges="256p" oct="3" pname="f" pnum="53"/>
				<note xml:id="m-64" dur="4" dur.ges="256p" oct="4" pname="f" pnum="65"/>
			</chord>
		</layer>
	</staff>
</measure>
```