### PR TITLE
add more control to midi output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 ### Added
-* Support for `mnum.visible` on `<scoredef>` (@rettinghaus)
+* Support for `<instrDef>` (@rettinghaus)
+* Support for `mnum.visible` on `<scoreDef>` (@rettinghaus)
 * Implementation of `<mNum>` and generation from `measure@n` if necessary (@rettinghaus)
 * Support for mulitple lines or `<harm>` according to `@n` value
 * Adjustment of `<hairpin>` length with surrounding `<dynam>` or `<hairpin>`

--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		409B3DDB1F2D1C550098A265 /* btrem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 409B3DDA1F2D1C550098A265 /* btrem.cpp */; };
 		40ABF1FF1E5DF23B00F32F41 /* expansion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40ABF1FE1E5DF23B00F32F41 /* expansion.cpp */; };
 		40D0D5E21E3BD7FE00E6BF5C /* turn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40D0D5E01E3BD7FE00E6BF5C /* turn.cpp */; };
+		40D45EC1204EEAE1009C1EC9 /* instrdef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40D45EBF204EEAE0009C1EC9 /* instrdef.cpp */; };
+		40D45EC2204EEAFB009C1EC9 /* instrdef.h in Headers */ = {isa = PBXBuildFile; fileRef = 40D45EC0204EEAE0009C1EC9 /* instrdef.h */; };
+		40D45EC3204EEAFE009C1EC9 /* instrdef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40D45EBF204EEAE0009C1EC9 /* instrdef.cpp */; };
+		40D45EC4204EEB03009C1EC9 /* instrdef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40D45EBF204EEAE0009C1EC9 /* instrdef.cpp */; };
 		40F910081E2799740081B7BB /* trill.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40F910071E2799740081B7BB /* trill.cpp */; };
 		4D09D3ED1EA8AD8500A420E6 /* horizontalaligner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D09D3EC1EA8AD8500A420E6 /* horizontalaligner.cpp */; };
 		4D09FAED1D78B8C40099FDFE /* atts_midi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEE29051940BCC100C76319 /* atts_midi.cpp */; };
@@ -603,6 +607,8 @@
 		40CA06581E351161009CFDD7 /* humlib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = humlib.cpp; path = src/hum/humlib.cpp; sourceTree = "<group>"; };
 		40D0D5E01E3BD7FE00E6BF5C /* turn.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = turn.cpp; path = src/turn.cpp; sourceTree = "<group>"; };
 		40D0D5E11E3BD7FE00E6BF5C /* turn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = turn.h; path = include/vrv/turn.h; sourceTree = "<group>"; };
+		40D45EBF204EEAE0009C1EC9 /* instrdef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = instrdef.cpp; path = src/instrdef.cpp; sourceTree = "<group>"; };
+		40D45EC0204EEAE0009C1EC9 /* instrdef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = instrdef.h; path = include/vrv/instrdef.h; sourceTree = "<group>"; };
 		40F910061E2799640081B7BB /* trill.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = trill.h; path = include/vrv/trill.h; sourceTree = "<group>"; };
 		40F910071E2799740081B7BB /* trill.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = trill.cpp; path = src/trill.cpp; sourceTree = "<group>"; };
 		4D09D3EC1EA8AD8500A420E6 /* horizontalaligner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = horizontalaligner.cpp; path = src/horizontalaligner.cpp; sourceTree = "<group>"; };
@@ -1265,6 +1271,8 @@
 		8F086F38188539F00037FD8E /* containers */ = {
 			isa = PBXGroup;
 			children = (
+				40D45EBF204EEAE0009C1EC9 /* instrdef.cpp */,
+				40D45EC0204EEAE0009C1EC9 /* instrdef.h */,
 				4D4C26EC1EF7E75400681770 /* label.cpp */,
 				4D4C26EB1EF7E73000681770 /* label.h */,
 				8F086EC6188539540037FD8E /* layer.cpp */,
@@ -1509,6 +1517,7 @@
 				4DF4407A1D3D085600152B7E /* functorparams.h in Headers */,
 				4D763EC91987D067003FCAB5 /* metersig.h in Headers */,
 				4DB3D8CD1F83D11100B5FC2B /* harm.h in Headers */,
+				40D45EC2204EEAFB009C1EC9 /* instrdef.h in Headers */,
 				4D422101199805E400963292 /* att.h in Headers */,
 				4D422102199805E400963292 /* attdef.h in Headers */,
 				4D16947C1E41DE7200569BF4 /* atts_cmnornaments.h in Headers */,
@@ -1739,6 +1748,7 @@
 				4D16943A1E3A44F300569BF4 /* pugixml.cpp in Sources */,
 				4D16943B1E3A44F300569BF4 /* Binasc.cpp in Sources */,
 				4D16943C1E3A44F300569BF4 /* view_beam.cpp in Sources */,
+				40D45EC3204EEAFE009C1EC9 /* instrdef.cpp in Sources */,
 				4D16943D1E3A44F300569BF4 /* view_element.cpp in Sources */,
 				4D16943E1E3A44F300569BF4 /* view_graph.cpp in Sources */,
 				4D16943F1E3A44F300569BF4 /* view_page.cpp in Sources */,
@@ -1883,6 +1893,7 @@
 				8F086F0A188539540037FD8E /* view_page.cpp in Sources */,
 				8F086F0B188539540037FD8E /* view_tuplet.cpp in Sources */,
 				4D4C26ED1EF7E75400681770 /* label.cpp in Sources */,
+				40D45EC1204EEAE1009C1EC9 /* instrdef.cpp in Sources */,
 				40910FEC1E42734C00DB1FA5 /* mordent.cpp in Sources */,
 				4DB726C01B8B9F480040231B /* rpt.cpp in Sources */,
 				2D2A799A1A69812C000A441B /* chord.cpp in Sources */,
@@ -2055,6 +2066,7 @@
 				4D9A9C1F19A1DE2000028D93 /* syl.cpp in Sources */,
 				4D4335CB1ED00A33003BE1A9 /* atts_gestural.cpp in Sources */,
 				4DB0B0171C44129300DBDCC3 /* timestamp.cpp in Sources */,
+				40D45EC4204EEB03009C1EC9 /* instrdef.cpp in Sources */,
 				4DF28A061A754DF000BA9F7D /* floatingobject.cpp in Sources */,
 				4DB3D8991F7C325D00B5FC2B /* lb.cpp in Sources */,
 				4DA3FCD419B61DB400CBDFE6 /* atts_cmn.cpp in Sources */,

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1035,12 +1035,14 @@ public:
     GenerateMIDIParams(MidiFile *midiFile)
     {
         m_midiFile = midiFile;
+        m_midiChannel = 0;
         m_midiTrack = 1;
         m_totalTime = 0.0;
         m_transSemi = 0;
         m_currentTempo = 120;
     }
     MidiFile *m_midiFile;
+    int m_midiChannel;
     int m_midiTrack;
     double m_totalTime;
     int m_transSemi;

--- a/include/vrv/instrdef.h
+++ b/include/vrv/instrdef.h
@@ -1,0 +1,51 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        instrdef.h
+// Author:      Klaus Rettinghaus
+// Created:     2018
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_INSTRDEF_H__
+#define __VRV_INSTRDEF_H__
+
+#include "atts_shared.h"
+#include "atts_midi.h"
+#include "object.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// InstrDef
+//----------------------------------------------------------------------------
+
+class InstrDef : public Object, public AttChannelized, public AttLabelled, public AttMidiInstrument, public AttNNumberLike {
+
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method resets all attribute classes
+     */
+    ///@{
+    InstrDef();
+    virtual ~InstrDef();
+    virtual Object *Clone() const { return new InstrDef(*this); }
+    virtual void Reset();
+    virtual std::string GetClassName() const { return "InstrDef"; }
+    virtual ClassId GetClassId() const { return INSTRDEF; }
+    ///@}
+
+    //----------//
+    // Functors //
+    //----------//
+
+private:
+    //
+public:
+    //
+private:
+    //
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -59,6 +59,7 @@ class FloatingElement;
 class FTrem;
 class Hairpin;
 class Harm;
+class InstrDef;
 class Label;
 class LabelAbbr;
 class Layer;
@@ -212,6 +213,7 @@ private:
     void WritePgHead2(pugi::xml_node currentNode, PgHead2 *pgHead2);
     void WriteStaffGrp(pugi::xml_node currentNode, StaffGrp *staffGrp);
     void WriteStaffDef(pugi::xml_node currentNode, StaffDef *staffDef);
+    void WriteInstrDef(pugi::xml_node currentNode, InstrDef *instrDef);
     void WriteLabel(pugi::xml_node currentNode, Label *label);
     void WriteLabelAbbr(pugi::xml_node currentNode, LabelAbbr *labelAbbr);
     void WriteMeasure(pugi::xml_node currentNode, Measure *measure);
@@ -441,6 +443,7 @@ private:
     bool ReadStaffGrpChildren(Object *parent, pugi::xml_node parentNode);
     bool ReadStaffDef(Object *parent, pugi::xml_node staffDef);
     bool ReadStaffDefChildren(Object *parent, pugi::xml_node parentNode);
+    bool ReadInstrDef(Object *parent, pugi::xml_node instrDef);
     bool ReadLabel(Object *parent, pugi::xml_node label);
     bool ReadLabelAbbr(Object *parent, pugi::xml_node labelAbbr);
     bool ReadMeasure(Object *parent, pugi::xml_node measure);

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -172,6 +172,7 @@ enum ClassId {
     VERSE,
     LAYER_ELEMENT_max,
     // Ids for ScoreDefElement child classes
+    INSTRDEF,
     SCOREDEF_ELEMENT,
     SCOREDEF,
     STAFFDEF,

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -302,6 +302,7 @@ void Doc::ExportMIDI(MidiFile *midiFile)
 
     // Process notes and chords, rests, spaces layer by layer
     // track 0 (included by default) is reserved for meta messages common to all tracks
+    int midiChannel = 0;
     int midiTrack = 1;
     std::vector<AttComparison *> filters;
     for (staves = prepareProcessingListsParams.m_layerTree.child.begin();
@@ -320,7 +321,9 @@ void Doc::ExportMIDI(MidiFile *midiFile)
                 instrdef = dynamic_cast<InstrDef *>(staffGrp->FindChildByType(INSTRDEF, 1));
             }
             if (instrdef) {
-                midiFile->addPatchChange(midiTrack, 0, 0, instrdef->GetMidiInstrnum());
+                midiChannel = instrdef->GetMidiChannel() - 1;
+                LogWarning("%d", midiChannel);
+                midiFile->addPatchChange(midiTrack, 0, midiChannel, instrdef->GetMidiInstrnum() - 1);
             }
             Label *label = dynamic_cast<Label *>(staffDef->FindChildByType(LABEL, 1));
             if (!label) {

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -320,7 +320,7 @@ void Doc::ExportMIDI(MidiFile *midiFile)
                 instrdef = dynamic_cast<InstrDef *>(staffGrp->FindChildByType(INSTRDEF, 1));
             }
             if (instrdef) {
-                midiFile->addInstrumentName(<#int aTrack#>, <#int aTick#>, <#const string &name#>)
+                midiFile->addPatchChange(midiTrack, 0, 0, instrdef->GetMidiInstrnum());
             }
             Label *label = dynamic_cast<Label *>(staffDef->FindChildByType(LABEL, 1));
             if (!label) {

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -19,6 +19,7 @@
 #include "chord.h"
 #include "functorparams.h"
 #include "glyph.h"
+#include "instrdef.h"
 #include "keysig.h"
 #include "label.h"
 #include "layer.h"
@@ -312,6 +313,15 @@ void Doc::ExportMIDI(MidiFile *midiFile)
             if (staffDef->HasTransSemi()) transSemi = staffDef->GetTransSemi();
             midiTrack = staffDef->GetN();
             midiFile->addTrack();
+            InstrDef *instrdef = dynamic_cast<InstrDef *>(staffDef->FindChildByType(INSTRDEF, 1));
+            if (!instrdef) {
+                StaffGrp *staffGrp = dynamic_cast<StaffGrp *>(staffDef->GetFirstParent(STAFFGRP));
+                assert(staffGrp);
+                instrdef = dynamic_cast<InstrDef *>(staffGrp->FindChildByType(INSTRDEF, 1));
+            }
+            if (instrdef) {
+                midiFile->addInstrumentName(<#int aTrack#>, <#int aTick#>, <#const string &name#>)
+            }
             Label *label = dynamic_cast<Label *>(staffDef->FindChildByType(LABEL, 1));
             if (!label) {
                 StaffGrp *staffGrp = dynamic_cast<StaffGrp *>(staffDef->GetFirstParent(STAFFGRP));

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -321,9 +321,8 @@ void Doc::ExportMIDI(MidiFile *midiFile)
                 instrdef = dynamic_cast<InstrDef *>(staffGrp->FindChildByType(INSTRDEF, 1));
             }
             if (instrdef) {
-                midiChannel = instrdef->GetMidiChannel() - 1;
-                LogWarning("%d", midiChannel);
-                midiFile->addPatchChange(midiTrack, 0, midiChannel, instrdef->GetMidiInstrnum() - 1);
+                if (instrdef->HasMidiChannel()) midiChannel = instrdef->GetMidiChannel() - 1;
+                if (instrdef->HasMidiInstrnum()) midiFile->addPatchChange(midiTrack, 0, midiChannel, instrdef->GetMidiInstrnum() - 1);
             }
             Label *label = dynamic_cast<Label *>(staffDef->FindChildByType(LABEL, 1));
             if (!label) {
@@ -346,6 +345,7 @@ void Doc::ExportMIDI(MidiFile *midiFile)
             filters.push_back(&matchLayer);
 
             GenerateMIDIParams generateMIDIParams(midiFile);
+            generateMIDIParams.m_midiChannel = midiChannel;
             generateMIDIParams.m_midiTrack = midiTrack;
             generateMIDIParams.m_transSemi = transSemi;
             generateMIDIParams.m_currentTempo = tempo;

--- a/src/instrdef.cpp
+++ b/src/instrdef.cpp
@@ -1,0 +1,50 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        instrdef.cpp
+// Author:      Klaus Rettinghaus
+// Created:     2018
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "instrdef.h"
+
+//----------------------------------------------------------------------------
+
+#include <assert.h>
+
+//----------------------------------------------------------------------------
+
+#include "scoredef.h"
+#include "vrv.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// InstrDef
+//----------------------------------------------------------------------------
+
+InstrDef::InstrDef() : Object("instrdef-"), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
+{
+    RegisterAttClass(ATT_CHANNELIZED);
+    RegisterAttClass(ATT_LABELLED);
+    RegisterAttClass(ATT_MIDIINSTRUMENT);
+    RegisterAttClass(ATT_NNUMBERLIKE);
+
+    Reset();
+}
+
+InstrDef::~InstrDef() {}
+
+void InstrDef::Reset()
+{
+    Object::Reset();
+    ResetChannelized();
+    ResetLabelled();
+    ResetMidiInstrument();
+    ResetNNumberLike();
+}
+
+//----------------------------------------------------------------------------
+// Functor methods
+//----------------------------------------------------------------------------
+
+} // namespace vrv

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -27,6 +27,7 @@
 #include "ftrem.h"
 #include "hairpin.h"
 #include "harm.h"
+#include "instrdef.h"
 #include "label.h"
 #include "layer.h"
 #include "mdiv.h"
@@ -471,6 +472,11 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             // part-name should be revised, as soon MEI can suppress labels
             std::string partName = GetContentOfChild(xpathNode.node(), "part-name[not(@print-object='no')]");
             std::string partAbbr = GetContentOfChild(xpathNode.node(), "part-abbreviation[not(@print-object='no')]");
+            pugi::xpath_node midiInstrument = xpathNode.node().select_single_node("midi-instrument");
+            pugi::xpath_node midiChannel = midiInstrument.node().select_single_node("midi-channel");
+            pugi::xpath_node midiProgram = midiInstrument.node().select_single_node("midi-program");
+            pugi::xpath_node midiVolume = midiInstrument.node().select_single_node("volume");
+            pugi::xpath_node midiPan = midiInstrument.node().select_single_node("pan");
             // create the staffDef(s)
             StaffGrp *partStaffGrp = new StaffGrp();
             int nbStaves = ReadMusicXmlPartAttributesAsStaffDef(partFirstMeasure.node(), partStaffGrp, staffOffset);
@@ -489,6 +495,14 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                     text->SetText(UTF8to16(partAbbr));
                     labelAbbr->AddChild(text);
                     partStaffGrp->AddChild(labelAbbr);
+                }
+                if (midiInstrument) {
+                    InstrDef *instrdef = new InstrDef;
+                    if (midiChannel) instrdef->SetMidiChannel(midiChannel.node().text().as_int());
+                    if (midiProgram) instrdef->SetMidiInstrnum(midiProgram.node().text().as_int());
+                    if (midiVolume) instrdef->SetMidiVolume(midiVolume.node().text().as_int());
+                    if (midiPan) instrdef->SetMidiPan(midiPan.node().text().as_int());
+                    partStaffGrp->AddChild(instrdef);
                 }
                 partStaffGrp->SetSymbol(staffGroupingSym_SYMBOL_brace);
                 partStaffGrp->SetBarthru(BOOLEAN_true);
@@ -510,6 +524,14 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                         text->SetText(UTF8to16(partAbbr));
                         labelAbbr->AddChild(text);
                         staffDef->AddChild(labelAbbr);
+                    }
+                    if (midiInstrument) {
+                        InstrDef *instrdef = new InstrDef;
+                        if (midiChannel) instrdef->SetMidiChannel(midiChannel.node().text().as_int());
+                        if (midiProgram) instrdef->SetMidiInstrnum(midiProgram.node().text().as_int());
+                        if (midiVolume) instrdef->SetMidiVolume(midiVolume.node().text().as_int());
+                        if (midiPan) instrdef->SetMidiPan(midiPan.node().text().as_int());
+                        staffDef->AddChild(instrdef);
                     }
                 }
                 m_staffGrpStack.back()->MoveChildrenFrom(partStaffGrp);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -474,9 +474,10 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             std::string partAbbr = GetContentOfChild(xpathNode.node(), "part-abbreviation[not(@print-object='no')]");
             pugi::xpath_node midiInstrument = xpathNode.node().select_single_node("midi-instrument");
             pugi::xpath_node midiChannel = midiInstrument.node().select_single_node("midi-channel");
+            pugi::xpath_node midiName = midiInstrument.node().select_single_node("midi-name");
+            pugi::xpath_node midiPan = midiInstrument.node().select_single_node("pan");
             pugi::xpath_node midiProgram = midiInstrument.node().select_single_node("midi-program");
             pugi::xpath_node midiVolume = midiInstrument.node().select_single_node("volume");
-            pugi::xpath_node midiPan = midiInstrument.node().select_single_node("pan");
             // create the staffDef(s)
             StaffGrp *partStaffGrp = new StaffGrp();
             int nbStaves = ReadMusicXmlPartAttributesAsStaffDef(partFirstMeasure.node(), partStaffGrp, staffOffset);
@@ -498,10 +499,11 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                 }
                 if (midiInstrument) {
                     InstrDef *instrdef = new InstrDef;
+                    instrdef->SetMidiInstrname(instrdef->AttMidiInstrument::StrToMidinames(midiName.node().text().as_string()));
                     if (midiChannel) instrdef->SetMidiChannel(midiChannel.node().text().as_int());
+                    if (midiPan) instrdef->SetMidiPan(midiPan.node().text().as_int());
                     if (midiProgram) instrdef->SetMidiInstrnum(midiProgram.node().text().as_int());
                     if (midiVolume) instrdef->SetMidiVolume(midiVolume.node().text().as_int());
-                    if (midiPan) instrdef->SetMidiPan(midiPan.node().text().as_int());
                     partStaffGrp->AddChild(instrdef);
                 }
                 partStaffGrp->SetSymbol(staffGroupingSym_SYMBOL_brace);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -901,7 +901,7 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
     if (this->HasOctGes()) oct = this->GetOctGes();
 
     int pitch = midiBase + (oct + 1) * 12;
-    int channel = 0;
+    int channel = params->m_midiChannel;
     int velocity = 64;
 
     double starttime = params->m_totalTime + this->GetScoreTimeOnset();

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "functorparams.h"
+#include "instrdef.h"
 #include "label.h"
 #include "vrv.h"
 
@@ -61,7 +62,10 @@ void StaffDef::Reset()
 
 void StaffDef::AddChild(Object *child)
 {
-    if (child->Is(LABEL)) {
+    if (child->Is(INSTRDEF)) {
+        assert(dynamic_cast<InstrDef *>(child));
+    }
+    else if (child->Is(LABEL)) {
         assert(dynamic_cast<Label *>(child));
     }
     else if (child->Is(LABELABBR)) {

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "editorial.h"
+#include "instrdef.h"
 #include "label.h"
 #include "staffdef.h"
 #include "vrv.h"
@@ -56,17 +57,20 @@ void StaffGrp::Reset()
 
 void StaffGrp::AddChild(Object *child)
 {
-    if (child->Is(STAFFDEF)) {
-        assert(dynamic_cast<StaffDef *>(child));
-    }
-    else if (child->Is(STAFFGRP)) {
-        assert(dynamic_cast<StaffGrp *>(child));
+    if (child->Is(INSTRDEF)) {
+        assert(dynamic_cast<InstrDef *>(child));
     }
     else if (child->Is(LABEL)) {
         assert(dynamic_cast<Label *>(child));
     }
     else if (child->Is(LABELABBR)) {
         assert(dynamic_cast<LabelAbbr *>(child));
+    }
+    else if (child->Is(STAFFDEF)) {
+        assert(dynamic_cast<StaffDef *>(child));
+    }
+    else if (child->Is(STAFFGRP)) {
+        assert(dynamic_cast<StaffGrp *>(child));
     }
     else if (child->IsEditorialElement()) {
         assert(dynamic_cast<EditorialElement *>(child));


### PR DESCRIPTION
This PR adds support for `<instrDef>` in `<staffDef>` and `<staffGrp>`. 
When creating a MIDI file it respects the given midi channel and midi instrument number. 