### PR TITLE
Automatic Rest Location Detection within Beams

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -954,6 +954,14 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 if (abs(locAvg - loc) > 3) {
                     loc = locAvg;
                 }
+                // if loc is odd, we need to offset it to be even 
+                // so that the rest dots do not collide with the staff lines
+                if (loc % 2 != 0) {
+                    // if it's above the staff, offset downwards
+                    // if below the staff, offset upwards
+                    if (loc > 4) loc--;
+                    else loc++;
+                }
             }
             else if (hasMultipleLayer) {
                 Layer *firstLayer = dynamic_cast<Layer *>(staffY->FindChildByType(LAYER));

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -842,7 +842,7 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
             }
 
             // add offset
-            else if (staff->m_drawingLines > 1)
+            else if (staff->m_drawingLines > 3)
                 loc += 2;
         }
 
@@ -883,6 +883,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 ListOfObjects::const_iterator it = beamList->begin();
                 std::advance(it, restIndex);
                 ListOfObjects::const_reverse_iterator rit(it);
+                // iterate through the elements from the rest to the beginning of the beam
+                // until we hit a note or chord, which we will use to determine where the rest should be placed
                 for (; rit != beamList->rend(); ++rit) {
                     if ((*rit)->Is(NOTE)) {
                         Note *leftNote = dynamic_cast<Note *>(*rit);
@@ -910,6 +912,7 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                                                                      layerY->GetClefLocOffset(layerElementY));
                         }
 
+                        // if it's a rest, use the middle of the chord as the rest's location
                         leftLoc = (topChordLoc + bottomChordLoc) / 2;
                         break;
                     }
@@ -918,6 +921,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 int rightLoc = loc;
                 it = beamList->begin();
                 std::advance(it, restIndex);
+                // iterate through the elements from the rest to the end of the beam
+                // until we hit a note or chord, which we will use to determine where the rest should be placed
                 for (; it != beamList->end(); ++it) {
                     if ((*it)->Is(NOTE)) {
                         Note *rightNote = dynamic_cast<Note *>(*it);
@@ -945,22 +950,74 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                                                                      layerY->GetClefLocOffset(layerElementY));
                         }
 
+                        // if it's a rest, use the middle of the chord as the rest's location
                         rightLoc = (topChordLoc + bottomChordLoc) / 2;
                         break;
                     }
                 }
 
-                int locAvg = (rightLoc + leftLoc) / 2;
+                // average the left note and right note's locations together to get our rest location
+                const int locAvg = (rightLoc + leftLoc) / 2;
                 if (abs(locAvg - loc) > 3) {
                     loc = locAvg;
                 }
-                // if loc is odd, we need to offset it to be even 
-                // so that the rest dots do not collide with the staff lines
-                if (loc % 2 != 0) {
-                    // if it's above the staff, offset downwards
-                    // if below the staff, offset upwards
-                    if (loc > 4) loc--;
-                    else loc++;
+
+                // note: bottomAlignedLoc and topAlignedLoc are only accouting for discrepencies 
+                // between 8th, 16th and 32nd notes, not 64th's and on
+                // I've described how to implement 64ths and beyond below
+
+                // we need to check for bottom and top alignment because a 32nd rest that's top is in the space 
+                // under the staff (d4 on treble) can not be moved any closer to center by an incriment of 1
+                // because the dots will collide with the staff
+                // whereas a 16th rest that is in the same "loc" as the 32nd is actually below the 32nd
+                // (the top of the 16th will be in note b3 on treble clef) so can be moved closer to the staff
+                // than the 32nd without fear of the dots colliding with the staff lines
+
+                //bottomAlignedLoc is the location where all of the rest's stems align to form a straight line
+                int bottomAlignedLoc = loc;
+                // 8th note rests are aligned with the top of a 16th note rest, so to bottom align we have to push it down 2
+                if (rest->GetActualDur() == DURATION_8)
+                    bottomAlignedLoc -= 2;
+                // for durations smaller than 32nd, bottomAlignedLoc will need to decrease by 2 every iteration greater than from 32
+                // so 32 will be -0, 64 is -2, 128 is -4
+                // (currently not implemented)
+
+                //topAlignedLoc is the location where all of the top of the rests align to form a straight line
+                int topAlignedLoc = loc;
+                if (rest->GetActualDur() == DURATION_32)
+                    topAlignedLoc += 2;
+                // for smaller durations, topAlignedLoc offset will increase by 2 every iteration greater than from 32
+                // so 32 will need to be +2, 64 is +4, 128 is +6, etc.
+                // (currently only implemented for 32nds)
+
+                const int topOfStaffLoc = 10;
+                const int bottomOfStaffLoc = -4;
+
+                // move the extrema towards center a little for aesthetic reasons
+                const bool restAboveStaff = bottomAlignedLoc >= topOfStaffLoc;
+                const bool restBelowStaff = topAlignedLoc <= bottomOfStaffLoc;
+                if (restAboveStaff) {
+                    loc--;
+                    bottomAlignedLoc--;
+                }
+                else if (restBelowStaff) {
+                    loc++;
+                    topAlignedLoc++;
+                }
+
+                // use the newly aligned bottomAlignedLoc and topAlignedLoc values to check if it's within the staff
+                // because it might have changed since we assigned restAboveStaff and restBelowStaff
+                const bool isInStaff = bottomAlignedLoc < topOfStaffLoc && topAlignedLoc > bottomOfStaffLoc;
+                if (isInStaff) {
+                    // if loc is within the staff and odd, 
+                    // we need to offset it to be even
+                    // so that the dots do not collide with the staff lines
+                    if (loc % 2 != 0) {
+                        // if it's above the staff, offset downwards
+                        // if below the staff, offset upwards
+                        if (loc > 4) loc--;
+                        else loc++;
+                    }
                 }
             }
             else if (hasMultipleLayer) {


### PR DESCRIPTION
Related to #873 

When rests are within a beam element and sandwiched between two notes, this commit will automatically determine where to place the rests based on the average of the sandwiching note's locations.

Not sure if this is too much guesswork to be consistent with your project's goals - maybe add along as an option if you'd like?

Before:
![image](https://user-images.githubusercontent.com/2824685/40519725-d113a76c-5f86-11e8-8464-430235fa7d29.png)

After:
![image](https://user-images.githubusercontent.com/2824685/40519850-987df06e-5f87-11e8-92ee-f215c9abf787.png)
