### PR TITLE
Make font file generation work on Linux

### DIFF
--- a/fonts/generate-bbox.js
+++ b/fonts/generate-bbox.js
@@ -109,4 +109,4 @@ function extract() {
     };
 }
 
-page.open(address, extract());
+page.open("file://" + fs.absolute(address), extract());

--- a/fonts/generate_all.sh
+++ b/fonts/generate_all.sh
@@ -13,8 +13,12 @@ if [ ! -e tmp ]; then
 fi
 
 if ! command -v saxon9ee >/dev/null 2>&1 ; then
-	echo >&2 "Saxon9ee is required.  Aborting.";
-	exit 1;
+	if command -v saxonb-xslt >/dev/null 2>&1 ; then
+		alias saxon9ee='saxonb-xslt -ext:on'
+	else
+		echo >&2 "Saxon9ee or saxonb-xslt is required.  Aborting.";
+		exit 1;
+	fi
 fi
 
 if ! command -v phantomjs >/dev/null 2>&1 ; then


### PR DESCRIPTION
I don't see a `saxon9ee.jar` that comes with oXygen 21, but generation also works with `saxonb-xslt` which is available in Debian package `libsaxonb-java`.

Also, I had to make the file path absolute and add the `file:` protocol to make phantomjs do its work on an Ubuntu system.