### PR TITLE
Ending as parent of ScoreDef

### DIFF
--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -50,6 +50,9 @@ void Ending::AddChild(Object *child)
     if (child->Is(MEASURE)) {
         assert(dynamic_cast<Measure *>(child));
     }
+    else if (child->Is(SCOREDEF)) {
+        assert(dynamic_cast<ScoreDef *>(child));
+    }
     else if (child->IsSystemElement()) {
         assert(dynamic_cast<SystemElement *>(child));
         // here we are actually allowing ending withing ending, which is wrong

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2508,7 +2508,7 @@ bool MeiInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
 
 bool MeiInput::ReadScoreDef(Object *parent, pugi::xml_node scoreDef)
 {
-    assert(dynamic_cast<Score *>(parent) || dynamic_cast<Section *>(parent) || dynamic_cast<System *>(parent)
+    assert(dynamic_cast<Score *>(parent) || dynamic_cast<Section *>(parent) || dynamic_cast<System *>(parent) || dynamic_cast<Ending *>(parent)
         || dynamic_cast<EditorialElement *>(parent));
 
     ScoreDef *vrvScoreDef;


### PR DESCRIPTION
An implementation of issue #753 

This turned out to be much simpler than expected. Here is my test output:

![image](https://user-images.githubusercontent.com/2824685/36057439-c574ad16-0dd3-11e8-8da7-1028d64e4e75.png)

Which matches perfectly the input (ignore the overlapping endings, verovio displays it correctly, there is only one per measure):

![image](https://user-images.githubusercontent.com/2824685/36057442-cf3e5482-0dd3-11e8-869c-2178d093194a.png)

Let me know if I missed any other important test cases.

Test data:

```
<mei xml:id="m-1" meiversion="3.0.0" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink">
  <music xml:id="m-9">
    <body xml:id="m-10">
      <mdiv xml:id="m-11">
        <score xml:id="m-12">
          <scoreDef xml:id="m-13">
            <staffGrp xml:id="m-14">
              <staffDef xml:id="m-15" clef.line="4" clef.shape="F" key.mode="minor" key.sig="0" lines="5" n="1">
                <!-- keyboard.piano.grand.bright -->
                <instrDef xml:id="m-17" midi.channel="1" midi.instrname="Unnamed (bass staff)" midi.pan="63" midi.volume="100"/>
              </staffDef>
            </staffGrp>
          </scoreDef>
          <section xml:id="m-18">
            <sb xml:id="m-20"/>
            <measure xml:id="m-19" label="1" n="1" right="dbl">
              <staff xml:id="m-21" n="1">
                <layer xml:id="m-22" n="1">
                  <note xml:id="m-23" dur="4" dur.ges="256p" oct="3" pname="c" pnum="48" stem.dir="up"/>
                  <note xml:id="m-24" dur="4" dur.ges="256p" oct="3" pname="d" pnum="50" stem.dir="down"/>
                  <note xml:id="m-25" dur="2" dur.ges="512p" oct="3" pname="e" pnum="52" stem.dir="down"/>
                </layer>
              </staff>
            </measure>
            <ending xml:id="m-32" label="1." n="1" type="closed">
              <scoreDef xml:id="m-33" key.sig="1s"/>
              <measure xml:id="m-26" n="2" right="dbl">
                <staff xml:id="m-27" n="1">
                  <layer xml:id="m-28" n="1">
                    <note xml:id="m-29" dur="4" dur.ges="256p" oct="2" pname="g" pnum="43" stem.dir="up"/>
                    <note xml:id="m-30" dur="4" dur.ges="256p" oct="2" pname="a" pnum="45" stem.dir="up"/>
                    <note xml:id="m-31" dur="2" dur.ges="512p" oct="2" pname="b" pnum="47" stem.dir="up"/>
                  </layer>
                </staff>
              </measure>
            </ending>
            <ending xml:id="m-40" label="2." n="2" type="open">
              <scoreDef xml:id="m-41" key.sig="0"/>
              <measure xml:id="m-34" n="3">
                <staff xml:id="m-35" n="1">
                  <layer xml:id="m-36" n="1">
                    <note xml:id="m-37" dur="4" dur.ges="256p" oct="3" pname="c" pnum="48" stem.dir="up"/>
                    <note xml:id="m-38" dur="4" dur.ges="256p" oct="3" pname="d" pnum="50" stem.dir="down"/>
                    <note xml:id="m-39" dur="2" dur.ges="512p" oct="3" pname="e" pnum="52" stem.dir="down"/>
                  </layer>
                </staff>
              </measure>
            </ending>
            <ending xml:id="m-49" label="3." n="3" type="closed">
              <scoreDef xml:id="m-50" meter.count="3" meter.unit="4"/>
              <measure xml:id="m-42" n="4">
                <staff xml:id="m-43" n="1">
                  <layer xml:id="m-44" n="1">
                    <note xml:id="m-45" dur="4" dur.ges="256p" oct="3" pname="g" pnum="55" stem.dir="down"/>
                    <note xml:id="m-46" dur="4" dur.ges="256p" oct="3" pname="a" pnum="57" stem.dir="down"/>
                    <note xml:id="m-47" dur="4" dur.ges="256p" oct="3" pname="b" pnum="59" stem.dir="down"/>
                    <clef xml:id="m-48" line="2" shape="G" staff="1" tstamp="4"/>
                  </layer>
                </staff>
              </measure>
            </ending>
            <ending xml:id="m-59" type="closed" n="4" label="4.">
              <scoreDef xml:id="m-60" meter.count="4" meter.unit="4">             
                <staffDef xml:id="m-68" clef.line="2" clef.shape="G" n="1"/>
              </scoreDef>
              <measure xml:id="m-51" n="5">
                <staff xml:id="m-52" n="1">
                  <layer xml:id="m-53" n="1">
                    <chord xml:id="m-54" dur="1" dur.ges="1024p" stem.dir="up">
                      <note xml:id="m-55" dur="1" dur.ges="1024p" oct="4" pname="c" pnum="60"/>
                      <note xml:id="m-56" dur="1" dur.ges="1024p" oct="4" pname="e" pnum="64"/>
                      <note xml:id="m-57" dur="1" dur.ges="1024p" oct="4" pname="g" pnum="67"/>
                    </chord>
                    <clef xml:id="m-58" line="4" shape="F" staff="1" tstamp="5"/>
                  </layer>
                </staff>
              </measure>
            </ending>
            <measure xml:id="m-61" n="6" right="end">
              <scoreDef xml:id="m-69">              
                <staffDef xml:id="m-70" clef.line="4" clef.shape="F" n="1"/>
              </scoreDef>
              <staff xml:id="m-62" n="1">
                <layer xml:id="m-63" n="1">
                  <chord xml:id="m-64" dur="1" dur.ges="1024p" stem.dir="down">
                    <note xml:id="m-65" dur="1" dur.ges="1024p" oct="3" pname="c" pnum="48"/>
                    <note xml:id="m-66" dur="1" dur.ges="1024p" oct="3" pname="e" pnum="52"/>
                    <note xml:id="m-67" dur="1" dur.ges="1024p" oct="3" pname="g" pnum="55"/>
                  </chord>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```