### PR TITLE
musicXMLimport supports endings

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -295,6 +295,8 @@ private:
     std::vector<std::pair<Tie *, musicxml::OpenTie> > m_tieStack;
     /* The stack for hairpins */
     std::vector<std::pair<Hairpin *, musicxml::OpenHairpin> > m_hairpinStack;
+    /* The stack of endings to be inserted at the end of XML import */
+    std::vector<std::pair<Measure *, musicxml::EndingInfo> > m_endingStack;
     /* The stacks for ControlElements */
     std::vector<Dir *> m_dirStack;
     std::vector<Dynam *> m_dynamStack;

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -94,14 +94,16 @@ namespace musicxml {
 
     class EndingInfo {
     public:
-        EndingInfo(std::string endingNumber, std::string endingType)
+        EndingInfo(std::string endingNumber, std::string endingType, std::string endingText)
         {
             m_endingNumber = endingNumber;
             m_endingType = endingType;
+            m_endingText = endingText;
         }
 
         std::string m_endingNumber;
         std::string m_endingType;
+        std::string m_endingText;
     };
 
 } // namespace musicxml

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -91,7 +91,7 @@ namespace musicxml {
         int m_dirN;
         std::string m_endID;
     };
-    
+
     class EndingInfo {
     public:
         EndingInfo(std::string endingNumber, std::string endingType)
@@ -99,13 +99,13 @@ namespace musicxml {
             m_endingNumber = endingNumber;
             m_endingType = endingType;
         }
-        
+
         void SetEndingType(std::string endingType) { m_endingType = endingType; }
-        
+
         std::string m_endingNumber;
         std::string m_endingType;
     };
-   
+
 } // namespace musicxml
 
 //----------------------------------------------------------------------------
@@ -203,6 +203,13 @@ private:
     bool HasAttributeWithValue(pugi::xml_node node, std::string attribute, std::string value);
     bool IsElement(pugi::xml_node node, std::string name);
     bool HasContentWithValue(pugi::xml_node node, std::string value);
+    ///@}
+
+    /*
+     * @name Helper method to check whether a ending measure number is already present in m_endingStack.
+     */
+    ///@{
+    bool NotInEndingStack(std::string measureN);
     ///@}
 
     /*

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -91,6 +91,18 @@ namespace musicxml {
         int m_dirN;
         std::string m_endID;
     };
+    
+    class EndingInfo{
+    public:
+        EndingInfo(std:string endingNumber, std:string endingType)
+        {
+            m_endingNumber = endingNumber;
+            m_endingType = endingType;
+        }
+        
+        std::string m_endingNumber;
+        std::string m_endingType;
+    }
 
 } // namespace musicxml
 

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -94,7 +94,7 @@ namespace musicxml {
 
     class EndingInfo {
     public:
-        EndingInfo(std::string endingNumber, std::string endingType, std::string endingText)
+        EndingInfo(std::string const &endingNumber, std::string const &endingType, std::string const &endingText)
         {
             m_endingNumber = endingNumber;
             m_endingType = endingType;
@@ -209,7 +209,7 @@ private:
      * @name Helper method to check whether a ending measure number is already present in m_endingStack.
      */
     ///@{
-    bool NotInEndingStack(std::string measureN);
+    bool NotInEndingStack(std::string const &measureN);
     ///@}
 
     /*

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -100,8 +100,6 @@ namespace musicxml {
             m_endingType = endingType;
         }
 
-        void SetEndingType(std::string endingType) { m_endingType = endingType; }
-
         std::string m_endingNumber;
         std::string m_endingType;
     };

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -49,7 +49,7 @@ namespace musicxml {
 
     class OpenTie {
     public:
-        OpenTie(int staffN, data_PITCHNAME pname, char oct)
+        OpenTie(const int &staffN, const data_PITCHNAME &pname, const char &oct)
         {
             m_staffN = staffN;
             m_pname = pname;
@@ -63,14 +63,14 @@ namespace musicxml {
 
     class OpenSlur {
     public:
-        OpenSlur(int number) { m_number = number; }
+        OpenSlur(const int &number) { m_number = number; }
 
         int m_number;
     };
 
     class CloseSlur {
     public:
-        CloseSlur(std::string measureNum, int number)
+        CloseSlur(const std::string &measureNum, const int &number)
         {
             m_measureNum = measureNum;
             m_number = number;
@@ -82,7 +82,7 @@ namespace musicxml {
 
     class OpenHairpin {
     public:
-        OpenHairpin(int dirN, std::string endID)
+        OpenHairpin(const int &dirN, const std::string &endID)
         {
             m_dirN = dirN;
             m_endID = endID;
@@ -94,7 +94,7 @@ namespace musicxml {
 
     class EndingInfo {
     public:
-        EndingInfo(std::string const &endingNumber, std::string const &endingType, std::string const &endingText)
+        EndingInfo(const std::string &endingNumber, const std::string &endingType, const std::string &endingText)
         {
             m_endingNumber = endingNumber;
             m_endingType = endingType;

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -92,18 +92,20 @@ namespace musicxml {
         std::string m_endID;
     };
     
-    class EndingInfo{
+    class EndingInfo {
     public:
-        EndingInfo(std:string endingNumber, std:string endingType)
+        EndingInfo(std::string endingNumber, std::string endingType)
         {
             m_endingNumber = endingNumber;
             m_endingType = endingType;
         }
         
+        void SetEndingType(std::string endingType) { m_endingType = endingType; }
+        
         std::string m_endingNumber;
         std::string m_endingType;
-    }
-
+    };
+   
 } // namespace musicxml
 
 //----------------------------------------------------------------------------
@@ -215,8 +217,7 @@ private:
      * @name Methods for opening and closing ties and slurs.
      * Opened ties and slurs are stacked together with musicxml::OpenTie
      * and musicxml::OpenSlur objects.
-     * For now: only slurs starting and ending on the same staff/voice are
-     * supported
+     * Slur starts and ends are matched based on its number.
      */
     ///@{
     void OpenTie(Staff *staff, Note *note, Tie *tie);
@@ -296,7 +297,7 @@ private:
     /* The stack for hairpins */
     std::vector<std::pair<Hairpin *, musicxml::OpenHairpin> > m_hairpinStack;
     /* The stack of endings to be inserted at the end of XML import */
-    std::vector<std::pair<Measure *, musicxml::EndingInfo> > m_endingStack;
+    std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> > m_endingStack;
     /* The stacks for ControlElements */
     std::vector<Dir *> m_dirStack;
     std::vector<Dynam *> m_dynamStack;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -626,12 +626,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                     section->DetachChild(idx);
                     ending->AddChild(*jter);
                 }
-                if (*jter == measureList.back()) {
-                    logString = logString + ").";
-                }
-                else {
-                    logString = logString + ", ";
-                }
+                logString = logString + ((*jter == measureList.back()) ? ")." : ", ");
             }
             LogMessage(logString.c_str());
         }
@@ -1171,7 +1166,7 @@ void MusicXmlInput::ReadMusicXmlBarLine(pugi::xml_node node, Measure *measure, s
             }
         }
         else if (endingType == "stop" || endingType == "discontinue") {
-            m_endingStack.back().second.SetEndingType(endingType);
+            m_endingStack.back().second.m_endingType = endingType;
             if (NotInEndingStack(measure->GetN())) {
                 m_endingStack.back().first.push_back(measure);
             }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -605,8 +605,12 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         for (iter = m_endingStack.begin(); iter != m_endingStack.end(); ++iter) {
             LogMessage("Ending number='%s', endType='%s'", iter->second.m_endingNumber.c_str(), iter->second.m_endingType.c_str());
             std::vector<Measure * > measureList = iter->first;
-            for (std::vector<Measure *>::iterator jter = measureList.begin(); jter != measureList.end(); ++jter) {
-                LogMessage("   Measure number id: '%s'", (*jter)->GetUuid().c_str());
+            std::vector<Measure *>::iterator jter = measureList.begin();
+            Object *section = (*jter)->GetParent();
+            LogMessage("Section %s.", section->GetUuid().c_str());
+            // XXX continue here... Ending ending = Ending();
+            for (; jter != measureList.end(); ++jter) {
+                LogMessage("   Measure id: '%s'", (*jter)->GetUuid().c_str());
             }
         }
         m_slurStack.clear();

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2229,16 +2229,12 @@ std::string MusicXmlInput::ConvertKindToSymbol(std::string value)
         return "";
 }
 
-bool MusicXmlInput::NotInEndingStack(std::string const &measureN)
+bool MusicXmlInput::NotInEndingStack(const std::string &measureN)
 {
-    std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> >::iterator iter;
-    for (iter = m_endingStack.begin(); iter != m_endingStack.end(); ++iter) {
-        std::vector<Measure *> measureList = iter->first;
-        std::vector<Measure *>::iterator jter;
-        for (jter = measureList.begin(); jter != measureList.end(); ++jter) {
-            if ((*jter)->GetN() == measureN) {
+    for (auto &endingItem : m_endingStack) {
+        for (auto &measure : endingItem.first) {
+            if (measure->GetN() == measureN)
                 return false;
-            }
         }
     }
     return true;


### PR DESCRIPTION
Here is a way to get endings into Verovio from musicXML. It works for my examples supporting `@type="discontinue"`, multi-staff scores, and endings spanning over multiple measures. Please test it.

If the `<ending>` element text is missing in musicXML, the `@number` attribute is taken instead (several musicXML exporters do this). 