### PR TITLE
Support Short and Tick barlines (measure@bar.len measure@bar.place)

### DIFF
--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -33,6 +33,7 @@ class TimestampAttr;
  * For internally simplication of processing, unmeasured music is contained in one single measure object
  */
 class Measure : public Object,
+                public AttBarring,
                 public AttMeasureLog,
                 public AttMeterConformanceBar,
                 public AttNNumberLike,

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1070,6 +1070,7 @@ void MeiOutput::WriteMeasure(pugi::xml_node currentNode, Measure *measure)
     assert(measure);
 
     WriteXmlId(currentNode, measure);
+    measure->WriteBarring(currentNode);
     measure->WriteMeasureLog(currentNode);
     measure->WriteMeterConformanceBar(currentNode);
     measure->WriteNNumberLike(currentNode);
@@ -3676,6 +3677,7 @@ bool MeiInput::ReadMeasure(Object *parent, pugi::xml_node measure)
     }
     SetMeiUuid(measure, vrvMeasure);
 
+    vrvMeasure->ReadBarring(measure);
     vrvMeasure->ReadMeasureLog(measure);
     vrvMeasure->ReadMeterConformanceBar(measure);
     vrvMeasure->ReadNNumberLike(measure);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1335,6 +1335,13 @@ void MusicXmlInput::ReadMusicXmlBarLine(pugi::xml_node node, Measure *measure, s
         }
         else {
             measure->SetRight(barRendition);
+            if (barStyle == "short" || barStyle == "tick") {
+                measure->SetBarLen(4);
+                if (barStyle == "short")
+                    measure->SetBarPlace(2);
+                else
+                    measure->SetBarPlace(-2);
+            }
         }
     }
     // parse endings (prima volta, seconda volta...)
@@ -2548,8 +2555,8 @@ data_BARRENDITION MusicXmlInput::ConvertStyleToRend(std::string value, bool repe
     // if (value == "") return BARRENDITION_rptboth;
     if ((value == "light-heavy") && repeat) return BARRENDITION_rptend;
     if (value == "regular") return BARRENDITION_single;
-    // if (value == "short") return; // TODO: Support 'short' barlines.
-    // if (value == "tick") return; // TODO: Support 'tick' barlines.
+    if (value == "short") return BARRENDITION_single;
+    if (value == "tick") return BARRENDITION_single;
     LogWarning("MusicXML import: Unsupported bar-style '%s'", value.c_str());
     return BARRENDITION_NONE;
 }

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -44,8 +44,15 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 Measure::Measure(bool measureMusic, int logMeasureNb)
-    : Object("measure-"), AttMeasureLog(), AttMeterConformanceBar(), AttNNumberLike(), AttPointing(), AttTyped()
+    : Object("measure-")
+    , AttBarring()
+    , AttMeasureLog()
+    , AttMeterConformanceBar()
+    , AttNNumberLike()
+    , AttPointing()
+    , AttTyped()
 {
+    RegisterAttClass(ATT_BARRING);
     RegisterAttClass(ATT_MEASURELOG);
     RegisterAttClass(ATT_METERCONFORMANCEBAR);
     RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -633,9 +633,15 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                     continue;
                 }
                 int yTop = staff->GetDrawingY();
+                if (measure->HasBarPlace()) {
+                    yTop += measure->GetBarPlace() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+                }
                 // for the bottom position we need to take into account the number of lines and the staff size
                 int yBottom = staff->GetDrawingY()
                     - (childStaffDef->GetLines() - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+                if (measure->HasBarLen()) {
+                    yBottom = yTop - (measure->GetBarLen() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
+                }
                 // Make sure barlines are visible with a single line
                 if (childStaffDef->GetLines() == 1) {
                     yTop += m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);


### PR DESCRIPTION
Tested with [46a-Barlines.xml](https://github.com/cuthbertLab/musicxmlTestSuite/blob/master/xmlFiles/46a-Barlines.xml).

"short" is implemented like MuseScore's "Short 1" barline span.

"tick" is implemented like MuseScore's "Tick2" barline span. (longer than the [SMuFL barlineTick glyph](http://www.smufl.org/version/latest/range/barlines/))

<img width="219" alt="Screen Shot 2019-12-05 at 16 27 15" src="https://user-images.githubusercontent.com/12452738/70275663-9caa2000-177c-11ea-8a61-0e35e935c47f.png">
