### PR TITLE
MusicXmlImport: dashes imported as @extender for <dir> and <dynam>

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -123,6 +123,20 @@ namespace musicxml {
         bool isFirst = true; // insert clef change at first layer, others use @sameas
     };
 
+    class OpenDashes {
+    public:
+        OpenDashes(const int &dirN, int &staffNum, const int &measureCount)
+        {
+            m_dirN = dirN;
+            m_staffNum = staffNum;
+            m_measureCount = measureCount;
+        }
+
+        int m_dirN; // direction number
+        int m_staffNum;
+        int m_measureCount; // measure number of dashes start
+    };
+
 } // namespace musicxml
 
 //----------------------------------------------------------------------------
@@ -327,6 +341,8 @@ private:
     std::vector<std::tuple<int, double, musicxml::OpenHairpin> > m_hairpinStopStack;
     /* The stack of endings to be inserted at the end of XML import */
     std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> > m_endingStack;
+    /* The stack of open dashes (direction-type) containing *ControlElement, OpenDashes */
+    std::vector<std::pair<ControlElement *, musicxml::OpenDashes> > m_openDashesStack;
     /* The stacks for ControlElements */
     std::vector<Dir *> m_dirStack;
     std::vector<Dynam *> m_dynamStack;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -938,8 +938,8 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, int 
     if (!m_openDashesStack.empty()) { // open dashes without ending
         std::vector<std::pair<ControlElement *, musicxml::OpenDashes> >::iterator iter;
         for (iter = m_openDashesStack.begin(); iter != m_openDashesStack.end(); ++iter) {
-            LogWarning("MusicXML import: Dashes/extender lines for '%s' could not be closed.",
-                iter->first->GetUuid().c_str());
+            LogWarning(
+                "MusicXML import: Dashes/extender lines for '%s' could not be closed.", iter->first->GetUuid().c_str());
         }
         m_openDashesStack.clear();
     }
@@ -1379,7 +1379,8 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     Dynam *dynam = dynamic_cast<Dynam *>(riter->second);
                     std::vector<int> staffAttr = dynam->GetStaff();
                     if (std::find(staffAttr.begin(), staffAttr.end(), staffNum + staffOffset) != staffAttr.end()
-                        && dynam->GetPlace() == dynam->AttPlacement::StrToStaffrel(placeStr.c_str())) {
+                        && dynam->GetPlace() == dynam->AttPlacement::StrToStaffrel(placeStr.c_str())
+                        && riter->first == measureNum) {
                         dynam->SetExtender(BOOLEAN_true);
                         controlElement = dynam;
                         break;
@@ -1389,15 +1390,22 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     Dir *dir = dynamic_cast<Dir *>(riter->second);
                     std::vector<int> staffAttr = dir->GetStaff();
                     if (std::find(staffAttr.begin(), staffAttr.end(), staffNum + staffOffset) != staffAttr.end()
-                        && dir->GetPlace() == dir->AttPlacement::StrToStaffrel(placeStr.c_str())) {
+                        && dir->GetPlace() == dir->AttPlacement::StrToStaffrel(placeStr.c_str())
+                        && riter->first == measureNum) {
                         dir->SetExtender(BOOLEAN_true);
                         controlElement = dir;
                         break;
                     }
                 }
             }
-            musicxml::OpenDashes openDashes(dashesNumber, staffNum, m_measureCounts.at(measure));
-            m_openDashesStack.push_back(std::make_pair(controlElement, openDashes));
+            if (controlElement != nullptr) {
+                musicxml::OpenDashes openDashes(dashesNumber, staffNum, m_measureCounts.at(measure));
+                m_openDashesStack.push_back(std::make_pair(controlElement, openDashes));
+            }
+            else {
+                LogMessage("MusicXmlImport: dashes could not be matched to <dir> or <dynam> in measure %s.",
+                    measureNum.c_str());
+            }
         }
     }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -938,8 +938,7 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, int 
     if (!m_openDashesStack.empty()) { // open dashes without ending
         std::vector<std::pair<ControlElement *, musicxml::OpenDashes> >::iterator iter;
         for (iter = m_openDashesStack.begin(); iter != m_openDashesStack.end(); ++iter) {
-            LogWarning("MusicXML import: Dashes ending for element '%s' could not be "
-                       "matched to a start element.",
+            LogWarning("MusicXML import: Dashes/extender lines for '%s' could not be closed.",
                 iter->first->GetUuid().c_str());
         }
         m_openDashesStack.clear();

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1361,6 +1361,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     if (iter->first->Is(DIR))
                         dynamic_cast<Dir *>(iter->first)
                             ->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                    m_openDashesStack.erase(iter--);
                 }
             }
         }
@@ -1370,14 +1371,22 @@ void MusicXmlInput::ReadMusicXmlDirection(
             std::vector<std::pair<std::string, ControlElement *> >::reverse_iterator riter;
             for (riter = m_controlElements.rbegin(); riter != m_controlElements.rend(); ++riter) {
                 if (riter->second->Is(DYNAM)) {
-                    controlElement = (*riter).second;
-                    dynamic_cast<Dynam *>(controlElement)->SetExtender(BOOLEAN_true);
-                    break;
+                    Dynam *dynam = dynamic_cast<Dynam * >(riter->second);
+                    std::vector<int> staffAttr = dynam->GetStaff();
+                    if (std::find(staffAttr.begin(), staffAttr.end(), staffNum + staffOffset) != staffAttr.end() && dynam->GetPlace() == dynam->AttPlacement::StrToStaffrel(placeStr.c_str())) {
+                        dynam->SetExtender(BOOLEAN_true);
+                        controlElement = dynam;
+                        break;
+                    }
                 }
                 else if (riter->second->Is(DIR)) {
-                    controlElement = (*riter).second;
-                    dynamic_cast<Dir *>(controlElement)->SetExtender(BOOLEAN_true);
-                    break;
+                    Dir *dir = dynamic_cast<Dir * >(riter->second);
+                    std::vector<int> staffAttr = dir->GetStaff();
+                    if (std::find(staffAttr.begin(), staffAttr.end(), staffNum + staffOffset) != staffAttr.end() && dir->GetPlace() == dir->AttPlacement::StrToStaffrel(placeStr.c_str())) {
+                        dir->SetExtender(BOOLEAN_true);
+                        controlElement = dir;
+                        break;
+                    }
                 }
             }
             musicxml::OpenDashes openDashes(dashesNumber, staffNum, m_measureCounts.at(measure));


### PR DESCRIPTION
MusicXmlImport: MusicXml elements <direction-type> <dashes> are now imported as attributes `@extender="true"` and `tstamp2` for `<dir>` and `<dynam>`. 

As the dashes are not semantically matched to another direction-type in MusicXML, they have to be matched to a `<dir>` or `<dynam>` element in MEI. For each `<dashes type="start">` element, the importer finds the latest preceeding `<dir>` or `<dynam>` element that matches the staff number and the place attribute. When `<dashes type="start">` and the element to be matched are not in the same measure, a warning log message is displayed and nothing is imported.