### PR TITLE
Adding basic r/w for dots within notes and rests

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -31,7 +31,9 @@ Dot::Dot() : LayerElement("dot-"), PositionInterface(), AttColor(), AttDotLog()
     Reset();
 }
 
-Dot::~Dot() {}
+Dot::~Dot()
+{
+}
 
 void Dot::Reset()
 {
@@ -51,7 +53,6 @@ int Dot::PreparePointersByLayer(FunctorParams *functorParams)
 {
     PreparePointersByLayerParams *params = dynamic_cast<PreparePointersByLayerParams *>(functorParams);
     assert(params);
-
     m_drawingNote = params->m_currentNote;
 
     return FUNCTOR_CONTINUE;
@@ -62,8 +63,8 @@ int Dot::ResetDrawing(FunctorParams *functorParams)
     // Call parent one too
     LayerElement::ResetDrawing(functorParams);
     PositionInterface::InterfaceResetDrawing(functorParams, this);
-
     this->m_drawingNote = NULL;
+
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -98,7 +98,9 @@ MeiOutput::MeiOutput(Doc *doc, std::string filename) : FileOutputStream(doc)
     m_scoreBasedMEI = false;
 }
 
-MeiOutput::~MeiOutput() {}
+MeiOutput::~MeiOutput()
+{
+}
 
 bool MeiOutput::ExportFile()
 {
@@ -1776,7 +1778,9 @@ MeiInput::MeiInput(Doc *doc, std::string filename) : FileInputStream(doc)
     m_version = MEI_UNDEFINED;
 }
 
-MeiInput::~MeiInput() {}
+MeiInput::~MeiInput()
+{
+}
 
 bool MeiInput::ImportFile()
 {
@@ -2023,10 +2027,34 @@ bool MeiInput::IsAllowed(std::string element, Object *filterParent)
         else if (element == "artic") {
             return true;
         }
+        else if (element == "dot") {
+            return true;
+        }
         else if (element == "syl") {
             return true;
         }
         else if (element == "verse") {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+    // filter for rest
+    else if (filterParent->Is(REST)) {
+      if (element == "dot") {
+          return true;
+      }
+      else {
+          return false;
+      }
+    }
+    // filter for syl
+    else if (filterParent->Is(SYL)) {
+        if (element == "") {
+            return true;
+        }
+        else if (element == "rend") {
             return true;
         }
         else {
@@ -2063,18 +2091,6 @@ bool MeiInput::IsAllowed(std::string element, Object *filterParent)
     // filter for verse
     else if (filterParent->Is(VERSE)) {
         if (element == "syl") {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-    // filter for syl
-    else if (filterParent->Is(SYL)) {
-        if (element == "") {
-            return true;
-        }
-        else if (element == "rend") {
             return true;
         }
         else {
@@ -3651,7 +3667,7 @@ bool MeiInput::ReadRest(Object *parent, pugi::xml_node rest)
     vrvRest->ReadRestVisMensural(rest);
 
     parent->AddChild(vrvRest);
-    return true;
+    return ReadLayerChildren(vrvRest, rest, vrvRest);
 }
 
 bool MeiInput::ReadProport(Object *parent, pugi::xml_node proport)

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -117,7 +117,7 @@ bool Note::HasToBeAligned() const
 
 void Note::AddChild(Object *child)
 {
-    // additional verification for accid and artic - this will no be raised with editorial markup, though
+    // additional verification for accid and artic - this will not be raised with editorial markup, though
     if (child->Is(ACCID)) {
         IsAttributeComparison isAttributeComparison(ACCID);
         if (this->FindChildByAttComparison(&isAttributeComparison))
@@ -134,6 +134,9 @@ void Note::AddChild(Object *child)
     }
     else if (child->Is(ARTIC)) {
         assert(dynamic_cast<Artic *>(child));
+    }
+    else if (child->Is(DOT)) {
+        assert(dynamic_cast<Dots *>(child));
     }
     else if (child->Is(DOTS)) {
         assert(dynamic_cast<Dots *>(child));

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -136,7 +136,7 @@ void Note::AddChild(Object *child)
         assert(dynamic_cast<Artic *>(child));
     }
     else if (child->Is(DOT)) {
-        assert(dynamic_cast<Dots *>(child));
+        assert(dynamic_cast<Dot *>(child));
     }
     else if (child->Is(DOTS)) {
         assert(dynamic_cast<Dots *>(child));

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -39,7 +39,9 @@ Rest::Rest()
     Reset();
 }
 
-Rest::~Rest() {}
+Rest::~Rest()
+{
+}
 
 void Rest::Reset()
 {
@@ -53,7 +55,10 @@ void Rest::Reset()
 
 void Rest::AddChild(Object *child)
 {
-    if (child->Is(DOTS)) {
+    if (child->Is(DOT)) {
+        assert(dynamic_cast<Dots *>(child));
+    }
+    else if (child->Is(DOTS)) {
         assert(dynamic_cast<Dots *>(child));
     }
     else if (child->IsEditorialElement()) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -56,7 +56,7 @@ void Rest::Reset()
 void Rest::AddChild(Object *child)
 {
     if (child->Is(DOT)) {
-        assert(dynamic_cast<Dots *>(child));
+        assert(dynamic_cast<Dot *>(child));
     }
     else if (child->Is(DOTS)) {
         assert(dynamic_cast<Dots *>(child));


### PR DESCRIPTION
This PR adds simple support for `<dot>` in `<note>` and `<rest>`. 

Single dots on notes (even within chords) are already working, rests need to be addressed. 
 
![dots](https://user-images.githubusercontent.com/7693447/36195002-3c51ce8c-116c-11e8-85da-a14dd47bac0d.png)

```xml
<mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" meiversion="3.0.0">
    <meiHead>
      <fileDesc>
        <titleStmt>
          <title>Dots</title>
        </titleStmt>
        <pubStmt></pubStmt>
      </fileDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef meter.count="3" meter.unit="4">
                        <staffGrp n="1" >
                            <staffDef n="1" lines="5" clef.line="2" clef.shape="G"/>
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure n="1">
                            <staff n="1">
                                <layer n="1">
                                    <rest dur="4"><dot/></rest>
                                    <note pname="g" oct="4" dur="4"><dot/></note>
                                    <note pname="g" oct="4" dur="8"><sic><dot/></sic></note>
                                </layer>
                            </staff>
                        </measure>
                        <measure n="2">
                            <staff n="1">
                                <layer n="1">
                                  <chord dur="4">
                                    <note pname="g" oct="4" dur="4"><sic><dot/></sic></note>
                                    <note pname="d" oct="4" dur="4"></note>
                                  </chord>
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```