### PR TITLE
* MusicXML Barlines: Parse "regular" bar-styles properly

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2279,14 +2279,15 @@ data_BARRENDITION MusicXmlInput::ConvertStyleToRend(std::string value, bool repe
     if (value == "dashed") return BARRENDITION_dashed;
     if (value == "dotted") return BARRENDITION_dotted;
     if (value == "light-light") return BARRENDITION_dbl;
-    if (value == "regular") return BARRENDITION_dbldashed;
-    if (value == "regular") return BARRENDITION_dbldotted;
+    // if (value == "heavy-heavy") return; // TODO: Support Double thick barlines.
     if ((value == "light-heavy") && !repeat) return BARRENDITION_end;
     if (value == "none") return BARRENDITION_invis;
     if ((value == "heavy-light") && repeat) return BARRENDITION_rptstart;
     // if (value == "") return BARRENDITION_rptboth;
     if ((value == "light-heavy") && repeat) return BARRENDITION_rptend;
     if (value == "regular") return BARRENDITION_single;
+    // if (value == "short") return; // TODO: Support 'short' barlines.
+    // if (value == "tick") return; // TODO: Support 'tick' barlines.
     LogWarning("MusicXML import: Unsupported bar-style '%s'", value.c_str());
     return BARRENDITION_NONE;
 }


### PR DESCRIPTION
This fixes a bug where barlines with explicit "regular" bar-style are rendered as double dashed bar lines.