### PR TITLE
Adds explicit initialisation to local variables

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -71,7 +71,7 @@ bool EditorToolkitNeume::ParseEditorAction(const std::string &json_editorAction,
     }
     else if (action == "insert") {
         std::string elementType, startId, endId, staffId;
-        int ulx, uly, lrx, lry;
+        int ulx = 0, uly = 0, lrx = 0, lry = 0;
         std::vector<std::pair<std::string, std::string> > attributes;
         if (this->ParseInsertAction(
                 json.get<jsonxx::Object>("param"), &elementType, &staffId, &ulx, &uly, &lrx, &lry, &attributes)) {


### PR DESCRIPTION
Adds explicit initialisation to local variables to avoid execution path with uninitialised variables.
Only for `lrx` and `lry` execution path possible when they are used before being initialised, but initialisation for all variable on one line added for unification.