### PR TITLE
Cross-staff notes now imported from MusicXML.

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -160,7 +160,7 @@ private:
     void ReadMusicXmlFigures(pugi::xml_node node, Measure *measure, std::string measureNum);
     void ReadMusicXmlForward(pugi::xml_node, Measure *measure, std::string measureNum);
     void ReadMusicXmlHarmony(pugi::xml_node, Measure *measure, std::string measureNum);
-    void ReadMusicXmlNote(pugi::xml_node, Measure *measure, std::string measureNum);
+    void ReadMusicXmlNote(pugi::xml_node, Measure *measure, std::string measureNum, int staffOffset);
     void ReadMusicXmlPrint(pugi::xml_node, Section *section);
     ///@}
 

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -92,10 +92,11 @@ namespace musicxml {
         std::string m_endingType;
         std::string m_endingText;
     };
-    
+
     class ClefChange {
     public:
-        ClefChange(const std::string &measureNum, Staff *staff, Clef *clef, const int &scoreOnset) {
+        ClefChange(const std::string &measureNum, Staff *staff, Clef *clef, const int &scoreOnset)
+        {
             m_measureNum = measureNum;
             m_staff = staff;
             m_clef = clef;
@@ -108,7 +109,7 @@ namespace musicxml {
         int m_scoreOnset; // the score position of clef change
         bool isFirst = true; // insert clef change at first layer, others use @sameas
     };
-    
+
 } // namespace musicxml
 
 //----------------------------------------------------------------------------

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -213,22 +213,23 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element)
 
 Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
 {
+    // Find voice number of node
     int layerNum = 1;
-    // first find if voice number corresponds to an existing layer number in any staff (as with cross-staff notes).
+    std::string layerNumStr = GetContentOfChild(node, "voice");
+    if (!layerNumStr.empty()) {
+        layerNum = atoi(layerNumStr.c_str());
+    }
+    if (layerNum < 1) {
+        LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
+        layerNum = 1;
+    }
+    // Check if voice number corresponds to an existing layer number in any staff (as with cross-staff notes).
     for (auto item : *measure->GetChildren()) {
         Staff *staff = dynamic_cast<Staff *>(item);
         assert(staff);
         for (auto layer : *staff->GetChildren()) {
             assert(layer);
             // Now look for the layer with the corresponding voice
-            std::string layerNumStr = GetContentOfChild(node, "voice");
-            if (!layerNumStr.empty()) {
-                layerNum = atoi(layerNumStr.c_str());
-            }
-            if (layerNum < 1) {
-                LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
-                layerNum = 1;
-            }
             if (layerNum == dynamic_cast<Layer *>(layer)->GetN()) {
                 return SelectLayer(layerNum, staff);
             }
@@ -247,16 +248,6 @@ Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
     staffNum--;
     Staff *staff = dynamic_cast<Staff *>(measure->GetChild(staffNum));
     assert(staff);
-    // Now look for the layer with the corresponding voice
-    layerNum = 1;
-    std::string layerNumStr = GetContentOfChild(node, "voice");
-    if (!layerNumStr.empty()) {
-        layerNum = atoi(layerNumStr.c_str());
-    }
-    if (layerNum < 1) {
-        LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
-        layerNum = 1;
-    }
     return SelectLayer(layerNum, staff);
 }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -213,6 +213,29 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element)
 
 Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
 {
+    int layerNum = 1;
+    // first find if voice number corresponds to an existing layer number in any staff (as with cross-staff notes).
+    for (auto item : *measure->GetChildren()) {
+        Staff *staff = dynamic_cast<Staff *>(item);
+        assert(staff);
+        for (auto layer : *staff->GetChildren()) {
+            assert(layer);
+            // Now look for the layer with the corresponding voice
+            std::string layerNumStr = GetContentOfChild(node, "voice");
+            if (!layerNumStr.empty()) {
+                layerNum = atoi(layerNumStr.c_str());
+            }
+            if (layerNum < 1) {
+                LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
+                layerNum = 1;
+            }
+            if (layerNum == dynamic_cast<Layer *>(layer)->GetN()) {
+                LogWarning("SelectLayer finds layer %d in %s.", layerNum, staff->GetUuid().c_str());
+                return SelectLayer(layerNum, staff);
+            }
+        }
+    }
+    // if not, take staff info of node element
     int staffNum = 1;
     std::string staffNumStr = GetContentOfChild(node, "staff");
     if (!staffNumStr.empty()) {
@@ -226,15 +249,16 @@ Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
     Staff *staff = dynamic_cast<Staff *>(measure->GetChild(staffNum));
     assert(staff);
     // Now look for the layer with the corresponding voice
-    int layerNum = 1;
+    layerNum = 1;
     std::string layerNumStr = GetContentOfChild(node, "voice");
     if (!layerNumStr.empty()) {
         layerNum = atoi(layerNumStr.c_str());
     }
     if (layerNum < 1) {
-        LogWarning("MusicXML import: Layer %d cannot be found", staffNum);
+        LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
         layerNum = 1;
     }
+    LogWarning("SelectLayer classic: layer %d in %s.", layerNum, staff->GetUuid().c_str());
     return SelectLayer(layerNum, staff);
 }
 
@@ -989,7 +1013,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
             ReadMusicXmlHarmony(*it, measure, measureNum);
         }
         else if (IsElement(*it, "note")) {
-            ReadMusicXmlNote(*it, measure, measureNum);
+            ReadMusicXmlNote(*it, measure, measureNum, staffOffset);
         }
         // for now only check first part
         else if (IsElement(*it, "print") && node.select_node("parent::part[not(preceding-sibling::part)]")) {
@@ -1489,7 +1513,7 @@ void MusicXmlInput::ReadMusicXmlHarmony(pugi::xml_node node, Measure *measure, s
     m_harmStack.push_back(harm);
 }
 
-void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std::string measureNum)
+void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std::string measureNum, int staffOffset)
 {
     assert(node);
     assert(measure);
@@ -1646,6 +1670,12 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             note->SetUuid(node.attribute("xml:id").as_string());
         }
         note->SetScoreTimeOnset(onset); // remember the MIDI onset within that measure
+        int noteStaffNum = atoi(GetContentOfChild(node, "staff").c_str());
+        LogMessage("MusixXmlInput::Note: %s noteStaffNum: %d, staffOffset: %d, staffNum: %d.",
+                   note->GetUuid().c_str(), noteStaffNum, staffOffset, staff->GetN());
+        // set @staff attribute, if existing and different from parent staff number
+        if (noteStaffNum > 0 && noteStaffNum + staffOffset != staff->GetN())
+            note->SetStaff(note->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(noteStaffNum + staffOffset)));
 
         // accidental
         pugi::xpath_node accidental = node.select_node("accidental");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -230,7 +230,6 @@ Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
                 layerNum = 1;
             }
             if (layerNum == dynamic_cast<Layer *>(layer)->GetN()) {
-                LogWarning("SelectLayer finds layer %d in %s.", layerNum, staff->GetUuid().c_str());
                 return SelectLayer(layerNum, staff);
             }
         }
@@ -258,7 +257,6 @@ Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
         LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
         layerNum = 1;
     }
-    LogWarning("SelectLayer classic: layer %d in %s.", layerNum, staff->GetUuid().c_str());
     return SelectLayer(layerNum, staff);
 }
 
@@ -654,7 +652,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         for (musicxml::ClefChange iter : m_ClefChangeStack) {
             if (iter.isFirst)
                 LogWarning("MusicXML import: Clef change at measure %s, staff %d, time %d not inserted.",
-                           iter.m_measureNum.c_str(), iter.m_staff->GetN(), iter.m_scoreOnset);
+                    iter.m_measureNum.c_str(), iter.m_staff->GetN(), iter.m_scoreOnset);
         }
         m_ClefChangeStack.clear();
     }
@@ -1092,7 +1090,7 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         // check if we have a staff number
         int staffNum = clef.node().attribute("number").as_int();
         staffNum = (staffNum < 1) ? 1 : staffNum;
-        Staff *staff = dynamic_cast<Staff *>(measure->GetChild(staffNum-1));
+        Staff *staff = dynamic_cast<Staff *>(measure->GetChild(staffNum - 1));
         assert(staff);
         pugi::xpath_node clefSign = clef.node().select_node("sign");
         pugi::xpath_node clefLine = clef.node().select_node("line");
@@ -1671,11 +1669,10 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
         }
         note->SetScoreTimeOnset(onset); // remember the MIDI onset within that measure
         int noteStaffNum = atoi(GetContentOfChild(node, "staff").c_str());
-        LogMessage("MusixXmlInput::Note: %s noteStaffNum: %d, staffOffset: %d, staffNum: %d.",
-                   note->GetUuid().c_str(), noteStaffNum, staffOffset, staff->GetN());
         // set @staff attribute, if existing and different from parent staff number
         if (noteStaffNum > 0 && noteStaffNum + staffOffset != staff->GetN())
-            note->SetStaff(note->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(noteStaffNum + staffOffset)));
+            note->SetStaff(
+                note->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(noteStaffNum + staffOffset)));
 
         // accidental
         pugi::xpath_node accidental = node.select_node("accidental");
@@ -1845,7 +1842,8 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             // color
             tie->SetColor(startTie.node().attribute("color").as_string());
             // placement and orientation
-            tie->SetCurvedir(               tie->AttCurvature::StrToCurvatureCurvedir(startTie.node().attribute("placement").as_string()));
+            tie->SetCurvedir(
+                tie->AttCurvature::StrToCurvatureCurvedir(startTie.node().attribute("placement").as_string()));
             if (!startTie.node().attribute("orientation").empty()) { // override only with non-empty attribute
                 tie->SetCurvedir(ConvertOrientationToCurvedir(startTie.node().attribute("orientation").as_string()));
             }


### PR DESCRIPTION
Cross-staff notes were assigned to the staff according to the `@staff` attribute in the musicXML note. Thus, a voice crossing staffs may have created two parallel layers in each staff that were not aligned to each other.

This example in Finale (code below):
<img width="487" alt="Bach_Invention_12-excerpt-Finale" src="https://user-images.githubusercontent.com/45632600/58158958-c8036c80-7c7b-11e9-93b8-2de0d44bbd4e.png">

...would appear like this in Verovio (code below):
<img width="460" alt="Bach_Invention_12-excerpt-Verovio" src="https://user-images.githubusercontent.com/45632600/58158996-d8b3e280-7c7b-11e9-97ac-93aac7318752.png">

The current approach uses the `@voice` information from musicXML to determine the relevant layer in all possible staves (added to `MusicXmlInput::SelectLayer`), and only if unsuccessful to select a layer as before.

I tested the code with several piano, voice/piano and orchestral scores and I am grateful for more testing. 

Known issues/questions: 
1) This solution does not work properly, when the layer starts with the cross-staff note in a given measure. In this rare case, it would be assigned to the wrong staff. 
2) Currently, the `@staff` attribute is added only to notes. In case of chords, we should probably write it to the chord instead?

Source musicXML of example: 
```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <movement-title>Invention Nr. 12</movement-title>
  <identification>
    <encoding>
      <software>Finale v26 for Mac</software>
      <encoding-date>2019-05-14</encoding-date>
      <supports attribute="new-system" element="print" type="yes" value="yes"/>
      <supports attribute="new-page" element="print" type="yes" value="yes"/>
      <supports element="accidental" type="yes"/>
      <supports element="beam" type="yes"/>
      <supports element="stem" type="yes"/>
    </encoding>
  </identification>
  <defaults>
    <scaling>
      <millimeters>6.791</millimeters>
      <tenths>40</tenths>
    </scaling>
    <page-layout>
      <page-height>1749</page-height>
      <page-width>1236</page-width>
      <page-margins type="both">
        <left-margin>85</left-margin>
        <right-margin>75</right-margin>
        <top-margin>94</top-margin>
        <bottom-margin>94</bottom-margin>
      </page-margins>
    </page-layout>
    <system-layout>
      <system-margins>
        <left-margin>0</left-margin>
        <right-margin>0</right-margin>
      </system-margins>
      <system-distance>100</system-distance>
      <top-system-distance>46</top-system-distance>
    </system-layout>
    <staff-layout>
      <staff-distance>74</staff-distance>
    </staff-layout>
    <appearance>
      <line-width type="stem">0.7487</line-width>
      <line-width type="beam">5</line-width>
      <line-width type="staff">0.7487</line-width>
      <line-width type="light barline">0.7487</line-width>
      <line-width type="heavy barline">5</line-width>
      <line-width type="leger">0.7487</line-width>
      <line-width type="ending">1.4583</line-width>
      <line-width type="wedge">0.7487</line-width>
      <line-width type="enclosure">0.7487</line-width>
      <line-width type="tuplet bracket">0.7487</line-width>
      <note-size type="grace">60</note-size>
      <note-size type="cue">60</note-size>
      <distance type="hyphen">120</distance>
      <distance type="beam">8</distance>
    </appearance>
    <music-font font-family="Maestro,engraved" font-size="19.25"/>
    <word-font font-family="Times New Roman" font-size="9.6"/>
  </defaults>
  <credit page="1">
    <credit-type>title</credit-type>
    <credit-words default-x="623" default-y="1665" font-size="24" justify="center" valign="top">Invention Nr. 12</credit-words>
  </credit>
  <credit page="1">
    <credit-words default-x="1162" default-y="1609" font-size="12" justify="right" valign="top">J.S. Bach (1685–1750)</credit-words>
  </credit>
  <credit page="1">
    <credit-words default-x="621" default-y="56" font-size="9" font-style="italic" justify="center" valign="bottom">Finale</credit-words>
    <credit-words font-size="5" font-style="italic">®</credit-words>
    <credit-words font-size="9" font-style="italic" xml:lang="de">-Arbeitsblätter</credit-words>
    <credit-words font-size="9" font-style="normal" xml:space="preserve">, Copyright © 2010 by MakeMusic, Inc.
</credit-words>
    <credit-words font-size="7" xml:lang="de" xml:space="preserve">MakeMusic erlaubt die Vervielfältigung dieser Arbeitsblätter nur für nichtkommerzielle Unterrichtsszwecke und unter der Voraussetzung, dass dieser Copryright-Hinweis auf jeder Kopie erscheint.
  Kopien dürfen nicht verkauft oder in anderen zum Verkauf angebotenen Materialien enthalten sein.</credit-words>
  </credit>
  <credit page="2">
    <credit-type>page number</credit-type>
    <credit-type>title</credit-type>
    <credit-words default-x="623" default-y="1690" font-size="12" justify="center" valign="top">Invention Nr. 12, S. 2</credit-words>
  </credit>
  <part-list>
    <score-part id="P1">
      <part-name print-object="no">MusicXML Part</part-name>
      <score-instrument id="P1-I1">
        <instrument-name>SmartMusic SoftSynth</instrument-name>
        <instrument-sound>keyboard.piano</instrument-sound>
        <virtual-instrument/>
      </score-instrument>
      <midi-device>MakeMusic: SmartMusicSoftSynth</midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>1</midi-program>
        <volume>80</volume>
        <pan>0</pan>
      </midi-instrument>
    </score-part>
  </part-list>
  <!--=========================================================-->
  <part id="P1">    
    <measure number="17" width="471">
      <print page-number="1">
        <system-layout>
          <system-margins>
            <left-margin>75</left-margin>
            <right-margin>0</right-margin>
          </system-margins>
          <top-system-distance>135</top-system-distance>
        </system-layout>
        <measure-numbering>system</measure-numbering>
      </print>
      <attributes>
        <divisions>4</divisions>
        <key>
          <fifths>3</fifths>
          <mode>major</mode>
        </key>
        <time>
          <beats>12</beats>
          <beat-type>8</beat-type>
        </time>
        <staves>2</staves>
        <clef number="1">
          <sign>G</sign>
          <line>2</line>
        </clef>
        <clef number="2">
          <sign>F</sign>
          <line>4</line>
        </clef>
      </attributes>     <note default-x="14">
        <pitch>
          <step>E</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-5">up</stem>
        <staff>1</staff>
      </note>
      <note default-x="51">
        <rest/>
        <duration>2</duration>
        <voice>1</voice>
        <type>eighth</type>
        <staff>1</staff>
      </note>
      <note default-x="90">
        <rest/>
        <duration>2</duration>
        <voice>1</voice>
        <type>eighth</type>
        <staff>1</staff>
      </note>
      <note default-x="130">
        <rest/>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <staff>1</staff>
      </note>
      <note default-x="149">
        <pitch>
          <step>F</step>
          <alter>1</alter>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="114">up</stem>
        <staff>2</staff>
        <beam number="1">begin</beam>
        <beam number="2">begin</beam>
      </note>
      <note default-x="167">
        <pitch>
          <step>A</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="114">up</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="189">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="114">up</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="209">
        <pitch>
          <step>F</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="0">up</stem>
        <staff>1</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="228">
        <pitch>
          <step>E</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="0">up</stem>
        <staff>1</staff>
        <beam number="1">end</beam>
        <beam number="2">end</beam>
      </note>
      <note default-x="246">
        <pitch>
          <step>D</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-11">up</stem>
        <staff>1</staff>
      </note>
      <note default-x="284">
        <rest/>
        <duration>2</duration>
        <voice>1</voice>
        <type>eighth</type>
        <staff>1</staff>
      </note>
      <note default-x="322">
        <rest/>
        <duration>2</duration>
        <voice>1</voice>
        <type>eighth</type>
        <staff>1</staff>
      </note>
      <note default-x="359">
        <rest/>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <staff>1</staff>
      </note>
      <note default-x="378">
        <pitch>
          <step>E</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="109">up</stem>
        <staff>2</staff>
        <beam number="1">begin</beam>
        <beam number="2">begin</beam>
      </note>
      <note default-x="396">
        <pitch>
          <step>G</step>
          <alter>1</alter>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="109">up</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="415">
        <pitch>
          <step>B</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="109">up</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="433">
        <pitch>
          <step>E</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="-5">up</stem>
        <staff>1</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="452">
        <pitch>
          <step>D</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>16th</type>
        <stem default-y="-5">up</stem>
        <staff>1</staff>
        <beam number="1">end</beam>
        <beam number="2">end</beam>
      </note>
      <backup>
        <duration>24</duration>
      </backup>
      <note default-x="16">
        <rest>
          <display-step>D</display-step>
          <display-octave>3</display-octave>
        </rest>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <staff>2</staff>
      </note>
      <note default-x="32">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-57">down</stem>
        <staff>2</staff>
        <beam number="1">begin</beam>
        <beam number="2">begin</beam>
      </note>
      <note default-x="51">
        <pitch>
          <step>E</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-57">down</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="70">
        <pitch>
          <step>G</step>
          <alter>1</alter>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-56">down</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="90">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-56">down</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="111">
        <pitch>
          <step>B</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-55">down</stem>
        <staff>2</staff>
        <beam number="1">end</beam>
        <beam number="2">end</beam>
      </note>
      <note default-x="130">
        <pitch>
          <step>A</step>
          <octave>3</octave>
        </pitch>
        <duration>2</duration>
        <voice>2</voice>
        <type>eighth</type>
        <stem default-y="-35">down</stem>
        <staff>2</staff>
      </note>
      <note default-x="169">
        <rest>
          <display-step>B</display-step>
          <display-octave>2</display-octave>
        </rest>
        <duration>2</duration>
        <voice>2</voice>
        <type>eighth</type>
        <staff>2</staff>
      </note>
      <note default-x="210">
        <rest>
          <display-step>B</display-step>
          <display-octave>2</display-octave>
        </rest>
        <duration>2</duration>
        <voice>2</voice>
        <type>eighth</type>
        <staff>2</staff>
      </note>
      <note default-x="246">
        <rest/>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <staff>2</staff>
      </note>
      <note default-x="265">
        <pitch>
          <step>B</step>
          <octave>2</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-60">down</stem>
        <staff>2</staff>
        <beam number="1">begin</beam>
        <beam number="2">begin</beam>
      </note>
      <note default-x="284">
        <pitch>
          <step>D</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-60">down</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="302">
        <pitch>
          <step>F</step>
          <alter>1</alter>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-60">down</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="321">
        <pitch>
          <step>B</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-60">down</stem>
        <staff>2</staff>
        <beam number="1">continue</beam>
        <beam number="2">continue</beam>
      </note>
      <note default-x="340">
        <pitch>
          <step>A</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>2</voice>
        <type>16th</type>
        <stem default-y="-60">down</stem>
        <staff>2</staff>
        <beam number="1">end</beam>
        <beam number="2">end</beam>
      </note>
      <note default-x="359">
        <pitch>
          <step>G</step>
          <alter>1</alter>
          <octave>3</octave>
        </pitch>
        <duration>2</duration>
        <voice>2</voice>
        <type>eighth</type>
        <stem default-y="-39">down</stem>
        <staff>2</staff>
      </note>
      <note default-x="399">
        <rest>
          <display-step>B</display-step>
          <display-octave>2</display-octave>
        </rest>
        <duration>2</duration>
        <voice>2</voice>
        <type>eighth</type>
        <staff>2</staff>
      </note>
      <note default-x="435">
        <rest>
          <display-step>B</display-step>
          <display-octave>2</display-octave>
        </rest>
        <duration>2</duration>
        <voice>2</voice>
        <type>eighth</type>
        <staff>2</staff>
      </note>
    </measure>
  </part>
  <!--=========================================================-->
</score-partwise>
```

Resulting MEI code of example: 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Invention Nr. 12</title>
            </titleStmt>
            <pubStmt></pubStmt>
        </fileDesc>
        <encodingDesc xml:id="encodingdesc-0000000532669677">
            <appInfo xml:id="appinfo-0000001867420643">
                <application xml:id="application-0000000265245996" isodate="2019-05-21T22:38:38" version="2.1.0-dev-9058f0f">
                    <name xml:id="name-0000001960887247">Verovio</name>
                    <p xml:id="p-0000001347913467">Transcoded from MusicXML</p>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mdiv-0000000576647666">
                <score xml:id="score-0000000123623551">
                    <scoreDef xml:id="scoredef-0000000366037767">
                        <staffGrp xml:id="staffgrp-0000000180923612">
                            <staffGrp xml:id="staffgrp-0000001600632111" symbol="brace" bar.thru="true">
                                <instrDef xml:id="instrdef-0000002093786379" midi.channel="0" midi.instrnum="0" midi.volume="80.00%" />
                                <staffDef xml:id="staffdef-0000000296243608" clef.shape="G" clef.line="2" key.mode="major" key.sig="3s" meter.count="12" meter.unit="8" n="1" lines="5" ppq="4" />
                                <staffDef xml:id="staffdef-0000001364024904" clef.shape="F" clef.line="4" key.mode="major" key.sig="3s" meter.count="12" meter.unit="8" n="2" lines="5" ppq="4" />
                            </staffGrp>
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="section-0000001124335008">
                        <pb xml:id="pb-0000000989869503" />
                        <measure xml:id="measure-0000001858602707" n="17">
                            <staff xml:id="staff-0000001596220275" n="1">
                                <layer xml:id="layer-0000000779056727" n="1">
                                    <note xml:id="note-0000000398614930" dur.ppq="2" dur="8" oct="4" pname="e" stem.dir="up" />
                                    <rest xml:id="rest-0000001519633517" dur.ppq="2" dur="8" />
                                    <rest xml:id="rest-0000000457506448" dur.ppq="2" dur="8" />
                                    <rest xml:id="rest-0000001319415276" dur.ppq="1" dur="16" />
                                    <note xml:id="note-0000000897339587" dur.ppq="2" dur="8" oct="4" pname="d" stem.dir="up" />
                                    <rest xml:id="rest-0000001956269475" dur.ppq="2" dur="8" />
                                    <rest xml:id="rest-0000001046430755" dur.ppq="2" dur="8" />
                                    <rest xml:id="rest-0000001618114002" dur.ppq="1" dur="16" />
                                </layer>
                            </staff>
                            <staff xml:id="staff-0000001308443601" n="2">
                                <layer xml:id="layer-0000000496404810" n="1">
                                    <beam xml:id="beam-0000000101673075">
                                        <note xml:id="note-0000001569872160" dur.ppq="1" dur="16" oct="3" pname="f" stem.dir="up" accid.ges="s" />
                                        <note xml:id="note-0000001275465223" dur.ppq="1" dur="16" oct="3" pname="a" stem.dir="up" />
                                        <note xml:id="note-0000000562238607" dur.ppq="1" dur="16" oct="4" pname="c" stem.dir="up" accid.ges="s" />
                                        <note xml:id="note-0000001661024709" dur.ppq="1" dur="16" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                                        <note xml:id="note-0000000586276689" dur.ppq="1" dur="16" oct="4" pname="e" stem.dir="up" />
                                    </beam>
                                    <beam xml:id="beam-0000002056609653">
                                        <note xml:id="note-0000001689139506" dur.ppq="1" dur="16" oct="3" pname="e" stem.dir="up" />
                                        <note xml:id="note-0000001781347649" dur.ppq="1" dur="16" oct="3" pname="g" stem.dir="up" accid.ges="s" />
                                        <note xml:id="note-0000001424832338" dur.ppq="1" dur="16" oct="3" pname="b" stem.dir="up" />
                                        <note xml:id="note-0000000566957069" dur.ppq="1" dur="16" oct="4" pname="e" stem.dir="up" />
                                        <note xml:id="note-0000000462516944" dur.ppq="1" dur="16" oct="4" pname="d" stem.dir="up" />
                                    </beam>
                                </layer>
                                <layer xml:id="layer-0000001778959315" n="2">
                                    <rest xml:id="rest-0000001701873671" dur.ppq="1" dur="16" ploc="d" oloc="3" />
                                    <beam xml:id="beam-0000001056094104">
                                        <note xml:id="note-0000000821263473" dur.ppq="1" dur="16" oct="3" pname="c" stem.dir="down" accid.ges="s" />
                                        <note xml:id="note-0000001548754317" dur.ppq="1" dur="16" oct="3" pname="e" stem.dir="down" />
                                        <note xml:id="note-0000000264520532" dur.ppq="1" dur="16" oct="3" pname="g" stem.dir="down" accid.ges="s" />
                                        <note xml:id="note-0000001498371553" dur.ppq="1" dur="16" oct="4" pname="c" stem.dir="down" accid.ges="s" />
                                        <note xml:id="note-0000001929000784" dur.ppq="1" dur="16" oct="3" pname="b" stem.dir="down" />
                                    </beam>
                                    <note xml:id="note-0000000155557929" dur.ppq="2" dur="8" oct="3" pname="a" stem.dir="down" />
                                    <rest xml:id="rest-0000000974514304" dur.ppq="2" dur="8" ploc="b" oloc="2" />
                                    <rest xml:id="rest-0000001951615306" dur.ppq="2" dur="8" ploc="b" oloc="2" />
                                    <rest xml:id="rest-0000000133223664" dur.ppq="1" dur="16" />
                                    <beam xml:id="beam-0000001412160674">
                                        <note xml:id="note-0000000195181274" dur.ppq="1" dur="16" oct="2" pname="b" stem.dir="down" />
                                        <note xml:id="note-0000001204143149" dur.ppq="1" dur="16" oct="3" pname="d" stem.dir="down" />
                                        <note xml:id="note-0000000148015915" dur.ppq="1" dur="16" oct="3" pname="f" stem.dir="down" accid.ges="s" />
                                        <note xml:id="note-0000000148362993" dur.ppq="1" dur="16" oct="3" pname="b" stem.dir="down" />
                                        <note xml:id="note-0000000308309184" dur.ppq="1" dur="16" oct="3" pname="a" stem.dir="down" />
                                    </beam>
                                    <note xml:id="note-0000002021898924" dur.ppq="2" dur="8" oct="3" pname="g" stem.dir="down" accid.ges="s" />
                                    <rest xml:id="rest-0000000670031612" dur.ppq="2" dur="8" ploc="b" oloc="2" />
                                    <rest xml:id="rest-0000001964541663" dur.ppq="2" dur="8" ploc="b" oloc="2" />
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
