### PR TITLE
MusicXML conversion: convert line-type for slurs and ties

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -17,7 +17,7 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-class Slur : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature {
+class Slur : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -17,7 +17,11 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-class Slur : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
+class Slur : public ControlElement,
+             public TimeSpanningInterface,
+             public AttColor,
+             public AttCurvature,
+             public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -20,7 +20,7 @@ namespace vrv {
 /**
  * This class models the MEI <tie> element.
  */
-class Tie : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature {
+class Tie : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -20,7 +20,11 @@ namespace vrv {
 /**
  * This class models the MEI <tie> element.
  */
-class Tie : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
+class Tie : public ControlElement,
+            public TimeSpanningInterface,
+            public AttColor,
+            public AttCurvature,
+            public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1254,6 +1254,7 @@ void MeiOutput::WriteSlur(pugi::xml_node currentNode, Slur *slur)
     WriteTimeSpanningInterface(currentNode, slur);
     slur->WriteColor(currentNode);
     slur->WriteCurvature(currentNode);
+    slur->WriteCurveRend(currentNode);
 }
 
 void MeiOutput::WriteStaff(pugi::xml_node currentNode, Staff *staff)
@@ -1292,6 +1293,7 @@ void MeiOutput::WriteTie(pugi::xml_node currentNode, Tie *tie)
     WriteTimeSpanningInterface(currentNode, tie);
     tie->WriteColor(currentNode);
     tie->WriteCurvature(currentNode);
+    tie->WriteCurveRend(currentNode);
 }
 
 void MeiOutput::WriteTrill(pugi::xml_node currentNode, Trill *trill)
@@ -3995,6 +3997,7 @@ bool MeiInput::ReadSlur(Object *parent, pugi::xml_node slur)
     ReadTimeSpanningInterface(slur, vrvSlur);
     vrvSlur->ReadColor(slur);
     vrvSlur->ReadCurvature(slur);
+    vrvSlur->ReadCurveRend(slur);
 
     parent->AddChild(vrvSlur);
     ReadUnsupportedAttr(slur, vrvSlur);
@@ -4025,6 +4028,7 @@ bool MeiInput::ReadTie(Object *parent, pugi::xml_node tie)
     ReadTimeSpanningInterface(tie, vrvTie);
     vrvTie->ReadColor(tie);
     vrvTie->ReadCurvature(tie);
+    vrvTie->ReadCurveRend(tie);
 
     parent->AddChild(vrvTie);
     ReadUnsupportedAttr(tie, vrvTie);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2100,6 +2100,8 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             if (!startTie.node().attribute("orientation").empty()) { // override only with non-empty attribute
                 tie->SetCurvedir(ConvertOrientationToCurvedir(startTie.node().attribute("orientation").as_string()));
             }
+            tie->SetLform(tie->AttCurveRend::StrToLineform(startTie.node().attribute("line-type").as_string()));
+
             // add it to the stack
             m_controlElements.push_back(std::make_pair(measureNum, tie));
             OpenTie(note, tie);
@@ -2354,7 +2356,7 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             // color
             meiSlur->SetColor(slur.attribute("color").as_string());
             // lineform
-            // meiSlur->SetLform(meiSlur->AttLineVis::StrToLineform(slur.attribute("line-type ").as_string()));
+            meiSlur->SetLform(meiSlur->AttCurveRend::StrToLineform(slur.attribute("line-type").as_string()));
             // placement and orientation
             meiSlur->SetCurvedir(ConvertOrientationToCurvedir(slur.attribute("orientation").as_string()));
             meiSlur->SetCurvedir(

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -29,11 +29,12 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature()
+Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
 
     Reset();
 }
@@ -46,6 +47,7 @@ void Slur::Reset()
     TimeSpanningInterface::Reset();
     ResetColor();
     ResetCurvature();
+    ResetCurveRend();
 
     m_drawingCurvedir = curvature_CURVEDIR_NONE;
 }

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -23,11 +23,12 @@ namespace vrv {
 // Tie
 //----------------------------------------------------------------------------
 
-Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature()
+Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
 
     Reset();
 }
@@ -40,6 +41,7 @@ void Tie::Reset()
     TimeSpanningInterface::Reset();
     ResetColor();
     ResetCurvature();
+    ResetCurveRend();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Will allow dotted, dashed, or wavy style curves.

These are currently not rendered, so this change is mostly under-the-hood.

I added lform to AttCurvature; inheriting it from AttCurveRend did not work (presumably because they both implement ReadCurvature and WriteCurvature).