### PR TITLE
Remove unused option "m_leftPosition"

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -503,7 +503,6 @@ public:
     OptionBool m_graceRhythmAlign;
     OptionBool m_graceRightAlign;
     OptionDbl m_hairpinSize;
-    OptionDbl m_leftPosition;
     OptionDbl m_lyricHyphenLength;
     OptionDbl m_lyricHyphenWidth;
     OptionBool m_lyricNoStartHyphen;

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1455,11 +1455,6 @@ double Doc::GetTopMargin(const ClassId classId) const
     return m_options->m_defaultTopMargin.GetValue();
 }
 
-double Doc::GetLeftPosition() const
-{
-    return m_options->m_leftPosition.GetValue();
-}
-
 Page *Doc::SetDrawingPage(int pageIdx)
 {
     // out of range

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -645,10 +645,6 @@ Options::Options()
     m_hairpinSize.Init(3.0, 1.0, 8.0);
     this->Register(&m_hairpinSize, "hairpinSize", &m_generalLayout);
 
-    m_leftPosition.SetInfo("Left position", "The left position");
-    m_leftPosition.Init(0.8, 0.0, 2.0);
-    this->Register(&m_leftPosition, "leftPosition", &m_generalLayout);
-
     m_lyricHyphenLength.SetInfo("Lyric hyphen length", "The lyric hyphen and dash length");
     m_lyricHyphenLength.Init(1.20, 0.50, 3.00);
     this->Register(&m_lyricHyphenLength, "lyricHyphenLength", &m_generalLayout);


### PR DESCRIPTION
This options seems to be used nowhere.  Its name and the hints given with "SetInfo()" don't even indicate what it was meant for.

Verovio compiles and runs fine without this code.