### PR TITLE
MusicXml Import: Support for arpeggios

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -23,6 +23,7 @@
 
 namespace vrv {
 
+class Arpeg;
 class Clef;
 class ControlElement;
 class Dir;
@@ -77,6 +78,18 @@ namespace musicxml {
 
         int m_dirN;
         int m_lastMeasureCount;
+    };
+
+    class OpenArpeggio {
+    public:
+        OpenArpeggio(const int &arpegN, const int &timeStamp)
+        {
+            m_arpegN = arpegN;
+            m_timeStamp = timeStamp;
+        }
+
+        int m_arpegN;
+        int m_timeStamp;
     };
 
     class EndingInfo {
@@ -328,6 +341,8 @@ private:
     std::vector<std::pair<std::string, ControlElement *> > m_controlElements;
     /* stack of clef changes to be inserted to all layers of a given staff */
     std::vector<musicxml::ClefChange> m_ClefChangeStack;
+    /* stack of new arpeggios that get more notes added. */
+    std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio> > m_ArpeggioStack;
     /* a map for the measure counts storing the index of each measure created */
     std::map<Measure *, int> m_measureCounts;
 };

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2042,24 +2042,19 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
 
     // arpeggio
     pugi::xpath_node xmlArpeggiate = notations.node().select_node("arpeggiate");
-    pugi::xpath_node chord = node.select_node("chord");
+    pugi::xpath_node isChord = node.select_node("chord");
     if (xmlArpeggiate) {
         int arpegN = xmlArpeggiate.node().attribute("number").as_int();
         arpegN = (arpegN < 1) ? 1 : arpegN;
         std::string direction = xmlArpeggiate.node().attribute("direction").as_string();
-        LogMessage(
-            "Measure %s/%f(%d): ReadMusixXmlnote: arpeggiate n: %d.", measureNum.c_str(), onset, m_durTotal, arpegN);
         bool added = false;
         if (!m_ArpeggioStack.empty()) { // check existing arpeggios
             std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio> >::iterator iter;
             for (iter = m_ArpeggioStack.begin(); iter != m_ArpeggioStack.end(); ++iter) {
                 if (iter->second.m_arpegN == arpegN && onset == iter->second.m_timeStamp) {
-                    if (!chord) {
-                        iter->first->GetPlistInterface()->AddRef("#" + element->GetUuid());
-                        LogMessage("Old %s amended with Measure %s/%f(%d): %s added.", iter->first->GetUuid().c_str(),
-                            measureNum.c_str(), onset, m_durTotal, m_ID.c_str());
-                    }
-                    added = true;
+                    // don't add other chord notes, because the chord is already referenced.
+                    if (!isChord) iter->first->GetPlistInterface()->AddRef("#" + element->GetUuid());
+                    added = true; // so that no new Arpeg gets created below
                     break;
                 }
             }
@@ -2067,17 +2062,20 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
         if (!added) {
             Arpeg *arpeggio = new Arpeg();
             arpeggio->GetPlistInterface()->AddRef("#" + element->GetUuid());
-            m_ArpeggioStack.push_back(std::make_pair(arpeggio, musicxml::OpenArpeggio(arpegN, onset)));
+            // color
+            arpeggio->SetColor(xmlArpeggiate.node().attribute("color").as_string());
+            // direction (up/down) and in MEI arrow
             if (!direction.empty()) {
                 arpeggio->SetArrow(BOOLEAN_true);
                 if (direction == "up")
                     arpeggio->SetOrder(arpegLog_ORDER_up);
                 else if (direction == "down")
                     arpeggio->SetOrder(arpegLog_ORDER_down);
+                else
+                    arpeggio->SetOrder(arpegLog_ORDER_NONE);
             }
+            m_ArpeggioStack.push_back(std::make_pair(arpeggio, musicxml::OpenArpeggio(arpegN, onset)));
             m_controlElements.push_back(std::make_pair(measureNum, arpeggio));
-            LogMessage("Measure %s/%f(%d): New %s created with %s.", measureNum.c_str(), onset, m_durTotal,
-                arpeggio->GetUuid().c_str(), m_ID.c_str());
         }
     }
 


### PR DESCRIPTION
Support for arpeggio import from MusicXml added (including parsing of `@number`, `@direction`, and `@color`). Relevant noteIds are collected and added to the `@plist` attribute of `<arpeg>`. 