### PR TITLE
* Measure Numbers: Allow <mNum> to display starting measure number

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -841,11 +841,10 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
         if (mnum) {
             // this should be an option
             Measure *systemStart = dynamic_cast<Measure *>(system->FindChildByType(MEASURE));
-            if (measure == systemStart || !mnum->IsGenerated()) {
-                // Draw measure numbers > 1
-                if ((measure->GetN() != "0") && (measure->GetN()) != "1") {
-                    DrawMNum(dc, mnum, measure);
-                }
+            // Draw non-generated measure numbers, and system starting measure numbers > 1.
+            if ((measure == systemStart && measure->GetN() != "0" && measure->GetN() != "1")
+                    || !mnum->IsGenerated()) {
+                DrawMNum(dc, mnum, measure);
             }
         }
     }


### PR DESCRIPTION
Based on discussion in https://github.com/rism-ch/verovio/pull/1154#issuecomment-540672948

This PR maintains the default measure-numbering behavior **unless** `<mNum>` is explicitly defined for measures 0 and 1.