### PR TITLE
MusicXML Import: prevent Adding Clef to a Chord error.

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -208,16 +208,8 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element)
     if (m_elementStack.empty()) {
         layer->AddChild(element);
     }
-    else {
-        if (element->Is(CLEF)) {
-            std::vector<LayerElement *>::reverse_iterator riter;
-            for (riter = m_elementStack.rbegin(); riter != m_elementStack.rend(); ++riter) {
-                if (!(*riter)->Is(CHORD)) (*riter)->AddChild(element);
-            }
-        }
-        else
-            (m_elementStack.back()->AddChild(element));
-    }
+    else
+        (m_elementStack.back()->AddChild(element));
 }
 
 Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
@@ -1553,11 +1545,14 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
     Staff *staff = dynamic_cast<Staff *>(layer->GetFirstParent(STAFF));
     assert(staff);
 
+    pugi::xpath_node isChord = node.select_node("chord");
+
     // add clef changes to all layers of a given measure, staff, and time stamp
     if (!m_ClefChangeStack.empty()) {
         std::vector<musicxml::ClefChange>::iterator iter;
         for (iter = m_ClefChangeStack.begin(); iter != m_ClefChangeStack.end(); iter++) {
-            if (iter->m_measureNum == measureNum && iter->m_staff == staff && iter->m_scoreOnset == m_durTotal) {
+            if (iter->m_measureNum == measureNum && iter->m_staff == staff && iter->m_scoreOnset == m_durTotal
+                && !isChord) {
                 if (iter->isFirst) { // add clef when first in staff
                     AddLayerElement(layer, iter->m_clef);
                     iter->isFirst = false;
@@ -2080,7 +2075,6 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
 
     // arpeggio
     pugi::xpath_node xmlArpeggiate = notations.node().select_node("arpeggiate");
-    pugi::xpath_node isChord = node.select_node("chord");
     if (xmlArpeggiate) {
         int arpegN = xmlArpeggiate.node().attribute("number").as_int();
         arpegN = (arpegN < 1) ? 1 : arpegN;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -208,8 +208,16 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element)
     if (m_elementStack.empty()) {
         layer->AddChild(element);
     }
-    else
-        (m_elementStack.back()->AddChild(element));
+    else {
+        if (element->Is(CLEF)) {
+            std::vector<LayerElement *>::reverse_iterator riter;
+            for (riter = m_elementStack.rbegin(); riter != m_elementStack.rend(); ++riter) {
+                if (!(*riter)->Is(CHORD)) (*riter)->AddChild(element);
+            }
+        }
+        else
+            (m_elementStack.back()->AddChild(element));
+    }
 }
 
 Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)


### PR DESCRIPTION
This commit fixes bug that created frequent error messages of Clefs being added to Chords (`[Error] Adding 'Clef' to a 'Chord'`), introduced by last commit on arpeggios (https://github.com/rism-ch/verovio/commit/3b3e69065b3ed294c108f1d407354beb549df200).