### PR TITLE
* MusicXML Cue Chord Parsing: Set chord as 'cue' if and only if all notes are cue

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2111,7 +2111,8 @@ void MusicXmlInput::ReadMusicXmlNote(pugi::xml_node node, Measure *measure, std:
             if (chord == NULL && m_elementStack.back()->Is(CHORD)) {
                 chord = dynamic_cast<Chord *>(m_elementStack.back());
             }
-            // A chord should be marked as cue=true if and only if all its child notes are cue.
+            assert(chord);
+            // Mark a chord as cue=true if and only if all its child notes are cue.
             // (This causes it to have a smaller stem).
             if (!cue) {
                 chord->SetCue(BOOLEAN_false);


### PR DESCRIPTION
As discussed in https://github.com/rism-ch/verovio/issues/1086#issuecomment-579275550

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <work>
    <work-title>Title</work-title>
    </work>
  <identification>
    <creator type="composer">Composer</creator>
    <encoding>
      <software>MuseScore 3.3.4</software>
      <encoding-date>2020-01-29</encoding-date>
      <supports element="accidental" type="yes"/>
      <supports element="beam" type="yes"/>
      <supports element="print" attribute="new-page" type="yes" value="yes"/>
      <supports element="print" attribute="new-system" type="yes" value="yes"/>
      <supports element="stem" type="yes"/>
      </encoding>
    </identification>
  <defaults>
    <scaling>
      <millimeters>7.05556</millimeters>
      <tenths>40</tenths>
      </scaling>
    <page-layout>
      <page-height>1584</page-height>
      <page-width>1224</page-width>
      <page-margins type="even">
        <left-margin>56.6929</left-margin>
        <right-margin>56.6929</right-margin>
        <top-margin>56.6929</top-margin>
        <bottom-margin>113.386</bottom-margin>
        </page-margins>
      <page-margins type="odd">
        <left-margin>56.6929</left-margin>
        <right-margin>56.6929</right-margin>
        <top-margin>56.6929</top-margin>
        <bottom-margin>113.386</bottom-margin>
        </page-margins>
      </page-layout>
    <word-font font-family="FreeSerif" font-size="10"/>
    <lyric-font font-family="FreeSerif" font-size="11"/>
    </defaults>
  <credit page="1">
    <credit-words default-x="612" default-y="1527.31" justify="center" valign="top" font-size="24">Cue test</credit-words>
    </credit>
  <credit page="1">
    <credit-words default-x="1167.31" default-y="1427.31" justify="right" valign="bottom" font-size="12">Composer</credit-words>
    </credit>
  <part-list>
    <score-part id="P1">
      <part-name>Piano</part-name>
      <part-abbreviation>Pno.</part-abbreviation>
      <score-instrument id="P1-I1">
        <instrument-name>Piano</instrument-name>
        </score-instrument>
      <midi-device id="P1-I1" port="1"></midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>1</midi-program>
        <volume>78.7402</volume>
        <pan>0</pan>
        </midi-instrument>
      </score-part>
    </part-list>
  <part id="P1">
    <measure number="1" width="386.36">
      <print>
        <system-layout>
          <system-margins>
            <left-margin>0.00</left-margin>
            <right-margin>724.26</right-margin>
            </system-margins>
          <top-system-distance>170.00</top-system-distance>
          </system-layout>
        </print>
      <attributes>
        <divisions>2</divisions>
        <key>
          <fifths>0</fifths>
          </key>
        <time>
          <beats>2</beats>
          <beat-type>4</beat-type>
          </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
          </clef>
        </attributes>
      <note default-x="84.84" default-y="-50.00">
        <pitch>
          <step>C</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        </note>
      <note default-x="84.84" default-y="-40.00">
        <chord/>
        <pitch>
          <step>E</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        </note>
      <note default-x="84.84" default-y="-30.00">
        <chord/>
        <pitch>
          <step>G</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        </note>
        <note default-x="234.25" default-y="-50.00">
          <pitch>
            <step>C</step>
            <octave>4</octave>
            </pitch>
          <duration>1</duration>
          <voice>1</voice>
          <type>eighth</type>
          <stem>up</stem>
          </note>
        <note default-x="234.25" default-y="-40.00">
          <chord/>
          <pitch>
            <step>E</step>
            <octave>4</octave>
            </pitch>
          <duration>1</duration>
          <voice>1</voice>
          <type size="cue">eighth</type>
          <stem>up</stem>
          </note>
        <note default-x="234.25" default-y="-30.00">
          <chord/>
          <pitch>
            <step>G</step>
            <octave>4</octave>
            </pitch>
          <duration>1</duration>
          <voice>1</voice>
          <type>eighth</type>
          <stem>up</stem>
          </note>
      <note default-x="234.25" default-y="-50.00">
        <pitch>
          <step>C</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type size="cue">eighth</type>
        <stem>up</stem>
        </note>
      <note default-x="234.25" default-y="-40.00">
        <chord/>
        <pitch>
          <step>E</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type size="cue">eighth</type>
        <stem>up</stem>
        </note>
      <note default-x="234.25" default-y="-30.00">
        <chord/>
        <pitch>
          <step>G</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type size="cue">eighth</type>
        <stem>up</stem>
        </note>
        <note default-x="234.25" default-y="-50.00">
          <pitch>
            <step>C</step>
            <octave>4</octave>
            </pitch>
          <duration>1</duration>
          <voice>1</voice>
          <type size="cue">eighth</type>
          <stem>up</stem>
          </note>
        <note default-x="234.25" default-y="-40.00">
          <chord/>
          <pitch>
            <step>E</step>
            <octave>4</octave>
            </pitch>
          <duration>1</duration>
          <voice>1</voice>
          <type>eighth</type>
          <stem>up</stem>
          </note>
        <note default-x="234.25" default-y="-30.00">
          <chord/>
          <pitch>
            <step>G</step>
            <octave>4</octave>
            </pitch>
          <duration>1</duration>
          <voice>1</voice>
          <type size="cue">eighth</type>
          <stem>up</stem>
          </note>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
        </barline>
      </measure>
    </part>
  </score-partwise>
```

<img width="537" alt="Screen Shot 2020-01-29 at 11 55 24" src="https://user-images.githubusercontent.com/12452738/73378699-06cbd680-428f-11ea-9a68-27abbc3af782.png">

The MEI for these notes looks like

```xml
<chord xml:id="chord-0000001779257808" dur.ppq="1" dur="8" cue="false" stem.dir="up">
    <note xml:id="note-0000001247938630" oct="4" pname="c" />
    <note xml:id="note-0000000276194581" oct="4" pname="e" />
    <note xml:id="note-0000001290161700" oct="4" pname="g" />
</chord>
<chord xml:id="chord-0000000783889948" dur.ppq="1" dur="8" cue="false" stem.dir="up">
    <note xml:id="note-0000000605308141" oct="4" pname="c" />
    <note xml:id="note-0000000026181691" oct="4" pname="e" cue="true" />
    <note xml:id="note-0000001949016649" oct="4" pname="g" />
</chord>
<chord xml:id="chord-0000000136721268" dur.ppq="1" dur="8" cue="true" stem.dir="up">
    <note xml:id="note-0000001554752052" oct="4" pname="c" cue="true" />
    <note xml:id="note-0000000066848986" oct="4" pname="e" cue="true" />
    <note xml:id="note-0000000396960321" oct="4" pname="g" cue="true" />
</chord>
<chord xml:id="chord-0000001299101475" dur.ppq="1" dur="8" cue="false" stem.dir="up">
    <note xml:id="note-0000001627907465" oct="4" pname="c" cue="true" />
    <note xml:id="note-0000000532251276" oct="4" pname="e" />
    <note xml:id="note-0000001277805977" oct="4" pname="g" cue="true" />
</chord>
```