### PR TITLE
fix tie and slur color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [unreleased]
+* Fig coloring of ties and slurs (@rettinghaus)
+* Fig bug with tuplet number placement (@rettinghaus)
 * Support for short and tick barlines  with `measure@bar.len` and `measure@bar.place` (@earboxer)
 * Support for dashed and dotted slurs and ties ((@earboxer and @napulen)
 * Options for controlling system divider display (--systemDivider "none|left|left-right")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
 ## [unreleased]
-* Fig coloring of ties and slurs (@rettinghaus)
-* Fig bug with tuplet number placement (@rettinghaus)
 * Support for short and tick barlines  with `measure@bar.len` and `measure@bar.place` (@earboxer)
 * Support for dashed and dotted slurs and ties ((@earboxer and @napulen)
 * Options for controlling system divider display (--systemDivider "none|left|left-right")
+* Fig coloring of ties and slurs (@rettinghaus)
+* Fig bug with tuplet number placement (@rettinghaus)
 
 ## [2.3.3] - 2019-11-26
 * Fix bug with NPM build (remove init function for adjusting memory)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -208,6 +208,9 @@ void SvgDeviceContext::StartGraphic(Object *object, std::string gClass, std::str
         AttColor *att = dynamic_cast<AttColor *>(object);
         assert(att);
         if (att->HasColor()) {
+            if (object->IsControlElement()) {
+              m_currentNode.append_attribute("color") = att->GetColor().c_str();
+            }
             m_currentNode.append_attribute("fill") = att->GetColor().c_str();
         }
     }


### PR DESCRIPTION
closes #1217

With `currentColor` in place, perhaps we need to rethink the internal brush color concept.