### PR TITLE
MusicXmlImport: Ties across layers matched by scoreTimeOnset

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -47,22 +47,6 @@ class Tie;
 
 namespace musicxml {
 
-    class OpenTie {
-    public:
-        OpenTie(const std::string &measureNum, const double &scoreTimeOnset, const data_PITCHNAME &pname, const char &oct)
-        {
-            m_measureNum = measureNum;
-            m_scoreTimeOnset = scoreTimeOnset;
-            m_pname = pname;
-            m_oct = oct;
-        }
-        
-        std::string m_measureNum;
-        double m_scoreTimeOnset;
-        data_PITCHNAME m_pname;
-        char m_oct;
-    };
-    
     class OpenSlur {
     public:
         OpenSlur(const int &number) { m_number = number; }
@@ -229,8 +213,8 @@ private:
      * Slur starts and ends are matched based on its number.
      */
     ///@{
-    void OpenTie(Measure *measure, Note *note, Tie *tie);
-    void CloseTie(Measure *measure, Note *note);
+    void OpenTie(Note *note, Tie *tie);
+    void CloseTie(Note *note);
     void OpenSlur(Measure *measure, int number, Slur *slur);
     void CloseSlur(Measure *measure, int number, LayerElement *element);
     ///@}
@@ -302,9 +286,9 @@ private:
     /* The stack for slur stops that might come before the slur has been opened */
     std::vector<std::pair<LayerElement *, musicxml::CloseSlur> > m_slurStopStack;
     /* The stack for open ties */
-    std::vector<std::pair<Tie *, musicxml::OpenTie> > m_tieStack;
+    std::vector<std::pair<Tie *, Note *> > m_tieStack;
     /* The stack for tie stops that might come before that tie was opened */
-    std::vector<musicxml::OpenTie> m_tieStopStack;
+    std::vector<Note *> m_tieStopStack;
     /* The stack for hairpins */
     std::vector<std::pair<Hairpin *, musicxml::OpenHairpin> > m_hairpinStack;
     /* The stack of endings to be inserted at the end of XML import */

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -49,18 +49,20 @@ namespace musicxml {
 
     class OpenTie {
     public:
-        OpenTie(const int &staffN, const data_PITCHNAME &pname, const char &oct)
+        OpenTie(const std::string &measureNum, const double &scoreTimeOnset, const data_PITCHNAME &pname, const char &oct)
         {
-            m_staffN = staffN;
+            m_measureNum = measureNum;
+            m_scoreTimeOnset = scoreTimeOnset;
             m_pname = pname;
             m_oct = oct;
         }
-
-        int m_staffN;
+        
+        std::string m_measureNum;
+        double m_scoreTimeOnset;
         data_PITCHNAME m_pname;
         char m_oct;
     };
-
+    
     class OpenSlur {
     public:
         OpenSlur(const int &number) { m_number = number; }
@@ -227,8 +229,8 @@ private:
      * Slur starts and ends are matched based on its number.
      */
     ///@{
-    void OpenTie(Staff *staff, Note *note, Tie *tie);
-    void CloseTie(Staff *staff, Note *note);
+    void OpenTie(Measure *measure, Note *note, Tie *tie);
+    void CloseTie(Measure *measure, Note *note);
     void OpenSlur(Measure *measure, int number, Slur *slur);
     void CloseSlur(Measure *measure, int number, LayerElement *element);
     ///@}
@@ -301,6 +303,8 @@ private:
     std::vector<std::pair<LayerElement *, musicxml::CloseSlur> > m_slurStopStack;
     /* The stack for open ties */
     std::vector<std::pair<Tie *, musicxml::OpenTie> > m_tieStack;
+    /* The stack for tie stops that might come before that tie was opened */
+    std::vector<musicxml::OpenTie> m_tieStopStack;
     /* The stack for hairpins */
     std::vector<std::pair<Hairpin *, musicxml::OpenHairpin> > m_hairpinStack;
     /* The stack of endings to be inserted at the end of XML import */

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1779,9 +1779,10 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             // color
             tie->SetColor(startTie.node().attribute("color").as_string());
             // placement and orientation
-            tie->SetCurvedir(ConvertOrientationToCurvedir(startTie.node().attribute("orientation").as_string()));
-            tie->SetCurvedir(
-                tie->AttCurvature::StrToCurvatureCurvedir(startTie.node().attribute("placement").as_string()));
+            tie->SetCurvedir(tie->AttCurvature::StrToCurvatureCurvedir(startTie.node().attribute("placement").as_string()));
+            if (!startTie.node().attribute("orientation").empty()) { // override only with non-empty attribute
+                tie->SetCurvedir(ConvertOrientationToCurvedir(startTie.node().attribute("orientation").as_string()));
+            }
             // add it to the stack
             m_controlElements.push_back(std::make_pair(measureNum, tie));
             OpenTie(note, tie);


### PR DESCRIPTION
The last change improved the import for ties substantially (see #1039 and https://github.com/rism-ch/verovio/commit/9c609e97d7d2917d10778803fe0a3402dab7c308). 

However, this Brahms example shows the problem when the `tied@type="stop"` occurs before it has been opened by `tied@type="start"`. The resulting MEI file has actually ties with notes in reverse order, pointing from one note backwards to another.

Original Finale excerpt (code below):
<img width="723" alt="Brahms3-Oboe-TieTest-Finale" src="https://user-images.githubusercontent.com/45632600/57681141-70d41b00-762f-11e9-90bf-1d57a6b39502.png">

Resulting Verovio rendering (with current develop, code below): 
<img width="807" alt="Brahms3-Oboe-TieTest-Dolet-Verovio" src="https://user-images.githubusercontent.com/45632600/57681208-8cd7bc80-762f-11e9-9d6d-eab68308b7b3.png">

This ordering issue is addressed in this commit: All open ties (`<tied@type="start">`) and ties to be closed (`<tied@type="stop">`) are collected in separate vectors. After a complete measure, these vectors are now compared to each other and matched by their scoreTimeOnset.

In addition, this commit closes ties that are not explicitly closed in the musicXML file (`<tied@type="stop">`), just by taking the subsequent note with identical pitch as the closing note, independently of layer or staff (but within a part only). I hope that this is an assumption that holds across styles.

Moreover, import of `@placement/@orientation` attributes do not override each other anymore.

Code of musicXML excerpt: 
```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <movement-title>Symphony No. 3 in F major, Op. 90</movement-title>
  <identification>
    <creator type="composer">Johannes Brahms</creator>
    <rights>© Copyright 2014 by Stichting Donemus Beheer, Rijswijk</rights>
    <encoding>
      <software>Finale 2014.5 for Mac</software>
      <software>Dolet 7.2 for Finale</software>
      <encoding-date>2019-05-04</encoding-date>
      <supports attribute="new-system" element="print" type="yes" value="yes"/>
      <supports attribute="new-page" element="print" type="yes" value="yes"/>
      <supports element="accidental" type="yes"/>
      <supports element="beam" type="yes"/>
      <supports element="stem" type="yes"/>
    </encoding>
  </identification>
  <defaults>
    <scaling>
      <millimeters>7.366</millimeters>
      <tenths>40</tenths>
    </scaling>
    <page-layout>
      <page-height>1977</page-height>
      <page-width>1398</page-width>
      <page-margins type="both">
        <left-margin>132</left-margin>
        <right-margin>96</right-margin>
        <top-margin>108</top-margin>
        <bottom-margin>108</bottom-margin>
      </page-margins>
    </page-layout>
    <system-layout>
      <system-margins>
        <left-margin>0</left-margin>
        <right-margin>0</right-margin>
      </system-margins>
      <system-distance>212</system-distance>
      <top-system-distance>171</top-system-distance>
    </system-layout>
    <appearance>
      <line-width type="stem">0.8333</line-width>
      <line-width type="beam">5</line-width>
      <line-width type="staff">1.1784</line-width>
      <line-width type="light barline">1.6667</line-width>
      <line-width type="heavy barline">5</line-width>
      <line-width type="leger">1.25</line-width>
      <line-width type="ending">0.7487</line-width>
      <line-width type="wedge">1.25</line-width>
      <line-width type="enclosure">1.6667</line-width>
      <line-width type="tuplet bracket">1.25</line-width>
      <note-size type="grace">68</note-size>
      <note-size type="cue">68</note-size>
      <distance type="hyphen">50</distance>
      <distance type="beam">8</distance>
    </appearance>
    <music-font font-family="EngraverFontSet,engraved" font-size="20.9"/>
    <word-font font-family="Poppl-Laudatio" font-size="12.2"/>
    <lyric-font font-family="Times" font-size="11.3"/>
  </defaults>
  <credit page="1">
    <credit-type>rights</credit-type>
    <credit-words default-x="148" default-y="56" font-size="9" halign="left" justify="center" valign="bottom">© Copyright 2014 by Stichting Donemus Beheer, Rijswijk</credit-words>
  </credit>
  <credit page="1">
    <credit-words default-x="1251" default-y="56" font-size="9" halign="right" valign="bottom">D 13353</credit-words>
  </credit>
  <part-list>
    <score-part id="P1">
      <part-name print-object="no">Oboe 1</part-name>
      <part-abbreviation print-object="no">Ob. 1</part-abbreviation>
      <score-instrument id="P1-I16">
        <instrument-name>Garritan: ARIA Player</instrument-name>
        <instrument-sound>wind.reed.oboe</instrument-sound>
      </score-instrument>
      <midi-instrument id="P1-I16">
        <midi-channel>3</midi-channel>
        <midi-bank>15489</midi-bank>
        <midi-program>69</midi-program>
        <volume>80</volume>
        <pan>29</pan>
      </midi-instrument>
    </score-part>
  </part-list>
  <!--=========================================================-->
  <part id="P1">
    <measure number="1" width="470">
      <print>
        <page-layout>
          <page-height>1977</page-height>
          <page-width>1398</page-width>
          <page-margins>
            <left-margin>96</left-margin>
            <right-margin>96</right-margin>
            <top-margin>108</top-margin>
            <bottom-margin>108</bottom-margin>
          </page-margins>
        </page-layout>
        <system-layout>
          <system-margins>
            <left-margin>52</left-margin>
            <right-margin>0</right-margin>
          </system-margins>
          <top-system-distance>271</top-system-distance>
        </system-layout>
        <measure-numbering>none</measure-numbering>
      </print>
      <attributes>
        <divisions>2</divisions>
        <key>
          <fifths>3</fifths>
          <mode>major</mode>
        </key>
        <time>
          <beats>6</beats>
          <beat-type>4</beat-type>
        </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
        </clef>
      </attributes>
      <sound tempo="120"/>
      <note default-x="129">
        <pitch>
          <step>A</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>half</type>
        <stem default-y="39">up</stem>
      </note>
      <note default-x="242">
        <pitch>
          <step>C</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <accidental>natural</accidental>
        <stem default-y="14">up</stem>
        <notations>
          <slur number="1" placement="above" type="start"/>
        </notations>
      </note>
      <note default-x="299">
        <pitch>
          <step>F</step>
          <alter>1</alter>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="29">up</stem>
      </note>
      <note default-x="355">
        <pitch>
          <step>A</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="39">up</stem>
        <notations>
          <slur number="1" type="stop"/>
        </notations>
      </note>
      <note default-x="412">
        <pitch>
          <step>G</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="34">up</stem>
        <notations>
          <tied orientation="over" type="start"/>
        </notations>
      </note>
      <backup>
        <duration>12</duration>
      </backup>
      <note default-x="142">
        <pitch>
          <step>G</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>2</voice>
        <type>half</type>
        <accidental>natural</accidental>
        <stem default-y="-30">down</stem>
      </note>
      <note default-x="242">
        <pitch>
          <step>A</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>2</voice>
        <type>quarter</type>
        <stem default-y="-54">down</stem>
        <notations>
          <tied orientation="under" type="start"/>
        </notations>
      </note>
      <note default-x="299">
        <pitch>
          <step>A</step>
          <octave>4</octave>
        </pitch>
        <duration>4</duration>
        <tie type="stop"/>
        <voice>2</voice>
        <type>half</type>
        <stem default-y="-54">down</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="425">
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>2</voice>
        <type>quarter</type>
        <accidental>natural</accidental>
        <stem default-y="-35">down</stem>
        <notations>
          <tied orientation="under" type="start"/>
          <slur number="1" placement="below" type="start"/>
        </notations>
      </note>
    </measure>
    <!--=======================================================-->
    <measure number="2" width="367">
      <note default-x="16">
        <pitch>
          <step>G</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>half</type>
        <stem default-y="34">up</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="133">
        <pitch>
          <step>G</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>quarter</type>
        <accidental>natural</accidental>
        <stem default-y="34">up</stem>
        <notations>
          <tied orientation="over" type="start"/>
        </notations>
      </note>
      <note default-x="191">
        <pitch>
          <step>G</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>half</type>
        <stem default-y="34">up</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="307">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="-45">down</stem>
        <notations>
          <tied orientation="under" type="start"/>
        </notations>
      </note>
      <note default-x="307">
        <chord/>
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>quarter</type>
        <accidental>natural</accidental>
        <stem>down</stem>
        <notations>
          <tied orientation="over" type="start"/>
        </notations>
      </note>
      <backup>
        <duration>12</duration>
      </backup>
      <note default-x="30">
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="stop"/>
        <voice>2</voice>
        <type>quarter</type>
        <stem default-y="-35">down</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="75">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>2</voice>
        <type>quarter</type>
        <stem default-y="-45">down</stem>
        <notations>
          <slur number="1" type="stop"/>
        </notations>
      </note>
      <note default-x="146">
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>2</voice>
        <type>quarter</type>
        <accidental>natural</accidental>
        <stem default-y="-35">down</stem>
        <notations>
          <tied orientation="under" type="start"/>
          <slur number="1" placement="below" type="start"/>
        </notations>
      </note>
      <note default-x="204">
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="stop"/>
        <voice>2</voice>
        <type>quarter</type>
        <stem default-y="-35">down</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="249">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>2</voice>
        <type>quarter</type>
        <stem default-y="-45">down</stem>
        <notations>
          <slur number="1" type="stop"/>
        </notations>
      </note>
      <direction placement="below">
        <direction-type>
          <words default-x="307" default-y="-70" font-family="Times" font-size="10.4" font-style="italic">cresc.</words>
        </direction-type>
        <sound dynamics="54"/>
      </direction>
    </measure>
    <!--=======================================================-->
    <measure number="3" width="318">
      <note default-x="15">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="-45">down</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="15">
        <chord/>
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
        <notations>
          <tied type="stop"/>
        </notations>
      </note>
      <note default-x="72">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>half</type>
        <stem default-y="-45">down</stem>
      </note>
      <note default-x="72">
        <chord/>
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>half</type>
        <accidental>natural</accidental>
        <stem>down</stem>
      </note>
      <note default-x="186">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>half</type>
        <stem default-y="-45">down</stem>
      </note>
      <note default-x="186">
        <chord/>
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>half</type>
        <stem>down</stem>
      </note>
      <note default-x="267">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="-45">down</stem>
      </note>
      <note default-x="267">
        <chord/>
        <pitch>
          <step>F</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
      </barline>
    </measure>
  </part>
  <!--=========================================================-->
</score-partwise>
```

Code of resulting MEI file (with ties pointing from a note backwards): 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Symphony No. 3 in F major, Op. 90</title>
            </titleStmt>
            <pubStmt></pubStmt>
        </fileDesc>
        <encodingDesc xml:id="encodingdesc-0000000540490664">
            <appInfo xml:id="appinfo-0000000170763038">
                <application xml:id="application-0000000976227274" isodate="2019-05-13T17:56:37" version="2.1.0-dev-9c609e9">
                    <name xml:id="name-0000000676731038">Verovio</name>
                    <p xml:id="p-0000000745161154">Transcoded from MusicXML</p>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mdiv-0000001946369621">
                <score xml:id="score-0000000015825396">
                    <scoreDef xml:id="scoredef-0000001349550002" midi.bpm="120">
                        <staffGrp xml:id="staffgrp-0000000952288717">
                            <staffDef xml:id="staffdef-0000001090650236" clef.shape="G" clef.line="2" key.mode="major" key.sig="3s" meter.count="6" meter.unit="4" n="1" lines="5" ppq="2">
                                <instrDef xml:id="instrdef-0000000465253169" midi.channel="2" midi.instrnum="68" midi.volume="80.00%" />
                            </staffDef>
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="section-0000001836941991">
                        <pb xml:id="pb-0000001259133465" />
                        <measure xml:id="measure-0000000522052656" n="1">
                            <staff xml:id="staff-0000001886043164" n="1">
                                <layer xml:id="layer-0000001868827628" n="1">
                                    <note xml:id="note-0000000290122774" dur.ppq="4" dur="2" oct="5" pname="a" stem.dir="up" />
                                    <note xml:id="note-0000001305583928" dur.ppq="2" dur="4" oct="5" pname="c" stem.dir="up">
                                        <accid xml:id="accid-0000002108656497" accid="n" />
                                    </note>
                                    <note xml:id="note-0000001222126636" dur.ppq="2" dur="4" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                                    <note xml:id="note-0000001138785766" dur.ppq="2" dur="4" oct="5" pname="a" stem.dir="up" />
                                    <note xml:id="note-0000001198107098" dur.ppq="2" dur="4" oct="5" pname="g" stem.dir="up" />
                                </layer>
                                <layer xml:id="layer-0000001351943423" n="2">
                                    <note xml:id="note-0000001736125101" dur.ppq="4" dur="2" oct="5" pname="g" stem.dir="down">
                                        <accid xml:id="accid-0000001194260718" accid="n" />
                                    </note>
                                    <note xml:id="note-0000001557722564" dur.ppq="2" dur="4" oct="4" pname="a" stem.dir="down" />
                                    <note xml:id="note-0000001308379576" dur.ppq="4" dur="2" oct="4" pname="a" stem.dir="down" />
                                    <note xml:id="note-0000001850472199" dur.ppq="2" dur="4" oct="5" pname="f" stem.dir="down">
                                        <accid xml:id="accid-0000001028072739" accid="n" />
                                    </note>
                                </layer>
                            </staff>
                            <slur xml:id="slur-0000000267118638" startid="#note-0000001305583928" endid="#note-0000001138785766" curvedir="above" />
                            <tie xml:id="tie-0000001779321814" startid="#note-0000001198107098" endid="#note-0000000779489370" />
                            <tie xml:id="tie-0000000669992571" startid="#note-0000001557722564" endid="#note-0000001308379576" />
                            <tie xml:id="tie-0000000165100611" startid="#note-0000001850472199" endid="#note-0000001354923670" />
                            <slur xml:id="slur-0000000297097153" startid="#note-0000001850472199" endid="#note-0000000285528902" curvedir="below" />
                        </measure>
                        <measure xml:id="measure-0000000412371196" n="2">
                            <staff xml:id="staff-0000000672903571" n="1">
                                <layer xml:id="layer-0000000841432695" n="1">
                                    <note xml:id="note-0000000779489370" dur.ppq="4" dur="2" oct="5" pname="g" stem.dir="up" />
                                    <note xml:id="note-0000001227594890" dur.ppq="2" dur="4" oct="5" pname="g" stem.dir="up">
                                        <accid xml:id="accid-0000001311919501" accid="n" />
                                    </note>
                                    <note xml:id="note-0000000823401866" dur.ppq="4" dur="2" oct="5" pname="g" stem.dir="up" />
                                    <chord xml:id="chord-0000000443661014" dur.ppq="2" dur="4" stem.dir="down">
                                        <note xml:id="note-0000000530540594" oct="5" pname="d" />
                                        <note xml:id="note-0000001002690850" oct="5" pname="f">
                                            <accid xml:id="accid-0000000920937941" accid="n" />
                                        </note>
                                    </chord>
                                </layer>
                                <layer xml:id="layer-0000001667009376" n="2">
                                    <note xml:id="note-0000001354923670" dur.ppq="2" dur="4" oct="5" pname="f" stem.dir="down" />
                                    <note xml:id="note-0000000285528902" dur.ppq="2" dur="4" oct="5" pname="d" stem.dir="down" />
                                    <note xml:id="note-0000001405788516" dur.ppq="2" dur="4" oct="5" pname="f" stem.dir="down">
                                        <accid xml:id="accid-0000000472504118" accid="n" />
                                    </note>
                                    <note xml:id="note-0000000686915592" dur.ppq="2" dur="4" oct="5" pname="f" stem.dir="down" />
                                    <note xml:id="note-0000000118268472" dur.ppq="2" dur="4" oct="5" pname="d" stem.dir="down" />
                                </layer>
                            </staff>
                            <tie xml:id="tie-0000001216449558" startid="#note-0000001227594890" endid="#note-0000000823401866" />
                            <tie xml:id="tie-0000000547439914" startid="#note-0000000530540594" endid="#note-0000001905543089" />
                            <tie xml:id="tie-0000001289330458" startid="#note-0000001002690850" endid="#note-0000000686915592" />
                            <tie xml:id="tie-0000002129668267" startid="#note-0000001405788516" endid="#note-0000000297547980" />
                            <slur xml:id="slur-0000001224618920" startid="#note-0000001405788516" endid="#note-0000000118268472" curvedir="below" />
                            <dir xml:id="dir-0000001315835429" place="below" staff="1" startid="#chord-0000001039069112">
                                <rend xml:id="rend-0000001913567414" fontfam="Times" fontstyle="italic">cresc.</rend>
                            </dir>
                        </measure>
                        <measure xml:id="measure-0000000612429626" right="end" n="3">
                            <staff xml:id="staff-0000001652833577" n="1">
                                <layer xml:id="layer-0000001472954694" n="1">
                                    <chord xml:id="chord-0000001039069112" dur.ppq="2" dur="4" stem.dir="down">
                                        <note xml:id="note-0000001905543089" oct="5" pname="d" />
                                        <note xml:id="note-0000000297547980" oct="5" pname="f" />
                                    </chord>
                                    <chord xml:id="chord-0000000334292479" dur.ppq="4" dur="2" stem.dir="down">
                                        <note xml:id="note-0000001546969644" oct="5" pname="d" />
                                        <note xml:id="note-0000000636474001" oct="5" pname="f">
                                            <accid xml:id="accid-0000000602489100" accid="n" />
                                        </note>
                                    </chord>
                                    <chord xml:id="chord-0000001276393199" dur.ppq="4" dur="2" stem.dir="down">
                                        <note xml:id="note-0000000648908095" oct="5" pname="d" />
                                        <note xml:id="note-0000001126345710" oct="5" pname="f" />
                                    </chord>
                                    <chord xml:id="chord-0000000811628909" dur.ppq="2" dur="4" stem.dir="down">
                                        <note xml:id="note-0000000423999665" oct="5" pname="d" />
                                        <note xml:id="note-0000000230947819" oct="5" pname="f" />
                                    </chord>
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
