### PR TITLE
MusicXmlImport: Clef changes are imported to all layers, using `@sameas`

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -106,7 +106,7 @@ namespace musicxml {
         Staff *m_staff;
         Clef *m_clef;
         int m_scoreOnset; // the score position of clef change
-        bool isFirst = true; // make visible to first clef change across layers
+        bool isFirst = true; // insert clef change at first layer, others use @sameas
     };
     
 } // namespace musicxml
@@ -322,7 +322,7 @@ private:
      * end of each measure
      */
     std::vector<std::pair<std::string, ControlElement *> > m_controlElements;
-    /* stack of clef changes to be inserted to all layers of that staff */
+    /* stack of clef changes to be inserted to all layers of a given staff */
     std::vector<musicxml::ClefChange> m_ClefChangeStack;
 };
 

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -91,7 +91,21 @@ namespace musicxml {
         std::string m_endingType;
         std::string m_endingText;
     };
+    
+    class ClefChange {
+    public:
+        ClefChange(Staff *staff, Clef *clef, const int &scoreOnset) {
+            m_staff = staff;
+            m_clef = clef;
+            m_scoreOnset = scoreOnset;
+        }
 
+        Staff m_staff;
+        Clef m_clef;
+        int m_scoreOnset; // the score position of clef change
+        bool isFirst = true; // make visible to first clef change across layers
+    };
+    
 } // namespace musicxml
 
 //----------------------------------------------------------------------------
@@ -305,6 +319,8 @@ private:
      * end of each measure
      */
     std::vector<std::pair<std::string, ControlElement *> > m_controlElements;
+    /* stack of clef changes to be inserted to all layers of that staff */
+    std::vector<musicxml::ClefChange> m_ClefChangeStack;
 };
 
 } // namespace vrv

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -23,6 +23,7 @@
 
 namespace vrv {
 
+class Clef;
 class ControlElement;
 class Dir;
 class Dynam;
@@ -94,14 +95,16 @@ namespace musicxml {
     
     class ClefChange {
     public:
-        ClefChange(Staff *staff, Clef *clef, const int &scoreOnset) {
+        ClefChange(const std::string &measureNum, Staff *staff, Clef *clef, const int &scoreOnset) {
+            m_measureNum = measureNum;
             m_staff = staff;
             m_clef = clef;
             m_scoreOnset = scoreOnset;
         }
 
-        Staff m_staff;
-        Clef m_clef;
+        std::string m_measureNum;
+        Staff *m_staff;
+        Clef *m_clef;
         int m_scoreOnset; // the score position of clef change
         bool isFirst = true; // make visible to first clef change across layers
     };

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1081,14 +1081,13 @@ void MusicXmlInput::ReadMusicXmlAttributes(
     assert(section);
     assert(measure);
 
-    // read clef changes as MEI clef
+    // read clef changes as MEI clef and add them to the stack
     pugi::xpath_node clef = node.select_node("clef");
     if (clef) {
         // check if we have a staff number
         int staffNum = clef.node().attribute("number").as_int();
         staffNum = (staffNum < 1) ? 1 : staffNum;
-        staffNum--; // these three lines could be moved into a new method selectStaff(staffNum, measure)
-        Staff *staff = dynamic_cast<Staff *>(measure->GetChild(staffNum));
+        Staff *staff = dynamic_cast<Staff *>((measure->GetChild(staffNum) - 1));
         assert(staff);
         pugi::xpath_node clefSign = clef.node().select_node("sign");
         pugi::xpath_node clefLine = clef.node().select_node("line");
@@ -1110,8 +1109,6 @@ void MusicXmlInput::ReadMusicXmlAttributes(
                     meiClef->SetDisPlace(STAFFREL_basic_above);
             }
             m_ClefChangeStack.push_back(musicxml::ClefChange(measureNum, staff, meiClef, m_durTotal));
-            LogMessage("Clef change added: measure %s, staff %d, tstamp %d.",
-                       measureNum.c_str(), staff->GetN(), m_durTotal);
         }
     }
 
@@ -1527,8 +1524,6 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
         std::vector<musicxml::ClefChange>::iterator iter;
         for (iter = m_ClefChangeStack.begin(); iter != m_ClefChangeStack.end(); iter++) {
             if (iter->m_measureNum == measureNum && iter->m_staff == staff && iter->m_scoreOnset == m_durTotal) {
-                LogMessage("Clef added: measure %s, staff %d, tstamp %d.",
-                           measureNum.c_str(), staff->GetN(), m_durTotal);
                 if (iter->isFirst) { // add clef when first in staff
                     AddLayerElement(layer, iter->m_clef);
                     iter->isFirst = false;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -232,7 +232,7 @@ Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
         layerNum = atoi(layerNumStr.c_str());
     }
     if (layerNum < 1) {
-        LogWarning("MusicXML import: Staff %d cannot be found", staffNum);
+        LogWarning("MusicXML import: Layer %d cannot be found", staffNum);
         layerNum = 1;
     }
     return SelectLayer(layerNum, staff);
@@ -1051,7 +1051,7 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         // check if we have a staff number
         int staffNum = clef.node().attribute("number").as_int();
         staffNum = (staffNum < 1) ? 1 : staffNum;
-        Layer *layer = SelectLayer(staffNum, measure);
+        //Layer *layer = SelectLayer(staffNum, measure);
         pugi::xpath_node clefSign = clef.node().select_node("sign");
         pugi::xpath_node clefLine = clef.node().select_node("line");
         if (clefSign && clefLine) {
@@ -1071,7 +1071,9 @@ void MusicXmlInput::ReadMusicXmlAttributes(
                 else
                     meiClef->SetDisPlace(STAFFREL_basic_above);
             }
+            m_ClefChangeStack(new musicxml::ClefChange(staff,))
             AddLayerElement(layer, meiClef);
+            LogMessage("Measure %s: clef change in staff %d, layer %d.", measureNum.c_str(), staffNum, layer->GetN());
         }
     }
 
@@ -1157,6 +1159,8 @@ void MusicXmlInput::ReadMusicXmlBackup(pugi::xml_node node, Measure *measure, st
     m_durTotal -= atoi(GetContentOfChild(node, "duration").c_str());
 
     pugi::xpath_node nextNote = node.next_sibling("note");
+    int staff = atoi(GetContentOfChild(nextNote.node(), "staff").c_str());
+    LogMessage("Measure %s: backup %d, position %d. Next note staff: %d.", measureNum.c_str(), atoi(GetContentOfChild(node, "duration").c_str()), m_durTotal, staff);
     if (nextNote && m_durTotal > 0) {
         // We need a <space> if a note follows that starts not at the beginning of the measure
         Layer *layer = new Layer();
@@ -1483,7 +1487,7 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
     assert(staff);
 
     LayerElement *element = NULL;
-
+    
     double onset = m_durTotal; // keep note onsets for later
 
     // add duration to measure time

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1084,7 +1084,7 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         // check if we have a staff number
         int staffNum = clef.node().attribute("number").as_int();
         staffNum = (staffNum < 1) ? 1 : staffNum;
-        Staff *staff = dynamic_cast<Staff *>((measure->GetChild(staffNum)-1));
+        Staff *staff = dynamic_cast<Staff *>(measure->GetChild(staffNum-1));
         assert(staff);
         pugi::xpath_node clefSign = clef.node().select_node("sign");
         pugi::xpath_node clefLine = clef.node().select_node("line");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1956,7 +1956,6 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
     }
 
     // slur
-    // cross staff slurs won't work
     pugi::xpath_node_set slurs = notations.node().select_nodes("slur");
     for (pugi::xpath_node_set::const_iterator it = slurs.begin(); it != slurs.end(); ++it) {
         pugi::xml_node slur = it->node();


### PR DESCRIPTION
This PR addresses a highly discussed issue (#400, #850, #540, #935, #18) that clef changes have to appear in all layers in order to affect the susequent notes accordingly. The solution proposed in #400 was to insert a full clef change with all necessary attributes in the first layer and to add clef changes with a `@sameas` reference to the first in all others. This is now added to MusicXmlImport.

There is a ClefChangeStack that collects all clef changes and inserts them to the all layers in the right measure, staff, and time stamp (before a note/rest/space is inserted or at the end of a measure).

