### PR TITLE
fix beamed tuplet number placement

### DIFF
--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -233,20 +233,21 @@ int TupletNum::GetDrawingXMid(Doc *doc)
     else {
         Tuplet *tuplet = dynamic_cast<Tuplet *>(this->GetFirstAncestor(TUPLET));
         assert(tuplet && tuplet->GetDrawingLeft() && tuplet->GetDrawingRight());
+        int xLeft = tuplet->GetDrawingLeft()->GetDrawingX();
+        int xRight = tuplet->GetDrawingRight()->GetDrawingX();
+        if (doc) {
+            xRight += (tuplet->GetDrawingRight()->GetDrawingRadius(doc) * 2);
+        }
         if (tuplet->GetNumAlignedBeam()) {
-            const ArrayOfBeamElementCoords *coords = tuplet->GetNumAlignedBeam()->GetElementCoords();
-            int xLeft = coords->front()->m_x;
-            int xRight = coords->back()->m_x;
-            return xLeft + ((xRight - xLeft) / 2);
-        }
-        else {
-            int xLeft = tuplet->GetDrawingLeft()->GetDrawingX();
-            int xRight = tuplet->GetDrawingRight()->GetDrawingX();
-            if (doc) {
-                xRight += (tuplet->GetDrawingRight()->GetDrawingRadius(doc) * 2);
+            Beam *beam = tuplet->GetNumAlignedBeam();
+            data_STEMDIRECTION beamPos = beam->m_drawingParams.m_stemDir;
+            switch (beamPos) {
+                case STEMDIRECTION_up: xLeft += (tuplet->GetDrawingLeft()->GetDrawingRadius(doc)); break;
+                case STEMDIRECTION_down: xRight -= (tuplet->GetDrawingRight()->GetDrawingRadius(doc)); break;
+                default: break;
             }
-            return xLeft + ((xRight - xLeft) / 2);
         }
+        return xLeft + ((xRight - xLeft) / 2);
     }
 }
 


### PR DESCRIPTION
closes #1138

![-home-rettinghaus-git-verovio-tools-beamedtuplets_001 svg 2019-12-05](https://user-images.githubusercontent.com/7693447/70252120-1c39ee00-1781-11ea-9063-04f7e3f3e980.jpeg)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Beamed tuplets</title>
            </titleStmt>
            <pubStmt>
                <respStmt>
                    <persName role="encoder" auth.uri="http://d-nb.info/gnd" auth="GND" codedval="140541624">Klaus Rettinghaus</persName>
                </respStmt>
            </pubStmt>
        </fileDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef key.sig="1f" meter.count="4" meter.unit="4">
                        <staffGrp>
                            <staffDef clef.shape="G" clef.line="2" n="1" lines="5"/>
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <beam>
                                        <note dur="8" oct="4" pname="a" stem.dir="down" accid.ges="f"/>
                                        <tuplet num="3" numbase="2" num.place="above" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="down" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="down"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="down"/>
                                        </tuplet>
                                    </beam>
                                    <beam>
                                        <note dur="8" oct="4" pname="a" stem.dir="down" accid.ges="f"/>
                                        <tuplet num="3" numbase="2" num.place="below" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="down" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="down"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="down"/>
                                        </tuplet>
                                    </beam>
                                </layer>
                            </staff>
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <beam>
                                        <tuplet num="3" numbase="2" num.place="above" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="down" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="down"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="down"/>
                                        </tuplet>
                                        <note dur="8" oct="4" pname="a" stem.dir="down" accid.ges="f"/>
                                    </beam>
                                    <beam>
                                        <tuplet num="3" numbase="2" num.place="below" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="down" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="down"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="down"/>
                                        </tuplet>
                                        <note dur="8" oct="4" pname="a" stem.dir="down" accid.ges="f"/>
                                    </beam>
                                </layer>
                            </staff>
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <beam>
                                        <note dur="8" oct="4" pname="a" stem.dir="up" accid.ges="f"/>
                                        <tuplet num="3" numbase="2" num.place="above" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="up" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="up"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="up"/>
                                        </tuplet>
                                    </beam>
                                    <beam>
                                        <note dur="8" oct="4" pname="a" stem.dir="up" accid.ges="f"/>
                                        <tuplet num="3" numbase="2" num.place="below" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="up" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="up"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="up"/>
                                        </tuplet>
                                    </beam>
                                </layer>
                            </staff>
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <beam>
                                        <tuplet num="3" numbase="2" num.place="above" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="up" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="up"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="up"/>
                                        </tuplet>
                                        <note dur="8" oct="4" pname="a" stem.dir="up" accid.ges="f"/>
                                    </beam>
                                    <beam>
                                        <tuplet num="3" numbase="2" num.place="below" bracket.visible="false">
                                            <note dur="16" oct="4" pname="g" stem.dir="up" accid.ges="f"/>
                                            <note dur="16" oct="4" pname="a" stem.dir="up"/>
                                            <note dur="16" oct="4" pname="b" stem.dir="up"/>
                                        </tuplet>
                                        <note dur="8" oct="4" pname="a" stem.dir="up" accid.ges="f"/>
                                    </beam>
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
