### PR TITLE
Support rendering of dotted and dashed curves.

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -70,6 +70,7 @@ public:
      * @name Drawing methods
      */
     ///@{
+    virtual void DrawSimpleBezierPath(Point bezier[4]);
     virtual void DrawComplexBezierPath(Point bezier1[4], Point bezier2[4]);
     virtual void DrawCircle(int x, int y, int radius);
     virtual void DrawEllipse(int x, int y, int width, int height);

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -136,6 +136,7 @@ public:
      * @name Drawing methods
      */
     ///@{
+    virtual void DrawSimpleBezierPath(Point bezier[4]) = 0;
     virtual void DrawComplexBezierPath(Point bezier1[4], Point bezier2[4]) = 0;
     virtual void DrawCircle(int x, int y, int radius) = 0;
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -17,7 +17,7 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-class Slur : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature {
+class Slur : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -17,7 +17,11 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-class Slur : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
+class Slur : public ControlElement,
+             public TimeSpanningInterface,
+             public AttColor,
+             public AttCurvature,
+             public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -72,6 +72,7 @@ public:
      * @name Drawing methods
      */
     ///@{
+    virtual void DrawSimpleBezierPath(Point bezier[4]);
     virtual void DrawComplexBezierPath(Point bezier1[4], Point bezier2[4]);
     virtual void DrawCircle(int x, int y, int radius);
     virtual void DrawEllipse(int x, int y, int width, int height);

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -20,7 +20,7 @@ namespace vrv {
 /**
  * This class models the MEI <tie> element.
  */
-class Tie : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature {
+class Tie : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -20,7 +20,11 @@ namespace vrv {
 /**
  * This class models the MEI <tie> element.
  */
-class Tie : public ControlElement, public TimeSpanningInterface, public AttColor, public AttCurvature, public AttCurveRend {
+class Tie : public ControlElement,
+            public TimeSpanningInterface,
+            public AttColor,
+            public AttCurvature,
+            public AttCurveRend {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -481,6 +481,7 @@ protected:
     void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawSmuflCode(
         DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
+    void DrawDashedBezierCurve(DeviceContext *dc, Point bezier[4], int penStyle, int thickness, int staffSize, float angle = 0.0);
     void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0);
     void DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int fillSection);
     void DrawTextString(DeviceContext *dc, std::wstring str, TextDrawingParams &params);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -481,7 +481,8 @@ protected:
     void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawSmuflCode(
         DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
-    void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0, int penStyle = AxSOLID);
+    void DrawThickBezierCurve(
+        DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0, int penStyle = AxSOLID);
     void DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int fillSection);
     void DrawTextString(DeviceContext *dc, std::wstring str, TextDrawingParams &params);
     void DrawDynamString(DeviceContext *dc, std::wstring str, TextDrawingParams &params, Rend *rend);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -481,8 +481,7 @@ protected:
     void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawSmuflCode(
         DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
-    void DrawDashedBezierCurve(DeviceContext *dc, Point bezier[4], int penStyle, int thickness, int staffSize, float angle = 0.0);
-    void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0);
+    void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0, int penStyle = AxSOLID);
     void DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int fillSection);
     void DrawTextString(DeviceContext *dc, std::wstring str, TextDrawingParams &params);
     void DrawDynamString(DeviceContext *dc, std::wstring str, TextDrawingParams &params, Rend *rend);

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -119,6 +119,16 @@ Point BBoxDeviceContext::GetLogicalOrigin()
 }
 
 // calculated better
+void BBoxDeviceContext::DrawSimpleBezierPath(Point bezier[4])
+{
+    Point pos;
+    int width, height;
+    int minYPos, maxYPos;
+
+    BoundingBox::ApproximateBezierBoundingBox(bezier, pos, width, height, minYPos, maxYPos);
+    // LogDebug("x %d, y %d, width %d, height %d", pos.x, pos.y, width, height);
+    UpdateBB(pos.x, pos.y, pos.x + width, pos.y + height);
+}
 void BBoxDeviceContext::DrawComplexBezierPath(Point bezier1[4], Point bezier2[4])
 {
     Point pos;

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -37,6 +37,9 @@ void DeviceContext::SetPen(int colour, int width, int opacity, int dashLength)
 
     switch (opacity) {
         case AxSOLID: opacityValue = 1.0; break;
+        case AxDOT: dashLength = dashLength ?: width * 1; opacityValue = 1.0; break;
+        case AxLONG_DASH: dashLength = dashLength ?: width * 4; opacityValue = 1.0; break;
+        case AxSHORT_DASH: dashLength = dashLength ?: width * 2; opacityValue = 1.0; break;
         case AxTRANSPARENT: opacityValue = 0.0; break;
         default: opacityValue = 1.0; // solid brush by default
     }

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -37,9 +37,18 @@ void DeviceContext::SetPen(int colour, int width, int opacity, int dashLength)
 
     switch (opacity) {
         case AxSOLID: opacityValue = 1.0; break;
-        case AxDOT: dashLength = dashLength ?: width * 1; opacityValue = 1.0; break;
-        case AxLONG_DASH: dashLength = dashLength ?: width * 4; opacityValue = 1.0; break;
-        case AxSHORT_DASH: dashLength = dashLength ?: width * 2; opacityValue = 1.0; break;
+        case AxDOT:
+            dashLength = dashLength ? dashLength : width * 1;
+            opacityValue = 1.0;
+            break;
+        case AxLONG_DASH:
+            dashLength = dashLength ? dashLength : width * 4;
+            opacityValue = 1.0;
+            break;
+        case AxSHORT_DASH:
+            dashLength = dashLength ? dashLength : width * 2;
+            opacityValue = 1.0;
+            break;
         case AxTRANSPARENT: opacityValue = 0.0; break;
         default: opacityValue = 1.0; // solid brush by default
     }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1254,6 +1254,7 @@ void MeiOutput::WriteSlur(pugi::xml_node currentNode, Slur *slur)
     WriteTimeSpanningInterface(currentNode, slur);
     slur->WriteColor(currentNode);
     slur->WriteCurvature(currentNode);
+    slur->WriteCurveRend(currentNode);
 }
 
 void MeiOutput::WriteStaff(pugi::xml_node currentNode, Staff *staff)
@@ -1292,6 +1293,7 @@ void MeiOutput::WriteTie(pugi::xml_node currentNode, Tie *tie)
     WriteTimeSpanningInterface(currentNode, tie);
     tie->WriteColor(currentNode);
     tie->WriteCurvature(currentNode);
+    tie->WriteCurveRend(currentNode);
 }
 
 void MeiOutput::WriteTrill(pugi::xml_node currentNode, Trill *trill)
@@ -3995,6 +3997,7 @@ bool MeiInput::ReadSlur(Object *parent, pugi::xml_node slur)
     ReadTimeSpanningInterface(slur, vrvSlur);
     vrvSlur->ReadColor(slur);
     vrvSlur->ReadCurvature(slur);
+    vrvSlur->ReadCurveRend(slur);
 
     parent->AddChild(vrvSlur);
     ReadUnsupportedAttr(slur, vrvSlur);
@@ -4025,6 +4028,7 @@ bool MeiInput::ReadTie(Object *parent, pugi::xml_node tie)
     ReadTimeSpanningInterface(tie, vrvTie);
     vrvTie->ReadColor(tie);
     vrvTie->ReadCurvature(tie);
+    vrvTie->ReadCurveRend(tie);
 
     parent->AddChild(vrvTie);
     ReadUnsupportedAttr(tie, vrvTie);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2100,6 +2100,8 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             if (!startTie.node().attribute("orientation").empty()) { // override only with non-empty attribute
                 tie->SetCurvedir(ConvertOrientationToCurvedir(startTie.node().attribute("orientation").as_string()));
             }
+            tie->SetLform(tie->AttCurveRend::StrToLineform(startTie.node().attribute("line-type").as_string()));
+
             // add it to the stack
             m_controlElements.push_back(std::make_pair(measureNum, tie));
             OpenTie(note, tie);
@@ -2354,7 +2356,7 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             // color
             meiSlur->SetColor(slur.attribute("color").as_string());
             // lineform
-            // meiSlur->SetLform(meiSlur->AttLineVis::StrToLineform(slur.attribute("line-type ").as_string()));
+            meiSlur->SetLform(meiSlur->AttCurveRend::StrToLineform(slur.attribute("line-type").as_string()));
             // placement and orientation
             meiSlur->SetCurvedir(ConvertOrientationToCurvedir(slur.attribute("orientation").as_string()));
             meiSlur->SetCurvedir(

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -29,11 +29,12 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature()
+Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
 
     Reset();
 }
@@ -46,6 +47,7 @@ void Slur::Reset()
     TimeSpanningInterface::Reset();
     ResetColor();
     ResetCurvature();
+    ResetCurveRend();
 
     m_drawingCurvedir = curvature_CURVEDIR_NONE;
 }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -477,11 +477,11 @@ pugi::xml_node SvgDeviceContext::AppendChild(std::string name)
 void SvgDeviceContext::DrawSimpleBezierPath(Point bezier[4])
 {
     pugi::xml_node pathChild = AppendChild("path");
-    pathChild.append_attribute("d")
-        = StringFormat("M%d,%d C%d,%d %d,%d %d,%d", bezier[0].x, bezier[0].y, // M command
-            bezier[1].x, bezier[1].y, bezier[2].x, bezier[2].y, bezier[3].x, bezier[3].y // First bezier
-            )
-              .c_str();
+    pathChild.append_attribute("d") = StringFormat("M%d,%d C%d,%d %d,%d %d,%d", // Base string
+        bezier[0].x, bezier[0].y, // M Command
+        bezier[1].x, bezier[1].y, bezier[2].x, bezier[2].y, bezier[3].x, bezier[3].y // Remaining bezier points.
+        )
+                                          .c_str();
     pathChild.append_attribute("fill") = "none";
     pathChild.append_attribute("stroke") = GetColour(m_penStack.top().GetColour()).c_str();
     pathChild.append_attribute("stroke-linecap") = "round";
@@ -491,8 +491,7 @@ void SvgDeviceContext::DrawSimpleBezierPath(Point bezier[4])
         // Since we have stroke-linecap=round, change the dash length to be the percieved length.
         int dashOn = std::max(m_penStack.top().GetDashLength() - m_penStack.top().GetWidth(), 0);
         int dashOff = m_penStack.top().GetDashLength() + m_penStack.top().GetWidth();
-        pathChild.append_attribute("stroke-dasharray")
-            = StringFormat("%d, %d", dashOn, dashOff).c_str();
+        pathChild.append_attribute("stroke-dasharray") = StringFormat("%d, %d", dashOn, dashOff).c_str();
     }
 }
 void SvgDeviceContext::DrawComplexBezierPath(Point bezier1[4], Point bezier2[4])

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -474,6 +474,27 @@ pugi::xml_node SvgDeviceContext::AppendChild(std::string name)
 }
 
 // Drawing methods
+void SvgDeviceContext::DrawSimpleBezierPath(Point bezier[4])
+{
+    pugi::xml_node pathChild = AppendChild("path");
+    pathChild.append_attribute("d")
+        = StringFormat("M%d,%d C%d,%d %d,%d %d,%d", bezier[0].x, bezier[0].y, // M command
+            bezier[1].x, bezier[1].y, bezier[2].x, bezier[2].y, bezier[3].x, bezier[3].y // First bezier
+            )
+              .c_str();
+    pathChild.append_attribute("fill") = "none";
+    pathChild.append_attribute("stroke") = GetColour(m_penStack.top().GetColour()).c_str();
+    pathChild.append_attribute("stroke-linecap") = "round";
+    pathChild.append_attribute("stroke-linejoin") = "round";
+    pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
+    if (m_penStack.top().GetDashLength() > 0) {
+        // Since we have stroke-linecap=round, change the dash length to be the percieved length.
+        int dashOn = std::max(m_penStack.top().GetDashLength() - m_penStack.top().GetWidth(), 0);
+        int dashOff = m_penStack.top().GetDashLength() + m_penStack.top().GetWidth();
+        pathChild.append_attribute("stroke-dasharray")
+            = StringFormat("%d, %d", dashOn, dashOff).c_str();
+    }
+}
 void SvgDeviceContext::DrawComplexBezierPath(Point bezier1[4], Point bezier2[4])
 {
     pugi::xml_node pathChild = AppendChild("path");

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -23,11 +23,12 @@ namespace vrv {
 // Tie
 //----------------------------------------------------------------------------
 
-Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature()
+Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
 
     Reset();
 }
@@ -40,6 +41,7 @@ void Tie::Reset()
     TimeSpanningInterface::Reset();
     ResetColor();
     ResetCurvature();
+    ResetCurveRend();
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -886,11 +886,23 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
     assert(curve);
     curve->UpdateCurveParams(bezier, 0.0, thickness, drawingCurveDir);
 
+    int penStyle = AxSOLID;
+    switch (tie->GetLform()) {
+        case LINEFORM_dashed:
+            penStyle = AxSHORT_DASH;
+            break;
+        case LINEFORM_dotted:
+            penStyle = AxDOT;
+            break;
+        default:
+            break;
+    }
+
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
         dc->StartGraphic(tie, "spanning-tie", "");
-    DrawThickBezierCurve(dc, bezier, thickness, staff->m_drawingStaffSize);
+    DrawThickBezierCurve(dc, bezier, thickness, staff->m_drawingStaffSize, 0, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
     else

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -888,14 +888,9 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
 
     int penStyle = AxSOLID;
     switch (tie->GetLform()) {
-        case LINEFORM_dashed:
-            penStyle = AxSHORT_DASH;
-            break;
-        case LINEFORM_dotted:
-            penStyle = AxDOT;
-            break;
-        default:
-            break;
+        case LINEFORM_dashed: penStyle = AxSHORT_DASH; break;
+        case LINEFORM_dotted: penStyle = AxDOT; break;
+        default: break;
     }
 
     if (graphic)

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -255,7 +255,8 @@ void View::DrawSmuflString(
     dc->ResetBrush();
 }
 
-void View::DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle, int penStyle)
+void View::DrawThickBezierCurve(
+    DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle, int penStyle)
 {
     assert(dc);
 
@@ -278,7 +279,8 @@ void View::DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thicknes
         // Solid Thick Bezier Curves are made of two beziers, filled in.
         dc->SetPen(m_currentColour, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
         dc->DrawComplexBezierPath(bez1, bez2);
-    } else {
+    }
+    else {
         // Dashed or Dotted Thick Bezier Curves have a uniform line width.
         dc->SetPen(m_currentColour, thickness, penStyle);
         dc->DrawSimpleBezierPath(bez1);

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -255,26 +255,7 @@ void View::DrawSmuflString(
     dc->ResetBrush();
 }
 
-void View::DrawDashedBezierCurve(DeviceContext *dc, Point bezier[4], int penStyle, int thickness, int staffSize, float angle)
-{
-    assert(dc);
-
-    Point bez1[4], bez2[4]; // filled array with control points and end point
-
-    BoundingBox::CalcThickBezier(bezier, 0, angle, bez1, bez2);
-
-    bez1[0] = ToDeviceContext(bez1[0]);
-    bez1[1] = ToDeviceContext(bez1[1]);
-    bez1[2] = ToDeviceContext(bez1[2]);
-    bez1[3] = ToDeviceContext(bez1[3]);
-
-    // Actually draw it
-    dc->SetPen(m_currentColour, thickness, penStyle);
-    dc->DrawSimpleBezierPath(bez1);
-    dc->ResetPen();
-}
-
-void View::DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle)
+void View::DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle, int penStyle)
 {
     assert(dc);
 
@@ -293,8 +274,15 @@ void View::DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thicknes
     bez2[3] = ToDeviceContext(bez2[3]);
 
     // Actually draw it
-    dc->SetPen(m_currentColour, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), AxSOLID);
-    dc->DrawComplexBezierPath(bez1, bez2);
+    if (penStyle == AxSOLID) {
+        // Solid Thick Bezier Curves are made of two beziers, filled in.
+        dc->SetPen(m_currentColour, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
+        dc->DrawComplexBezierPath(bez1, bez2);
+    } else {
+        // Dashed or Dotted Thick Bezier Curves have a uniform line width.
+        dc->SetPen(m_currentColour, thickness, penStyle);
+        dc->DrawSimpleBezierPath(bez1);
+    }
     dc->ResetPen();
 }
 

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -255,6 +255,25 @@ void View::DrawSmuflString(
     dc->ResetBrush();
 }
 
+void View::DrawDashedBezierCurve(DeviceContext *dc, Point bezier[4], int penStyle, int thickness, int staffSize, float angle)
+{
+    assert(dc);
+
+    Point bez1[4], bez2[4]; // filled array with control points and end point
+
+    BoundingBox::CalcThickBezier(bezier, 0, angle, bez1, bez2);
+
+    bez1[0] = ToDeviceContext(bez1[0]);
+    bez1[1] = ToDeviceContext(bez1[1]);
+    bez1[2] = ToDeviceContext(bez1[2]);
+    bez1[3] = ToDeviceContext(bez1[3]);
+
+    // Actually draw it
+    dc->SetPen(m_currentColour, thickness, penStyle);
+    dc->DrawSimpleBezierPath(bez1);
+    dc->ResetPen();
+}
+
 void View::DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle)
 {
     assert(dc);

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -60,7 +60,22 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     else
         dc->StartGraphic(slur, "spanning-slur", "");
 
-    DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle());
+    switch (slur->GetLform()) {
+        case LINEFORM_dashed:
+            DrawDashedBezierCurve(dc, points, AxLONG_DASH, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle());
+            break;
+        case LINEFORM_dotted:
+            DrawDashedBezierCurve(dc, points, AxDOT, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle());
+            break;
+        case LINEFORM_wavy:
+            // TODO: Implement wavy slur.
+        case LINEFORM_NONE:
+        default:
+        case LINEFORM_solid:
+            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle());
+            break;
+    }
+
 
     /*
     int i;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -60,22 +60,15 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     else
         dc->StartGraphic(slur, "spanning-slur", "");
 
+    int penStyle = AxSOLID;
     switch (slur->GetLform()) {
-        case LINEFORM_dashed:
-            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), AxSHORT_DASH);
-            break;
-        case LINEFORM_dotted:
-            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), AxDOT);
-            break;
+        case LINEFORM_dashed: penStyle = AxSHORT_DASH; break;
+        case LINEFORM_dotted: penStyle = AxDOT; break;
         case LINEFORM_wavy:
-            // TODO: Implement wavy slur.
-        case LINEFORM_NONE:
-        default:
-        case LINEFORM_solid:
-            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), AxSOLID);
-            break;
+        // TODO: Implement wavy slur.
+        default: break;
     }
-
+    DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), penStyle);
 
     /*
     int i;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -62,17 +62,17 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
 
     switch (slur->GetLform()) {
         case LINEFORM_dashed:
-            DrawDashedBezierCurve(dc, points, AxLONG_DASH, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle());
+            DrawThickBezierCurve(dc, points, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle(), AxLONG_DASH);
             break;
         case LINEFORM_dotted:
-            DrawDashedBezierCurve(dc, points, AxDOT, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle());
+            DrawThickBezierCurve(dc, points, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle(), AxDOT);
             break;
         case LINEFORM_wavy:
             // TODO: Implement wavy slur.
         case LINEFORM_NONE:
         default:
         case LINEFORM_solid:
-            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle());
+            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), AxSOLID);
             break;
     }
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -62,10 +62,10 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
 
     switch (slur->GetLform()) {
         case LINEFORM_dashed:
-            DrawThickBezierCurve(dc, points, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle(), AxLONG_DASH);
+            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), AxSHORT_DASH);
             break;
         case LINEFORM_dotted:
-            DrawThickBezierCurve(dc, points, curve->GetThickness() / 2, staff->m_drawingStaffSize, curve->GetAngle(), AxDOT);
+            DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), AxDOT);
             break;
         case LINEFORM_wavy:
             // TODO: Implement wavy slur.


### PR DESCRIPTION
Inspired by #701 

(This is based on #1211 , because we need GetLform for ties and slurs)

This PR also allows dash-length to be automatically set based on the penStyle and the thickness passed to `SetPen`.

<img width="511" alt="Screen Shot 2019-12-04 at 13 33 53" src="https://user-images.githubusercontent.com/12452738/70170482-c2f78f00-169a-11ea-8fc4-e8e554a4d8ad.png">

MEI to test with
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mdiv-0000000738863936">
                <score xml:id="score-0000001335725398">
                    <scoreDef xml:id="scoredef-0000000694607183">
                        <staffGrp xml:id="staffgrp-0000001545928361">
                            <staffDef xml:id="staffdef-0000000941316302" n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4">
                                <keySig xml:id="keysig-0000001209649547" sig="0" />
                            </staffDef>
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="section-0000001890202095">
                        <pb xml:id="pb-0000000901020594" />
                        <measure xml:id="measure-0000001805524828" n="1">
                            <staff xml:id="staff-0000000663931922" n="1">
                                <layer xml:id="layer-0000000378783242" n="1">
                                    <note xml:id="note-0000001068418586" dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up">
                                        <verse xml:id="verse-0000001800402335" n="1">
                                            <syl xml:id="syl-0000001317458115" con="d" wordpos="i">dot</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="note-0000000994362534" dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="down" />
                                    <note xml:id="note-0000000533367984" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                                    <note xml:id="note-0000000718964510" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down">
                                        <verse xml:id="verse-0000001893521548" n="1">
                                            <syl xml:id="syl-0000000856492343" con="s" wordpos="t">ted</syl>
                                        </verse>
                                    </note>
                                </layer>
                            </staff>
                            <slur xml:id="slur-0000000898432313" startid="#note-0000001068418586" endid="#note-0000000533367984" curvedir="above" lform="dotted" />
                        </measure>
                        <measure xml:id="measure-0000000772617531" n="2">
                            <staff xml:id="staff-0000001921261896" n="1">
                                <layer xml:id="layer-0000001084569780" n="1">
                                    <note xml:id="note-0000000523096724" dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up">
                                        <verse xml:id="verse-0000002036073097" n="1">
                                            <syl xml:id="syl-0000000128626334" con="s">dashed</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="note-0000001170026308" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                                    <note xml:id="note-0000000124402977" dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up">
                                        <verse xml:id="verse-0000001339245908" n="1">
                                            <syl xml:id="syl-0000000929871549" con="s">straight</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="note-0000000820638600" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                                </layer>
                            </staff>
                            <slur xml:id="slur-0000001012160885" startid="#note-0000000523096724" endid="#note-0000001170026308" curvedir="above" lform="dashed" />
                            <slur xml:id="slur-0000001745302539" startid="#note-0000000124402977" endid="#note-0000000820638600" curvedir="above" />
                        </measure>
                        <measure xml:id="measure-0000001332969166" right="end" n="3">
                            <staff xml:id="staff-0000001191480757" n="1">
                                <layer xml:id="layer-0000002079558271" n="1">
                                    <note xml:id="note-0000000839505772" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down">
                                        <verse xml:id="verse-0000000605949214" n="1">
                                            <syl xml:id="syl-0000000820985624" con="s">dotted</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="note-0000002018656970" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down">
                                        <verse xml:id="verse-0000001621039484" n="1">
                                            <syl xml:id="syl-0000001833061746" con="s">dashed</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="note-0000000407420941" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down">
                                        <verse xml:id="verse-0000001345888751" n="1">
                                            <syl xml:id="syl-0000000906984206" con="s">straight</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="note-0000000430433867" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                                </layer>
                            </staff>
                            <tie xml:id="tie-0000000168141825" startid="#note-0000000839505772" endid="#note-0000002018656970" lform="dotted" />
                            <tie xml:id="tie-0000001285677865" startid="#note-0000002018656970" endid="#note-0000000407420941" lform="dashed" />
                            <tie xml:id="tie-0000000725904982" startid="#note-0000000407420941" endid="#note-0000000430433867" />
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```