### PR TITLE
fixing pre build run script

### DIFF
--- a/Verovio.xcodeproj/xcshareddata/xcschemes/VerovioFramework.xcscheme
+++ b/Verovio.xcodeproj/xcshareddata/xcschemes/VerovioFramework.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "cd ${SRCROOT}/tools&#10;./get_git_commit.sh&#10;">
+               scriptText = "cd &quot;${SRCROOT}/tools&quot;&#10;./get_git_commit.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "cd ${SRCROOT}/bindings/iOS&#10;sh create_ios_framework_headers.sh&#10;">
+               scriptText = "cd &quot;${SRCROOT}/bindings/iOS&quot;&#10;sh create_ios_framework_headers.sh&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
 Pre build run script now supports directories with spaces in the name (eg. "iOS Application")