### PR TITLE
Last System Justification: Use parameter to set minimum width for justification.

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1216,11 +1216,12 @@ public:
  * member 2: the non justifiable margin
  * member 3: the system full width (without system margins)
  * member 4: the functor to be redirected to the MeasureAligner
+ * member 5: the doc
  **/
 
 class JustifyXParams : public FunctorParams {
 public:
-    JustifyXParams(Functor *functor)
+    JustifyXParams(Functor *functor, Doc *doc)
     {
         m_measureXRel = 0;
         m_justifiableRatio = 1.0;
@@ -1228,6 +1229,7 @@ public:
         m_rightBarLineX = 0;
         m_systemFullWidth = 0;
         m_functor = functor;
+        m_doc = doc;
     }
     int m_measureXRel;
     double m_justifiableRatio;
@@ -1235,6 +1237,7 @@ public:
     int m_rightBarLineX;
     int m_systemFullWidth;
     Functor *m_functor;
+    Doc *m_doc;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -457,6 +457,7 @@ public:
     OptionBool m_landscape;
     OptionBool m_mensuralToMeasure;
     OptionDbl m_midiTempoAdjustment;
+    OptionDbl m_minLastJust;
     OptionBool m_mmOutput;
     OptionBool m_noFooter;
     OptionBool m_noHeader;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -457,7 +457,7 @@ public:
     OptionBool m_landscape;
     OptionBool m_mensuralToMeasure;
     OptionDbl m_midiTempoAdjustment;
-    OptionDbl m_minLastJust;
+    OptionDbl m_minLastJustification;
     OptionBool m_mmOutput;
     OptionBool m_noFooter;
     OptionBool m_noHeader;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -513,9 +513,9 @@ Options::Options()
     m_midiTempoAdjustment.Init(1.0, 0.2, 4.0);
     this->Register(&m_midiTempoAdjustment, "midiTempoAdjustment", &m_generalLayout);
 
-    m_minLastJust.SetInfo("Minimum last-system-justification width", "The last system is only justified if the unjustified width is greater than this percent");
-    m_minLastJust.Init(0.8, 0.0, 1.0);
-    this->Register(&m_minLastJust, "minLastJust", &m_general);
+    m_minLastJustification.SetInfo("Minimum last-system-justification width", "The last system is only justified if the unjustified width is greater than this percent");
+    m_minLastJustification.Init(0.8, 0.0, 1.0);
+    this->Register(&m_minLastJustification, "minLastJustification", &m_general);
 
     m_mmOutput.SetInfo("MM output", "Specify that the output in the SVG is given in mm (default is px)");
     m_mmOutput.Init(false);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -513,6 +513,10 @@ Options::Options()
     m_midiTempoAdjustment.Init(1.0, 0.2, 4.0);
     this->Register(&m_midiTempoAdjustment, "midiTempoAdjustment", &m_generalLayout);
 
+    m_minLastJust.SetInfo("Minimum last-system-justification width", "The last system is only justified if the unjustified width is greater than this percent");
+    m_minLastJust.Init(0.8, 0.0, 1.0);
+    this->Register(&m_minLastJust, "minLastJust", &m_general);
+
     m_mmOutput.SetInfo("MM output", "Specify that the output in the SVG is given in mm (default is px)");
     m_mmOutput.Init(false);
     this->Register(&m_mmOutput, "mmOutput", &m_general);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -461,7 +461,7 @@ void Page::JustifyHorizontally()
 
     // Justify X position
     Functor justifyX(&Object::JustifyX);
-    JustifyXParams justifyXParams(&justifyX);
+    JustifyXParams justifyXParams(&justifyX, doc);
     justifyXParams.m_systemFullWidth
         = doc->m_drawingPageWidth - doc->m_drawingPageMarginLeft - doc->m_drawingPageMarginRight;
     this->Process(&justifyX, &justifyXParams);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -596,9 +596,8 @@ int System::JustifyX(FunctorParams *functorParams)
     // do not justify it if the non-justified width is less than a specified percent.
     if ((parent->GetIdx() == parent->GetParent()->GetChildCount() - 1)
         && (this->GetIdx() == parent->GetChildCount() - 1)) {
-        // TODO: Get this from the option.
-        double minLastJust = 0.8;
-        if (minLastJust > 0 && params->m_justifiableRatio > (1/minLastJust)) {
+        double minLastJust = params->m_doc->GetOptions()->m_minLastJustification.GetValue();
+        if ((minLastJust > 0) && (params->m_justifiableRatio > (1/minLastJust))) {
             return FUNCTOR_STOP;
         }
     }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -592,12 +592,13 @@ int System::JustifyX(FunctorParams *functorParams)
         LogWarning("\tDrawing justifiable width: %d", m_drawingJustifiableWidth);
     }
 
-    // Check if we are on the last page and on the last system - do no justify it if ratio > 1.25
-    // Eventually we should make this a parameter
+    // Check if we are on the last page and on the last system:
+    // do not justify it if the non-justified width is less than a specified percent.
     if ((parent->GetIdx() == parent->GetParent()->GetChildCount() - 1)
         && (this->GetIdx() == parent->GetChildCount() - 1)) {
-        // HARDCODED
-        if (params->m_justifiableRatio > 1.25) {
+        // TODO: Get this from the option.
+        double minLastJust = 0.8;
+        if (minLastJust > 0 && params->m_justifiableRatio > (1/minLastJust)) {
             return FUNCTOR_STOP;
         }
     }


### PR DESCRIPTION
https://github.com/rism-ch/verovio/issues/198#issuecomment-232763469 allowed the last line to be justified if it was 80% or more* of the width.

This PR hopes to make it possible to pass this as a parameter.