### PR TITLE
Change to "min" to not incorrectly assign "min" to "maj"

### DIFF
--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -606,7 +606,7 @@ void AbcInput::parseKey(std::string keyString)
                 c = tolower(c);
             }
 
-            if (modeString == "min") {
+            if (modeString == "min" || modeString == "m") {
                 mode = MODE_minor;
                 accidNum -= 3;
             }

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -606,7 +606,7 @@ void AbcInput::parseKey(std::string keyString)
                 c = tolower(c);
             }
 
-            if (modeString[0] == 'm' && modeString[2] != 'x') { // should mean "min"
+            if (modeString == "min") {
                 mode = MODE_minor;
                 accidNum -= 3;
             }


### PR DESCRIPTION
If a key was defined as maj, it was being assigned to min instead,
overwriting the default major mode. 

AFAIK the only m*x mode in the spec is mixolydian, so just checking for min doesn't overwrite the default major mode defined.

Example abc [daniel-chisolms-reel.abc.txt](https://github.com/rism-ch/verovio/files/2974106/daniel-chisolms-reel.abc.txt), also see http://abcnotation.com/wiki/abc:standard:v2.1#kkey

Thanks for such a great tool, hope to be able contribute more.
