### PR TITLE
Develop expand option for expansion element (and making sections invisble).

### DIFF
--- a/Verovio.xcodeproj/xcshareddata/xcschemes/VerovioFramework.xcscheme
+++ b/Verovio.xcodeproj/xcshareddata/xcschemes/VerovioFramework.xcscheme
@@ -83,6 +83,16 @@
             ReferencedContainer = "container:Verovio.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "/Users/werner/Goebl-OMR/Beethoven-Variationen/Op35/BreitkopfHaertel1860er/Beethoven-Op35-Eroica-Variationen-Breitkopf.mei"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-a -s 20 --expand expansion-default"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/bindings/iOS/all.h
+++ b/bindings/iOS/all.h
@@ -15,6 +15,7 @@
 #import <VerovioFramework/bboxdevicecontext.h>
 #import <VerovioFramework/damage.h>
 #import <VerovioFramework/beatrpt.h>
+#import <VerovioFramework/expansionmap.h>
 #import <VerovioFramework/page.h>
 #import <VerovioFramework/bracketspan.h>
 #import <VerovioFramework/reg.h>

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -5,6 +5,8 @@
 // Copyright (c) Authors and others. All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
 
+#include <iostream>
+
 #include "expansionmap.h"
 
 //----------------------------------------------------------------------------
@@ -35,7 +37,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
     assert(prevSect);
     // find all siblings of expansion element to know what in MEI file
     std::vector<std::string> reductionList;
-    for (auto o : prevSect->GetParent()->GetChildren()) {
+    for (auto o : *prevSect->GetParent()->GetChildren()) {
         if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG)) reductionList.push_back(o->GetUuid());
     }
 
@@ -104,7 +106,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
         Object *currSect = prevSect->GetParent()->FindDescendantByUuid(r);
         if (currSect) {
             // currSect->SetVisibility(HIDDEN); here, we will turn visibility off
-            std::cout << "Set " << r.c_str() << " to HIDDEN\n;" // DEBUG, please delete
+            std::cout << "Set " << r.c_str() << " to HIDDEN\n"; // DEBUG, please delete
         }
     }
 }

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -34,13 +34,11 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
 {
     assert(prevSect);
     // find all siblings of expansion element to know what in MEI file
-    const vrv::ArrayOfObjects* expansionSiblings = prevSect->GetParent()->GetChildren();
     std::vector<std::string> reductionList;
-    for (auto o : *expansionSiblings) {
-        if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG))
-            reductionList.push_back(o->GetUuid());
+    for (auto o : prevSect->GetParent()->GetChildren()) {
+        if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG)) reductionList.push_back(o->GetUuid());
     }
-    
+
     for (std::string s : expansionList) {
         if (s.rfind("#", 0) == 0) s = s.substr(1, s.size() - 1); // remove trailing hash from reference
         Object *currSect = prevSect->GetParent()->FindDescendantByUuid(s); // find section pointer of reference string
@@ -50,10 +48,10 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
         if (currSect->Is(EXPANSION)) { // if reference is itself an expansion, resolve it recursively
             // remove parent from reductionList, if expansion
             for (auto it = begin(reductionList); it != end(reductionList);) {
-              if ((*it).compare(currSect->GetParent()->GetUuid()) == 0)
-                it = reductionList.erase(it);
-              else
-                ++it;
+                if ((*it).compare(currSect->GetParent()->GetUuid()) == 0)
+                    it = reductionList.erase(it);
+                else
+                    ++it;
             }
             Expansion *currExpansion = dynamic_cast<Expansion *>(currSect);
             assert(currExpansion);
@@ -91,13 +89,13 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
                 prevSect = currSect;
                 existingList.push_back(s);
             }
-            
+
             // remove s from reductionList
             for (auto it = begin(reductionList); it != end(reductionList);) {
-              if ((*it).compare(s) == 0)
-                it = reductionList.erase(it);
-              else
-                ++it;
+                if ((*it).compare(s) == 0)
+                    it = reductionList.erase(it);
+                else
+                    ++it;
             }
         }
     }
@@ -106,7 +104,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
         Object *currSect = prevSect->GetParent()->FindDescendantByUuid(r);
         if (currSect) {
             // currSect->SetVisibility(HIDDEN); here, we will turn visibility off
-            std::cout << "Set |" << r.c_str() << "| to >>HIDDEN<<: " << currSect->GetUuid() << "\n"; // DEBUG, please delete
+            std::cout << "Set " << r.c_str() << " to HIDDEN\n;" // DEBUG, please delete
         }
     }
 }

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -36,8 +36,10 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
 {
     assert(prevSect);
     // find all siblings of expansion element to know what in MEI file
+    const vrv::ArrayOfObjects *expansionSiblings = prevSect->GetParent()->GetChildren();
+    assert(expansionSiblings);
     std::vector<std::string> reductionList;
-    for (auto o : *prevSect->GetParent()->GetChildren()) {
+    for (auto o : *expansionSiblings) {
         if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG)) reductionList.push_back(o->GetUuid());
     }
 


### PR DESCRIPTION
I have added the removing functionality by creating a list of strings `reductionList` (containing all relevant siblings of the initial expansion element) which gets reduced for every element in `expansionList`(or for its parent when itself an `<expansion>`). In the end, all remaining elements in `reductionList` will be set invisible (line to be inserted). 