### PR TITLE
fixing java build script for linux

### DIFF
--- a/bindings/java/build.sh
+++ b/bindings/java/build.sh
@@ -37,5 +37,5 @@ FILES="$SRCFILES \
  ../../libmei/atts_visual.cpp"
 
 CXXOPTS="-g -fpic -std=c++11 -I../../include -I../../include/vrv -I../../include/json -I../../include/hum -I../../include/midi -I../../include/pugi -I../../include/utf8 -I../../libmei -I/opt/local/include/ -I/System/Library/Frameworks/JavaVM.framework/Headers/"
-g++ -shared -o target/libverovio.jnilib $CXXOPTS $FILES verovio_wrap.cxx
+g++ -shared -o -I$JAVA_HOME/include -I$JAVA_HOME/include/linux target/libverovio.jnilib $CXXOPTS $FILES verovio_wrap.cxx
 cp target/libverovio.jnilib target/classes/META-INF/lib

--- a/bindings/java/build.sh
+++ b/bindings/java/build.sh
@@ -37,5 +37,6 @@ FILES="$SRCFILES \
  ../../libmei/atts_visual.cpp"
 
 CXXOPTS="-g -fpic -std=c++11 -I../../include -I../../include/vrv -I../../include/json -I../../include/hum -I../../include/midi -I../../include/pugi -I../../include/utf8 -I../../libmei -I/opt/local/include/ -I/System/Library/Frameworks/JavaVM.framework/Headers/"
-g++ -shared -o -I$JAVA_HOME/include -I$JAVA_HOME/include/linux target/libverovio.jnilib $CXXOPTS $FILES verovio_wrap.cxx
+PATHS="-I$JAVA_HOME/include -I$JAVA_HOME/include/linux" # paths to java libraries
+g++ -shared -o target/libverovio.jnilib $CXXOPTS $PATHS $FILES verovio_wrap.cxx
 cp target/libverovio.jnilib target/classes/META-INF/lib

--- a/doc/importer.mei
+++ b/doc/importer.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://music-encoding.org/schema/3.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="3.0.0">
+<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
     <meiHead>
         <fileDesc>
             <titleStmt>
@@ -19,8 +19,8 @@
     </meiHead>
     <music>
         <body>
-            <mdiv>
-                <score>
+            <mdiv xml:id="mdiv-0000001987263494">
+                <score xml:id="score-0000000835703227">
                     <scoreDef xml:id="scoredef-000000190837422" key.sig="2s" meter.sym="common">
                         <staffGrp xml:id="m-000000092666214">
                             <staffDef xml:id="staffdef-000000085929658" clef.shape="G" clef.line="2" n="1" lines="5" />


### PR DESCRIPTION
This PR adds paths to java on linux (tested on Ubuntu 18.10) and should work on all other systems as well without any warning. 
Updated the importer.mei to MEI4.