### PR TITLE
Adds support for mensur changes in PAE import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+* Fix for Plaine & Easie mensur changes in mensural notation
 * Barline segmentation with text and dynamic indications overlapping measures
 * Improved layout with text (dir, tempo, etc.) at the end of a system
 * Support for dashed bar lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 * Fix for Plaine & Easie mensur changes in mensural notation
+* Use SMuFL glyphs for mensural signs (@rettinghaus)
 * Barline segmentation with text and dynamic indications overlapping measures
 * Improved layout with text (dir, tempo, etc.) at the end of a system
 * Support for dashed bar lines

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -62,6 +62,7 @@ namespace pae {
             rest = old.rest;
 
             clef = old.clef;
+            mensur = old.mensur;
             meter = old.meter;
             key = old.key;
 
@@ -87,6 +88,7 @@ namespace pae {
             tuplet_note = 0;
 
             clef = NULL;
+            mensur = NULL;
             meter = NULL;
             key = NULL;
         }
@@ -112,6 +114,7 @@ namespace pae {
             rest = d.rest;
 
             clef = d.clef;
+            mensur = d.mensur;
             meter = d.meter;
             key = d.key;
 
@@ -145,6 +148,7 @@ namespace pae {
         bool rest;
 
         Clef *clef;
+        Mensur *mensur;
         MeterSig *meter;
         KeySig *key;
     };

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -348,11 +348,10 @@ void PaeInput::parsePlainAndEasy(std::istream &infile)
             if (m_is_mensural) {
                 Mensur *mensur = new Mensur();
                 i += getTimeInfo(incipit, NULL, mensur, i + 1);
-                if (current_measure.mensur) {
-                    delete current_measure.mensur;
+                if (current_note.mensur) {
+                    delete current_note.mensur;
                 }
-                // When will this be deleted? Potential memory leak? LP
-                current_measure.mensur = mensur;
+                current_note.mensur = mensur;
             }
             else {
                 MeterSig *meter = new MeterSig;
@@ -803,7 +802,7 @@ data_PITCHNAME PaeInput::getPitch(char c_note)
 
 //////////////////////////////
 //
-// getTimeInfo -- read the key signature.
+// getTimeInfo -- read the time signature.
 //
 
 int PaeInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, int index)
@@ -885,7 +884,7 @@ int PaeInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
             if (matches[1] == "c") {
                 mensur->SetSign(MENSURATIONSIGN_C);
             }
-            // 0
+            // O
             else {
                 mensur->SetSign(MENSURATIONSIGN_O);
             }
@@ -916,7 +915,7 @@ int PaeInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
 
 //////////////////////////////
 //
-// getClefInfo -- read the key signature.
+// getClefInfo -- read the clef.
 //
 
 int PaeInput::getClefInfo(const char *incipit, Clef *mclef, int index)
@@ -1341,6 +1340,9 @@ void PaeInput::parseNote(pae::Note *note)
     if (note->meter) {
         addLayerElement(note->meter);
     }
+    if (note->mensur) {
+        addLayerElement(note->mensur);
+    }
 
     // Handle key change. Evil if done in a beam
     if (note->key) {
@@ -1400,6 +1402,8 @@ void PaeInput::parseNote(pae::Note *note)
 
     // Add the note to the current container
     addLayerElement(element);
+
+    // Add mensural dot
     if (m_is_mensural && note->dots > 0) {
         Dot *dot = new Dot();
         addLayerElement(dot);

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -43,7 +43,7 @@ Mensur::Mensur(const ScoreDefInterface *mensurAttr) : LayerElement("mensur-")
 {
     Init();
 
-    // this->SetColor(mensurAttr->GetMensurColor());
+    this->SetColor(mensurAttr->GetMensurColor());
     this->SetDot(mensurAttr->GetMensurDot());
     this->SetOrient(mensurAttr->GetMensurOrient());
     this->SetSign(mensurAttr->GetMensurSign());


### PR DESCRIPTION
addresses #805:

![paemens](https://user-images.githubusercontent.com/7693447/40104197-f901c490-58ef-11e8-8a59-8477e004ce8d.png)

```
@clef:C+3
@timesig:c/
@data:1-9C,1ABB2-2B@3 '2.C4D2E
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title />
      </titleStmt>
      <pubStmt>
        <date>2018-05-16 09:59:59</date>
      </pubStmt>
    </fileDesc>
    <encodingDesc>
      <projectDesc>
        <p>Encoded with Verovio version 2.0.0-dev-5e35785-dirty</p>
      </projectDesc>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv xml:id="mdiv-0000001806829217">
        <score xml:id="score-0000001959881539">
          <scoreDef xml:id="scoredef-0000001333219331" mensur.sign="C" mensur.slash="1">
            <staffGrp xml:id="staffgrp-0000000089203265">
              <staffDef xml:id="staffdef-0000000295689249" clef.shape="C" clef.line="3" n="1" notationtype="mensural" lines="5" />
            </staffGrp>
          </scoreDef>
          <section xml:id="section-0000001624848287">
            <measure xml:id="measure-0000001589551460" right="invis">
              <staff xml:id="staff-0000001423104357" n="1">
                <layer xml:id="layer-0000001439542909" n="1">
                  <rest xml:id="rest-0000000846904461" dur="semibrevis" />
                  <note xml:id="note-0000000401663711" dur="brevis" oct="4" pname="c" />
                  <note xml:id="note-0000000262671507" dur="semibrevis" oct="3" pname="a" />
                  <note xml:id="note-0000000083778080" dur="semibrevis" oct="3" pname="b" />
                  <note xml:id="note-0000000726023919" dur="semibrevis" oct="3" pname="b" />
                  <rest xml:id="rest-0000000954112571" dur="minima" />
                  <note xml:id="note-0000000509588648" dur="minima" oct="3" pname="b" />
                  <mensur xml:id="mensur-0000000098876164" num="3" />
                  <note xml:id="note-0000001333128891" dur="minima" oct="4" pname="c" />
                  <dot xml:id="dot-0000001356978084" />
                  <note xml:id="note-0000000454326648" dur="semiminima" oct="4" pname="d" />
                  <note xml:id="note-0000000799763418" dur="minima" oct="4" pname="e" />
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```