### PR TITLE
Add option to use svg viewBox on root node

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -451,7 +451,6 @@ public:
     OptionGrp m_general;
 
     OptionBool m_adjustPageHeight;
-    OptionBool m_useSvgViewBox;
     OptionIntMap m_breaks;
     OptionBool m_evenNoteSpacing;
     OptionBool m_humType;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -468,6 +468,7 @@ public:
     OptionInt m_pageMarginRight;
     OptionInt m_pageMarginTop;
     OptionInt m_pageWidth;
+    OptionBool m_svgViewBox;
     OptionInt m_unit;
     OptionBool m_usePgFooterForAll;
     OptionBool m_usePgHeaderForAll;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -165,6 +165,11 @@ public:
      */
     void SetMMOutput(bool mmOutput) { m_mmOutput = mmOutput; }
 
+    /**
+     * Setting m_viewBox flag (false by default)
+     */
+    void SetSvgViewBox(bool svgViewBox) { m_svgViewBox = svgViewBox; }
+
 private:
     /**
      * Copy the content of a file to the output stream.
@@ -226,6 +231,9 @@ private:
 
     // output as mm (for pdf generation with a 72 dpi)
     bool m_mmOutput;
+
+    // use viewbox on svg root element
+    bool m_svgViewBox;
 };
 
 } // namespace vrv

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -166,7 +166,7 @@ public:
     void SetMMOutput(bool mmOutput) { m_mmOutput = mmOutput; }
 
     /**
-     * Setting m_viewBox flag (false by default)
+     * Setting m_svgViewBox flag (false by default)
      */
     void SetSvgViewBox(bool svgViewBox) { m_svgViewBox = svgViewBox; }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -557,6 +557,10 @@ Options::Options()
     m_pageWidth.Init(2100, 100, 60000, true);
     this->Register(&m_pageWidth, "pageWidth", &m_general);
 
+    m_svgViewBox.SetInfo("Use viewbox on svg root", "Use viewBox on svg root element for easy scaling of document");
+    m_svgViewBox.Init(false);
+    this->Register(&m_svgViewBox, "svgViewBox", &m_general);
+
     m_unit.SetInfo("Unit", "The MEI unit (1⁄2 of the distance between the staff lines)");
     m_unit.Init(9, 6, 20, true);
     this->Register(&m_unit, "unit", &m_general);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -489,10 +489,6 @@ Options::Options()
     m_adjustPageHeight.Init(false);
     this->Register(&m_adjustPageHeight, "adjustPageHeight", &m_general);
 
-    m_useSvgViewBox.SetInfo("Use viewbox on svg root", "Use viewbox on svg root element for easy scaling of document");
-    m_useSvgViewBox.Init(false);
-    this->Register(&m_useSvgViewBox, "useSvgViewBox", &m_general);
-
     m_breaks.SetInfo("Breaks", "Define page and system breaks layout");
     m_breaks.Init(BREAKS_auto, &Option::s_breaks);
     this->Register(&m_breaks, "breaks", &m_general);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -47,6 +47,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext()
     m_vrvTextFont = false;
 
     m_mmOutput = false;
+    m_svgViewBox = false;
 
     // create the initial SVG element
     // width and height need to be set later; these are taken care of in "commit"
@@ -81,15 +82,22 @@ void SvgDeviceContext::Commit(bool xml_declaration)
     }
 
     // take care of width/height once userScale is updated
+    double height = (double)GetHeight() * GetUserScaleY();
+    double width = (double)GetWidth() * GetUserScaleX();
+    const char *format = "%gpx";
+
     if (m_mmOutput) {
-        m_svgNode.prepend_attribute("height")
-            = StringFormat("%gmm", ((double)GetHeight() * GetUserScaleY()) / 10).c_str();
-        m_svgNode.prepend_attribute("width")
-            = StringFormat("%gmm", ((double)GetWidth() * GetUserScaleX()) / 10).c_str();
+        height /=  10;
+        width /= 10;
+        format = "%gmm";
+    }
+
+    if(m_svgViewBox) {
+        m_svgNode.prepend_attribute("viewBox") = StringFormat("0 0 %g %g", width, height).c_str();
     }
     else {
-        m_svgNode.prepend_attribute("height") = StringFormat("%gpx", ((double)GetHeight() * GetUserScaleY())).c_str();
-        m_svgNode.prepend_attribute("width") = StringFormat("%gpx", ((double)GetWidth() * GetUserScaleX())).c_str();
+        m_svgNode.prepend_attribute("height") = StringFormat(format, height).c_str();
+        m_svgNode.prepend_attribute("width") = StringFormat(format, width).c_str();
     }
 
     // add the woff VerovioText font if needed

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1042,6 +1042,11 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
         svg.SetMMOutput(true);
     }
 
+    // set the option to use viewbox on svg root
+    if (m_options->m_svgViewBox.GetValue()) {
+        svg.SetSvgViewBox(true);
+    }
+
     // render the page
     RenderToDeviceContext(pageNo, &svg);
 


### PR DESCRIPTION
Not sure it's the best name, but if you think this is useful for verovio users I'm happy to update it and discuss.

Add new boolean option that is false by default to
enable using a viewBox attribute instead of explicit width
and height on the svg root node.

Use case for this option is to allow the svg document to
scale to the size of its container by default, primarily for
web applications, without having to resize the doc based on the window when resized. 

I have noticed a little oddness in the javascript where it seems like the option is somehow cached, or always on, or something. I tried to follow the same logic as adjustPageHeight for the most part in determining how to add a new option. However the sample.html below seems to work fine building emscripten from this branch. The sample included here should demonstrate by toggling the flag with any tune. You should notice with false (default) that the tune does not stay within the container, which is how verovio currently behaves, but when true the svg document scales with the container size.

[sample.html.txt](https://github.com/rism-ch/verovio/files/2999889/sample.html.txt)

