### PR TITLE
Contributing: add guide how to point to latest commit of tutorial submodule

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -21,4 +21,33 @@ Please use the "Pull Request" mechanism for proposing contributions to the code 
  
 For proposing changes to the `verovio:gh-pages` branch of Verovio (e.g., its website), follow the same workflow but make the pull request to the `rism-ch/verovio:gh-pages-develop` branch.
 
-For updating the tutorial fork the submodule [verovio-tutorial](https://github.com/rism-ch/verovio-tutorial), make a PR there and wait for a merge to point to the latest commit from the parent module (i.e. `verovio:gh-pages`) afterwards.
+For updating the tutorial fork the submodule [verovio-tutorial](https://github.com/rism-ch/verovio-tutorial), make a PR there (on its main branch `verovio-tutorial:gh-pages`) and wait for a merge. Afterwards create a pull request in the parent module (i.e. `verovio:gh-pages`) to point to the latest commit of the submodule by doing the following: 
+
+- checkout a dedicated branch from the `verovio:gh-pages` branch for your changes (e.g. `verovio:gh-pages-update`)
+
+- change to the directory of the tutorials submodule
+    ```
+    cd gh-tutorial
+    ```
+
+    - checkout the main branch of the submodule (it is called `gh-pages`, too)
+        ```
+        git checkout gh-pages
+        ```
+    
+    - pull latest changes of remote submodule & check if it really has the latest commit
+        ```
+        git pull
+        git log -1 (should show commit hash of latest commit in submodule repository)
+        ```
+    
+- change back to the project root directory (Verovio main folder)
+    ```
+    cd ..
+    ```
+
+    - check the status to see that the submodule is now in the state you want, then commit with a concise commit message (make sure to push your changes to add them to your pull request)
+        ```
+        git status   # should declare: modified gh-tutorial
+        git commit -am "Pulled down update to tutorial submodule"
+        ```


### PR DESCRIPTION
As it turns out, pointing to the latest commit of the tutorial submodule is also quite cumbersome (and vulnerable to forgetting), so this PR adds a short guide to `Contributing.md` to address once more #954. 

In principal, the proposed changes follow the instructions provided in this SO answer: https://stackoverflow.com/a/5828396