### PR TITLE
Disable js-specific optimizations. Resolves #897

### DIFF
--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -34,7 +34,7 @@ my $VEROVIO_ROOT  = "..";
 # Memory is increased (TOTAL_STACK) for processing large files (tested up to 7MB)
 # Empirically, the memory amount required is roughly 5 times the file size.
 # This can be disabled in the light version, which uses the default memory settings.
-my $FLAGS = "--llvm-opts 3 --js-opts 0";
+my $FLAGS .= "-O2";
 $FLAGS .= " -DNDEBUG";
 $FLAGS .= " --memory-init-file 0";
 $FLAGS .= " -std=c++11";

--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -34,7 +34,7 @@ my $VEROVIO_ROOT  = "..";
 # Memory is increased (TOTAL_STACK) for processing large files (tested up to 7MB)
 # Empirically, the memory amount required is roughly 5 times the file size.
 # This can be disabled in the light version, which uses the default memory settings.
-my $FLAGS = "-O3";
+my $FLAGS = "--llvm-opts 3 --js-opts 0";
 $FLAGS .= " -DNDEBUG";
 $FLAGS .= " --memory-init-file 0";
 $FLAGS .= " -std=c++11";


### PR DESCRIPTION
Javascript optimizations in emscripten cause issue #897. This is one way of resolving it while keeping the LLVM optimizations at level 3.