### PR TITLE
MusicXML import: slurs across layers and staves are imported from MusicXML

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -63,15 +63,23 @@ namespace musicxml {
 
     class OpenSlur {
     public:
-        OpenSlur(int staffN, int layerN, int number)
+        OpenSlur(int number)
         {
-            m_staffN = staffN;
-            m_layerN = layerN;
             m_number = number;
         }
 
-        int m_staffN;
-        int m_layerN;
+        int m_number;
+    };
+
+    class CloseSlur {
+    public:
+        CloseSlur(std::string measureNum, int number)
+        {
+            m_measureNum = measureNum;
+            m_number = number;
+        }
+        
+        std::string m_measureNum;
         int m_number;
     };
 
@@ -204,8 +212,8 @@ private:
     ///@{
     void OpenTie(Staff *staff, Note *note, Tie *tie);
     void CloseTie(Staff *staff, Note *note);
-    void OpenSlur(Staff *staff, Layer *layer, int number, Slur *slur);
-    void CloseSlur(Staff *staff, Layer *layer, int number, LayerElement *element);
+    void OpenSlur(Measure *measure, int number, Slur *slur);
+    void CloseSlur(Measure *measure, int number, LayerElement *element);
     ///@}
 
     /*
@@ -272,6 +280,8 @@ private:
     std::vector<LayerElement *> m_elementStack;
     /* The stack for open slurs */
     std::vector<std::pair<Slur *, musicxml::OpenSlur> > m_slurStack;
+    /* The stack for slur stops that might come before the slur has been opened */
+    std::vector<std::pair<LayerElement *, musicxml::CloseSlur> > m_slurStopStack;
     /* The stack for open ties */
     std::vector<std::pair<Tie *, musicxml::OpenTie> > m_tieStack;
     /* The stack for hairpins */

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -326,26 +326,43 @@ void MusicXmlInput::CloseTie(Staff *staff, Note *note)
     LogWarning("MusicXML import: Note '%s' has tie ending without matching start", note->GetUuid().c_str());
 }
 
-void MusicXmlInput::OpenSlur(Staff *staff, Layer *layer, int number, Slur *slur)
+void MusicXmlInput::OpenSlur(Measure *measure, int number, Slur *slur)
 {
-    // No staff is set as slurs can appear across staves
+    // check whether matching closed slurs are present
+    std::vector<std::pair<LayerElement *, musicxml::CloseSlur> >::iterator iter;
+    for (iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
+        if ((iter->second.m_number == number) && (iter->second.m_measureNum == measure->GetN())) {
+            slur->SetStartid(m_ID);
+            slur->SetEndid("#" + iter->first->GetUuid());
+            m_slurStopStack.erase(iter);
+            return;
+        }
+        // if not in same measure, give up matching // move this to the end
+        if (iter->second.m_measureNum != measure->GetN()) {
+            LogWarning("MusicXML import: Closing slur for element '%s' could not be matched", iter->first->GetUuid().c_str());
+            m_slurStopStack.erase(iter);
+            break;
+        }
+    }
     slur->SetStartid(m_ID);
-    musicxml::OpenSlur openSlur(staff->GetN(), layer->GetN(), number);
+    musicxml::OpenSlur openSlur(number);
     m_slurStack.push_back(std::make_pair(slur, openSlur));
 }
 
-void MusicXmlInput::CloseSlur(Staff *staff, Layer *layer, int number, LayerElement *element)
+void MusicXmlInput::CloseSlur(Measure *measure, int number, LayerElement *element)
 {
     std::vector<std::pair<Slur *, musicxml::OpenSlur> >::iterator iter;
     for (iter = m_slurStack.begin(); iter != m_slurStack.end(); ++iter) {
-        if ((iter->second.m_staffN == staff->GetN()) && (iter->second.m_layerN == layer->GetN())
-            && (iter->second.m_number == number)) {
+        if (iter->second.m_number == number) {
             iter->first->SetEndid("#" + element->GetUuid());
             m_slurStack.erase(iter);
             return;
         }
     }
-    LogWarning("MusicXML import: Closing slur for element '%s' could not be matched", element->GetUuid().c_str());
+    musicxml::CloseSlur closeSlur(measure->GetN(), number);
+    m_slurStopStack.push_back(std::make_pair(element, closeSlur));
+    LogWarning("MusicXML import: Closing slur for element '%s' added to slurStopStack", element->GetUuid().c_str());
+    // LogWarning("MusicXML import: Closing slur for element '%s' could not be matched", element->GetUuid().c_str());
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -1843,10 +1860,10 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
                 meiSlur->AttCurvature::StrToCurvatureCurvedir(slur.attribute("placement").as_string()));
             // add it to the stack
             m_controlElements.push_back(std::make_pair(measureNum, meiSlur));
-            OpenSlur(staff, layer, slurNumber, meiSlur);
+            OpenSlur(measure, slurNumber, meiSlur);
         }
         else if (HasAttributeWithValue(slur, "type", "stop")) {
-            CloseSlur(staff, layer, slurNumber, element);
+            CloseSlur(measure, slurNumber, element);
         }
     }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -596,14 +596,17 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     }
     if (!m_slurStack.empty()) { // There are slurs left open
         std::vector<std::pair<Slur *, musicxml::OpenSlur> >::iterator iter;
-        for (iter = m_slurStack.begin(); iter != m_slurStack.end(); ++iter) {            LogWarning("MusicXML import: Slur element '%s' could not be ended.", iter->first->GetUuid().c_str());
+        for (iter = m_slurStack.begin(); iter != m_slurStack.end(); ++iter) {
+            LogWarning("MusicXML import: Slur element '%s' could not be ended.", iter->first->GetUuid().c_str());
         }
         m_slurStack.clear();
     }
     if (!m_slurStopStack.empty()) { // There are slurs ends without opening
         std::vector<std::pair<LayerElement *, musicxml::CloseSlur> >::iterator iter;
         for (iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
-            LogWarning("MusicXML import: Slur ending for element '%s' could not be matched to a start element.", iter->first->GetUuid().c_str());
+            LogWarning("MusicXML import: Slur ending for element '%s' could not be"
+                       "matched to a start element.",
+                iter->first->GetUuid().c_str());
         }
         m_slurStopStack.clear();
     }


### PR DESCRIPTION
Currently, slurs are only imported from MusicXML, when they are in the same voice (layer) and staff (please see discussion on issue #1042).  

In this branch, slurs starts and stops are matched only by their `@number` attribute, not `@layer` and `@staff` anymore. Since in a partwise MusicXML a `@stop` attribute of a slur may occur _before_ the `@start` attribute has been called, an additional `m_slurStopStack` is introduced that contains unmatched slur stops (in addition to the `m_slurStack` for opened slurs). Since these should be matched within the same measure, the routine in `MusicXmlInput::OpenSlur` for matching them checks for measure number and slur number. Left-over open slurs and unmatched slur stops are reported at the end by their `xml:id`.

Note: There is a restriction in MusicXML that there can not be more than 6 different slurs (or other spanners) in one measure (see http://usermanuals.musicxml.com/MusicXML/MusicXML.htm#ST-MusicXML-number-level.htm). I can imagine @craigsapp generating examples easily exceeding this restriction. :-)

I tested this code successfully with the examples from #1042 and some others. I am eager for comments and more discussion.
