### PR TITLE
* Transposition: Transpose simple chord symbols in Harm elements

### DIFF
--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -72,6 +72,11 @@ public:
      */
     virtual int AdjustHarmGrpsSpacing(FunctorParams *functorParams);
 
+    /**
+     * See Object::Transpose
+     */
+    virtual int Transpose(FunctorParams *functorParams);
+
 protected:
     //
 private:

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -11,6 +11,7 @@
 #include "controlelement.h"
 #include "textdirinterface.h"
 #include "timeinterface.h"
+#include "transposition.h"
 
 namespace vrv {
 
@@ -57,6 +58,12 @@ public:
      * Only supported elements will be actually added to the child list.
      */
     virtual void AddChild(Object *object);
+
+    /**
+     * Transposition related. The int tracks where we have iterated through the string.
+     */
+    TransPitch GetRootPitch(int &pos);
+    void SetRootPitch(TransPitch pitch, int endPos);
 
     //----------//
     // Functors //

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -62,10 +62,10 @@ public:
     /**
      * Transposition related. The int tracks where we have iterated through the string.
      */
-    TransPitch GetRootPitch(unsigned int &pos);
-    void SetRootPitch(TransPitch pitch, unsigned int endPos);
-    TransPitch GetBassPitch();
-    void SetBassPitch(TransPitch pitch);
+    bool GetRootPitch(TransPitch &pitch, unsigned int &pos);
+    void SetRootPitch(const TransPitch &pitch, unsigned int endPos);
+    bool GetBassPitch(TransPitch &pitch);
+    void SetBassPitch(const TransPitch &pitch);
 
     //----------//
     // Functors //

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -62,8 +62,10 @@ public:
     /**
      * Transposition related. The int tracks where we have iterated through the string.
      */
-    TransPitch GetRootPitch(int &pos);
-    void SetRootPitch(TransPitch pitch, int endPos);
+    TransPitch GetRootPitch(unsigned int &pos);
+    void SetRootPitch(TransPitch pitch, unsigned int endPos);
+    TransPitch GetBassPitch();
+    void SetBassPitch(TransPitch pitch);
 
     //----------//
     // Functors //

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -262,8 +262,8 @@ private:
 
     TransPitch GetTransPitch();
 
-    void UpdateFromTransPitch(TransPitch tp);
-                 
+    void UpdateFromTransPitch(const TransPitch &tp);
+
 public:
     //
 private:

--- a/include/vrv/transposition.h
+++ b/include/vrv/transposition.h
@@ -47,6 +47,7 @@ public:
     data_ACCIDENTAL_GESTURAL GetAccidG();
     data_ACCIDENTAL_WRITTEN GetAccidW();
     data_PITCHNAME GetPitchName();
+    std::wstring GetPitchString();
     bool IsValid(int maxAccid);
     void SetPitch(int aPname, int anAccid, int anOct);
 };

--- a/include/vrv/transposition.h
+++ b/include/vrv/transposition.h
@@ -44,10 +44,10 @@ public:
     TransPitch(const TransPitch &pitch);
     TransPitch &operator=(const TransPitch &pitch);
     static int GetChromaticAlteration(data_ACCIDENTAL_GESTURAL accidG, data_ACCIDENTAL_WRITTEN accidW);
-    data_ACCIDENTAL_GESTURAL GetAccidG();
-    data_ACCIDENTAL_WRITTEN GetAccidW();
-    data_PITCHNAME GetPitchName();
-    std::wstring GetPitchString();
+    data_ACCIDENTAL_GESTURAL GetAccidG() const;
+    data_ACCIDENTAL_WRITTEN GetAccidW() const;
+    data_PITCHNAME GetPitchName() const;
+    std::wstring GetPitchString() const;
     bool IsValid(int maxAccid);
     void SetPitch(int aPname, int anAccid, int anOct);
 };

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -225,18 +225,17 @@ int Harm::Transpose(FunctorParams *functorParams)
         int accid = 0;
         int i;
         for (i = 1;; i++) {
-            // We can't use a switch-case here because text is a wstring
-            if (text[i] == L'𝄫')
-                accid -= 2;
-            else if (text[i] == 'b' || text[i] == L'♭')
-                accid--;
-            else if (text[i] == '#' || text[i] == L'♯')
-                accid++;
-            else if (text[i] == L'𝄪')
-                accid += 2;
-            else
-                break;
+            switch (text[i]) {
+                case L'𝄫': accid -= 2; break;
+                case 'b':
+                case L'♭': accid--; break;
+                case '#':
+                case L'♯': accid++; break;
+                case L'𝄪': accid += 2; break;
+                default: goto break2;
+            }
         }
+    break2:
         TransPitch pitch = TransPitch((text[0] - 'C' + 7) % 7, accid, 4);
         params->m_transposer->Transpose(pitch);
         char pitchLetter = (pitch.m_pname + ('C' - 'A')) % 7 + 'A';

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -81,11 +81,11 @@ void Harm::AddChild(Object *child)
 
 bool Harm::GetRootPitch(TransPitch &pitch, unsigned int &pos)
 {
-    Text *textObject = dynamic_cast<Text *>(this->GetChild(0, TEXT));
-    assert(textObject);
+    Text *textObject = dynamic_cast<Text *>(this->FindDescendantByType(TEXT, 1));
+    if (!textObject) return false;
     std::wstring text = textObject->GetText();
 
-    if (text.at(pos) >= 'A' && text.at(pos) <= 'G') {
+    if (text.length() > pos && text.at(pos) >= 'A' && text.at(pos) <= 'G') {
         int pname = (text.at(pos) - 'C' + 7) % 7;
         int accid = 0;
         for (pos++; pos < text.length(); pos++) {
@@ -109,18 +109,25 @@ bool Harm::GetRootPitch(TransPitch &pitch, unsigned int &pos)
 
 void Harm::SetRootPitch(const TransPitch &pitch, unsigned int endPos)
 {
-    Text *textObject = dynamic_cast<Text *>(this->GetChild(0, TEXT));
-    assert(textObject);
+    Text *textObject = dynamic_cast<Text *>(this->FindDescendantByType(TEXT, 1));
+    if (!textObject) return;
     std::wstring text = textObject->GetText();
 
-    textObject->SetText(pitch.GetPitchString() + &text[endPos]);
+    if (text.length() > endPos) {
+        textObject->SetText(pitch.GetPitchString() + &text.at(endPos));
+    }
+    else {
+        textObject->SetText(pitch.GetPitchString());
+    }
 }
 
 bool Harm::GetBassPitch(TransPitch &pitch)
 {
-    Text *textObject = dynamic_cast<Text *>(this->GetChild(0, TEXT));
-    assert(textObject);
+    Text *textObject = dynamic_cast<Text *>(this->FindDescendantByType(TEXT, 1));
+    if (!textObject) return false;
     std::wstring text = textObject->GetText();
+    if (!text.length()) return false;
+
     for (unsigned int pos = 0; pos < text.length(); pos++) {
         if (text.at(pos) == L'/') {
             pos++;
@@ -132,8 +139,8 @@ bool Harm::GetBassPitch(TransPitch &pitch)
 
 void Harm::SetBassPitch(const TransPitch &pitch)
 {
-    Text *textObject = dynamic_cast<Text *>(this->GetChild(0, TEXT));
-    assert(textObject);
+    Text *textObject = dynamic_cast<Text *>(this->FindDescendantByType(TEXT, 1));
+    if (!textObject) return;
     std::wstring text = textObject->GetText();
     unsigned int pos;
     for (pos = 0; pos < text.length(); pos++) {

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -436,7 +436,7 @@ TransPitch Note::GetTransPitch()
     return TransPitch(pname, this->GetChromaticAlteration(), this->GetOct());
 }
 
-void Note::UpdateFromTransPitch(TransPitch tp)
+void Note::UpdateFromTransPitch(const TransPitch &tp)
 {
     this->SetPname(tp.GetPitchName());
 

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -161,6 +161,19 @@ data_PITCHNAME TransPitch::GetPitchName()
 {
     return static_cast<data_PITCHNAME>(m_pname + PITCHNAME_c);
 }
+
+std::wstring TransPitch::GetPitchString()
+{
+    char pitchLetter = (m_pname + ('C' - 'A')) % 7 + 'A';
+    switch (m_accid) {
+        case -2: return std::wstring({ pitchLetter, L'𝄫' });
+        case -1: return std::wstring({ pitchLetter, L'♭' });
+        default: LogError("Transposition: Could not get Accidental for %i", m_accid);
+        case 0: return std::wstring({ pitchLetter });
+        case 1: return std::wstring({ pitchLetter, L'♯' });
+        case 2: return std::wstring({ pitchLetter, L'♯', L'♯' });
+    }
+}
 //////////////////////////////
 //
 // operator= TransPitch -- copy operator for pitches.

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -129,7 +129,7 @@ int TransPitch::GetChromaticAlteration(data_ACCIDENTAL_GESTURAL accidG, data_ACC
     return 0;
 }
 
-data_ACCIDENTAL_GESTURAL TransPitch::GetAccidG()
+data_ACCIDENTAL_GESTURAL TransPitch::GetAccidG() const
 {
     switch (m_accid) {
         case -2: return ACCIDENTAL_GESTURAL_ff;
@@ -142,7 +142,7 @@ data_ACCIDENTAL_GESTURAL TransPitch::GetAccidG()
     LogWarning("Transposition: Could not get Gestural Accidental for %i", m_accid);
     return ACCIDENTAL_GESTURAL_NONE;
 }
-data_ACCIDENTAL_WRITTEN TransPitch::GetAccidW()
+data_ACCIDENTAL_WRITTEN TransPitch::GetAccidW() const
 {
     switch (m_accid) {
         case -3: return ACCIDENTAL_WRITTEN_tf;
@@ -157,12 +157,12 @@ data_ACCIDENTAL_WRITTEN TransPitch::GetAccidW()
     LogWarning("Transposition: Could not get Written Accidental for %i", m_accid);
     return ACCIDENTAL_WRITTEN_NONE;
 }
-data_PITCHNAME TransPitch::GetPitchName()
+data_PITCHNAME TransPitch::GetPitchName() const
 {
     return static_cast<data_PITCHNAME>(m_pname + PITCHNAME_c);
 }
 
-std::wstring TransPitch::GetPitchString()
+std::wstring TransPitch::GetPitchString() const
 {
     char pitchLetter = (m_pname + ('C' - 'A')) % 7 + 'A';
     switch (m_accid) {


### PR DESCRIPTION
This finishes the basic functionality for transposition by interval.

test with a file like [71d-ChordsFrets-Multistaff.xml](https://github.com/cuthbertLab/musicxmlTestSuite/blob/master/xmlFiles/71d-ChordsFrets-Multistaff.xml)

<img width="523" alt="Screen Shot 2019-12-13 at 17 37 31" src="https://user-images.githubusercontent.com/12452738/70836802-6fd6b800-1dcf-11ea-8dc7-60a0e9c2f5bb.png">

transposed up a Major 3rd:

<img width="603" alt="Screen Shot 2019-12-13 at 17 38 47" src="https://user-images.githubusercontent.com/12452738/70836811-782ef300-1dcf-11ea-87cc-dcb7c7f65ea7.png">
