### PR TITLE
* Note: Add UpdateFromTransPitch method to apply a pitch to a note.

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -190,6 +190,7 @@ public:
     int GetChromaticAlteration();
 
     TransPitch GetTransPitch();
+    void UpdateFromTransPitch(TransPitch tp);
 
     //----------//
     // Functors //

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -190,8 +190,11 @@ public:
     int GetChromaticAlteration();
 
     TransPitch GetTransPitch();
+
+private:
     void UpdateFromTransPitch(TransPitch tp);
 
+public:
     //----------//
     // Functors //
     //----------//

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -459,6 +459,43 @@ TransPitch Note::GetTransPitch()
     return TransPitch(pname, this->GetChromaticAlteration(), this->GetOct());
 }
 
+void Note::UpdateFromTransPitch(TransPitch tp)
+{
+    data_PITCHNAME pname = static_cast<data_PITCHNAME>(tp.m_pname + PITCHNAME_c);
+    this->SetPname(pname);
+
+    Accid *accid = this->GetDrawingAccid();
+    if (accid->HasAccidGes()) {
+        data_ACCIDENTAL_GESTURAL gestural = ACCIDENTAL_GESTURAL_NONE;
+        switch (tp.m_accid) {
+            case -2: gestural = ACCIDENTAL_GESTURAL_ff; break;
+            case -1: gestural = ACCIDENTAL_GESTURAL_f; break;
+            case 0: gestural = ACCIDENTAL_GESTURAL_NONE; break;
+            case 1: gestural = ACCIDENTAL_GESTURAL_s; break;
+            case 2: gestural = ACCIDENTAL_GESTURAL_ss; break;
+            default: break; // TODO: Return an error here.
+        }
+        accid->SetAccidGes(gestural);
+    }
+    else {
+        data_ACCIDENTAL_WRITTEN written = ACCIDENTAL_WRITTEN_NONE;
+        switch (tp.m_accid) {
+            case -3: written = ACCIDENTAL_WRITTEN_tf; break;
+            case -2: written = ACCIDENTAL_WRITTEN_ff; break;
+            case -1: written = ACCIDENTAL_WRITTEN_f; break;
+            case 0: written = ACCIDENTAL_WRITTEN_NONE; break;
+            case 1: written = ACCIDENTAL_WRITTEN_s; break;
+            case 2: written = ACCIDENTAL_WRITTEN_x; break;
+            case 3: written = ACCIDENTAL_WRITTEN_xs; break;
+            default: break; // TODO: Return an error here.
+        }
+        accid->SetAccid(written);
+    }
+
+    // Since we didn't read the oct.ges when getting TransPitch, we don't need to account for that.
+    this->SetOct(tp.m_oct);
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -492,8 +492,12 @@ void Note::UpdateFromTransPitch(TransPitch tp)
         accid->SetAccid(written);
     }
 
-    // Since we didn't read the oct.ges when getting TransPitch, we don't need to account for that.
-    this->SetOct(tp.m_oct);
+    if (this->GetOct() != tp.m_oct) {
+        if(this->HasOctGes()) {
+            this->SetOctGes(this->GetOctGes() + tp.m_oct - this->GetOct());
+        }
+        this->SetOct(tp.m_oct);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -465,25 +465,38 @@ void Note::UpdateFromTransPitch(TransPitch tp)
     this->SetPname(pname);
 
     Accid *accid = this->GetDrawingAccid();
+    bool transposeGesturalAccid = false;
+    bool transposeWrittenAccid = false;
     if (accid->HasAccidGes()) {
+        transposeGesturalAccid = true;
+    }
+    if (accid->HasAccid()) {
+        transposeWrittenAccid = true;
+    }
+    // TODO: Check the case of both existing but having unequal values.
+    if (!accid->HasAccidGes() && !accid->HasAccid()) {
+        transposeGesturalAccid = true;
+    }
+
+    if (transposeGesturalAccid) {
         data_ACCIDENTAL_GESTURAL gestural = ACCIDENTAL_GESTURAL_NONE;
         switch (tp.m_accid) {
             case -2: gestural = ACCIDENTAL_GESTURAL_ff; break;
             case -1: gestural = ACCIDENTAL_GESTURAL_f; break;
-            case 0: gestural = ACCIDENTAL_GESTURAL_NONE; break;
+            case 0: gestural = ACCIDENTAL_GESTURAL_n; break;
             case 1: gestural = ACCIDENTAL_GESTURAL_s; break;
             case 2: gestural = ACCIDENTAL_GESTURAL_ss; break;
             default: break; // TODO: Return an error here.
         }
         accid->SetAccidGes(gestural);
     }
-    else {
+    if (transposeWrittenAccid) {
         data_ACCIDENTAL_WRITTEN written = ACCIDENTAL_WRITTEN_NONE;
         switch (tp.m_accid) {
             case -3: written = ACCIDENTAL_WRITTEN_tf; break;
             case -2: written = ACCIDENTAL_WRITTEN_ff; break;
             case -1: written = ACCIDENTAL_WRITTEN_f; break;
-            case 0: written = ACCIDENTAL_WRITTEN_NONE; break;
+            case 0: written = ACCIDENTAL_WRITTEN_n; break;
             case 1: written = ACCIDENTAL_WRITTEN_s; break;
             case 2: written = ACCIDENTAL_WRITTEN_x; break;
             case 3: written = ACCIDENTAL_WRITTEN_xs; break;
@@ -493,7 +506,7 @@ void Note::UpdateFromTransPitch(TransPitch tp)
     }
 
     if (this->GetOct() != tp.m_oct) {
-        if(this->HasOctGes()) {
+        if (this->HasOctGes()) {
             this->SetOctGes(this->GetOctGes() + tp.m_oct - this->GetOct());
         }
         this->SetOct(tp.m_oct);


### PR DESCRIPTION
Implements

> Then take the resulting transposition and place it back into the note attributes.

from @craigsapp's [comment](https://github.com/rism-ch/verovio/issues/1189#issuecomment-563405899)

I call it `Note::UpdateFromTransPitch`

Eventually, we'll want a loop like
```c++
transposer->setTransposition("+M2")
while (Transposable transposableItem = iterator.iterate()){
  TransPitch pitch = transposableItem::GetTransPitch();
  transposer->Transpose(pitch);
  transposableItem::UpdateFromTransPitch(pitch);
}
```

We would need to implement `Transposable`.

Then we could just implement these two methods for `Harm`, `StaffDef`, `ScoreDef`, `KeySig` (and any others relevant classes that we may have missed), to complete the system.