### PR TITLE
Remove OUTLINING_LIMIT setting

### DIFF
--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -39,7 +39,6 @@ $FLAGS .= " -DNDEBUG";
 $FLAGS .= " --memory-init-file 0";
 $FLAGS .= " -std=c++11";
 $FLAGS .= " -s ASM_JS=1";
-$FLAGS .= " -s OUTLINING_LIMIT=10000";
 $FLAGS .= " -s TOTAL_MEMORY=256*1024*1024";
 $FLAGS .= " -s TOTAL_STACK=128*1024*1024";
 $FLAGS .= " -s WASM=0";


### PR DESCRIPTION
This setting is removed from versions of emscripten over 1.38.31 and
using it will cause builds to fail. Resolves rism-ch/verovio#1093.