### PR TITLE
Add support for principal-voice

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -24,6 +24,7 @@
 namespace vrv {
 
 class Arpeg;
+class BracketSpan;
 class Clef;
 class ControlElement;
 class Dir;
@@ -340,6 +341,7 @@ private:
     /* The stack for hairpin stops that might occur before a hairpin was started staffNumber, tStamp2, (hairpinNumber,
      * measureCount) */
     std::vector<std::tuple<int, double, musicxml::OpenSpanner> > m_hairpinStopStack;
+    std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner> > m_bracketStack;
     /* The stack of endings to be inserted at the end of XML import */
     std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> > m_endingStack;
     /* The stack of open dashes (direction-type) containing *ControlElement, OpenDashes */

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -68,9 +68,9 @@ namespace musicxml {
         int m_number;
     };
 
-    class OpenHairpin {
+    class OpenSpanner {
     public:
-        OpenHairpin(const int &dirN, const int &lastMeasureCount)
+        OpenSpanner(const int &dirN, const int &lastMeasureCount)
         {
             m_dirN = dirN;
             m_lastMeasureCount = lastMeasureCount;
@@ -336,10 +336,10 @@ private:
     /* The stack for tie stops that might come before that tie was opened */
     std::vector<Note *> m_tieStopStack;
     /* The stack for hairpins */
-    std::vector<std::pair<Hairpin *, musicxml::OpenHairpin> > m_hairpinStack;
+    std::vector<std::pair<Hairpin *, musicxml::OpenSpanner> > m_hairpinStack;
     /* The stack for hairpin stops that might occur before a hairpin was started staffNumber, tStamp2, (hairpinNumber,
      * measureCount) */
-    std::vector<std::tuple<int, double, musicxml::OpenHairpin> > m_hairpinStopStack;
+    std::vector<std::tuple<int, double, musicxml::OpenSpanner> > m_hairpinStopStack;
     /* The stack of endings to be inserted at the end of XML import */
     std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> > m_endingStack;
     /* The stack of open dashes (direction-type) containing *ControlElement, OpenDashes */

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1094,7 +1094,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
             // and with earliest end note.
             if (iter->second->GetPname() == (*jter)->GetPname() && iter->second->GetOct() == (*jter)->GetOct()
                 && (iter->second->GetScoreTimeOnset() < (*jter)->GetScoreTimeOnset()
-                       && (*jter)->GetScoreTimeOnset() < lastScoreTimeOnset)) {
+                    && (*jter)->GetScoreTimeOnset() < lastScoreTimeOnset)) {
                 iter->first->SetEndid("#" + (*jter)->GetUuid());
                 lastScoreTimeOnset = (*jter)->GetScoreTimeOnset();
                 tieMatched = true;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -17,6 +17,7 @@
 #include "arpeg.h"
 #include "beam.h"
 #include "beatrpt.h"
+#include "bracketspan.h"
 #include "breath.h"
 #include "btrem.h"
 #include "chord.h"
@@ -1637,6 +1638,14 @@ void MusicXmlInput::ReadMusicXmlDirection(
             m_controlElements.push_back(std::make_pair(measureNum, pedal));
             m_pedalStack.push_back(pedal);
         }
+    }
+
+    // Principal voice
+    pugi::xpath_node lead = type.node().select_node("principal-voice");
+    if (lead) {
+        BracketSpan *bracketSpan = new BracketSpan();
+        bracketSpan->SetColor(lead.node().attribute("color").as_string());
+        // if (!placeStr.empty()) bracketSpan->SetPlace(bracketSpan->AttPlacement::StrToStaffrel(placeStr.c_str()));
     }
 
     // Tempo


### PR DESCRIPTION
This PR adds support for `principal-voice` in MusicXML importer.
The `bracktSpan@func` get the generic value `analytical`, in addition `@type` is set to `principal-voice`.
Closes #1215 