### PR TITLE
adding "curvedir" attribute for "tie" element (2)

### DIFF
--- a/supported-mei.yml
+++ b/supported-mei.yml
@@ -403,6 +403,7 @@ classes:
   - id: "tie"
     att-classes:
       - color
+      - curvedir
       - staffident
       - startendid
       - startid


### PR DESCRIPTION
As requested, I redid my pull request (#929).

A minor addition: Just came across the `curvedir` attribute for the `tie` element. Verovio seems to handle this correctly, but it is missing in page of Supported MEI elements.