### PR TITLE
"Notehead" class added to SVG output

### DIFF
--- a/doc/guidelines.md
+++ b/doc/guidelines.md
@@ -26,7 +26,7 @@ The simplest way to fullfil the Verovio coding style is to use a clang-format to
 
 ### Downloading clang-format for OS X
 
-An easy way to install clang-format on OS X computers is to use [Hombrew](http://brew.sh).  Type this command in the terminal to install:
+An easy way to install clang-format on OS X computers is to use [Homebrew](http://brew.sh).  Type this command in the terminal to install:
 
 ```
 brew install clang-format

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -81,7 +81,7 @@ public:
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius);
     virtual void DrawText(
         const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET);
-    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
+    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false, std::string className = "");
     virtual void DrawSpline(int n, Point points[]);
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);
     virtual void DrawBackgroundImage(int x = 0, int y = 0){};

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -154,7 +154,7 @@ public:
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius) = 0;
     virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET)
         = 0;
-    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false) = 0;
+    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false, std::string className = "") = 0;
     virtual void DrawSpline(int n, Point points[]) = 0;
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg) = 0;
     virtual void DrawBackgroundImage(int x = 0, int y = 0) = 0;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -83,7 +83,7 @@ public:
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, double radius);
     virtual void DrawText(
         const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET);
-    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
+    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false, std::string className = "");
     virtual void DrawSpline(int n, Point points[]);
     virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);
     virtual void DrawBackgroundImage(int x = 0, int y = 0);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -470,7 +470,7 @@ protected:
     void DrawVerticalSegmentedLine(DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawSmuflCode(
-        DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
+        DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false, std::string className = "");
     void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0);
     void DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int fillSection);
     void DrawHarmString(DeviceContext *dc, int x, int y, std::wstring s);

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -294,7 +294,7 @@ void BBoxDeviceContext::DrawRotatedText(const std::string &text, int x, int y, d
     // TODO
 }
 
-void BBoxDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph)
+void BBoxDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph, std::string className)
 {
     assert(m_fontStack.top());
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -787,11 +787,14 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
         // Write the char in the SVG
         pugi::xml_node useChild = AppendChild("use");
         useChild.append_attribute("xlink:href") = StringFormat("#%s", glyph->GetCodeStr().c_str()).c_str();
-        useChild.append_attribute("class") = className.c_str();
         useChild.append_attribute("x") = x;
         useChild.append_attribute("y") = y;
         useChild.append_attribute("height") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();
         useChild.append_attribute("width") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();
+        
+        // If a custom class was provided for this element, add it
+        if (className.length() > 0)
+            useChild.append_attribute("class") = className.c_str();
 
         // Get the bounds of the char
         if (glyph->GetHorizAdvX() > 0)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -762,7 +762,7 @@ void SvgDeviceContext::DrawRotatedText(const std::string &text, int x, int y, do
     // TODO
 }
 
-void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph)
+void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph, std::string className)
 {
     assert(m_fontStack.top());
 
@@ -787,6 +787,7 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
         // Write the char in the SVG
         pugi::xml_node useChild = AppendChild("use");
         useChild.append_attribute("xlink:href") = StringFormat("#%s", glyph->GetCodeStr().c_str()).c_str();
+        useChild.append_attribute("class") = className.c_str();
         useChild.append_attribute("x") = x;
         useChild.append_attribute("y") = y;
         useChild.append_attribute("height") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1176,6 +1176,7 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
             fontNo = SMUFL_E0FA_noteheadWholeFilled;
         else
             fontNo = SMUFL_E0A2_noteheadWhole;
+
         DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true, "notehead");
     }
     // Other values

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1176,8 +1176,7 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
             fontNo = SMUFL_E0FA_noteheadWholeFilled;
         else
             fontNo = SMUFL_E0A2_noteheadWhole;
-
-        DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true);
+        DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true, "notehead");
     }
     // Other values
     else {
@@ -1186,7 +1185,7 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         else
             fontNo = SMUFL_E0A4_noteheadBlack;
 
-        DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true);
+        DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true, "notehead");
     }
 
     /************ Draw children (accidentals, etc) ************/

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -175,7 +175,7 @@ void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize)
     dc->ResetBrush();
 }
 
-void View::DrawSmuflCode(DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph)
+void View::DrawSmuflCode(DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph, std::string className)
 {
     assert(dc);
 
@@ -187,7 +187,7 @@ void View::DrawSmuflCode(DeviceContext *dc, int x, int y, wchar_t code, int staf
     dc->SetBrush(m_currentColour, AxSOLID);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
-    dc->DrawMusicText(str, ToDeviceContextX(x), ToDeviceContextY(y), setBBGlyph);
+    dc->DrawMusicText(str, ToDeviceContextX(x), ToDeviceContextY(y), setBBGlyph, className);
 
     dc->ResetFont();
     dc->ResetBrush();


### PR DESCRIPTION
While working on an editing interface, I realized that there are `g[class='note']` and `g[class='stem']` selectors available, but there didn't seem to be a reliable means of identifying what SVG `use` elements could reliably be considered a notehead, since the `xlink:href` attribute could have a variety of values.

This commit resolves that by adding an optional `className` parameter to `View::DrawSmuflCode` and `devicecontext::DrawMusicText` that is used in `View::DrawNote` to append a `notehead` class to all SVG elements that represent noteheads.

I have left `View::DrawMaximaToBrevis` as it is because I know absolutely nothing about those notation styles and don't want to semantically suggest something that is not correct.

- Added optional className parameter for View::DrawSmuflCode
- Added optional className parameter for devicecontext::DrawMusicText
- Added pugixml append_attribute for SVG `class` attribute
- Added "notehead" class for all notehead elements

- Fixed typo in doc/guidelines.md

(if you want another commit re-adding the line break in view-element that I accidentally deleted, let me know)