### PR TITLE
MusicXML import: add support for after-barline attribute of clef element

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -109,12 +109,13 @@ namespace musicxml {
 
     class ClefChange {
     public:
-        ClefChange(const std::string &measureNum, Staff *staff, Clef *clef, const int &scoreOnset)
+        ClefChange(const std::string &measureNum, Staff *staff, Clef *clef, const int &scoreOnset, bool afterBarline)
         {
             m_measureNum = measureNum;
             m_staff = staff;
             m_clef = clef;
             m_scoreOnset = scoreOnset;
+            m_afterBarline = afterBarline;
         }
 
         std::string m_measureNum;
@@ -122,6 +123,7 @@ namespace musicxml {
         Clef *m_clef;
         int m_scoreOnset; // the score position of clef change
         bool isFirst = true; // insert clef change at first layer, others use @sameas
+        bool m_afterBarline = false; // musicXML attribute
     };
 
     class OpenDashes {
@@ -189,7 +191,7 @@ private:
     void ReadMusicXmlFigures(pugi::xml_node node, Measure *measure, std::string measureNum);
     void ReadMusicXmlForward(pugi::xml_node, Measure *measure, std::string measureNum);
     void ReadMusicXmlHarmony(pugi::xml_node, Measure *measure, std::string measureNum);
-    void ReadMusicXmlNote(pugi::xml_node, Measure *measure, std::string measureNum, int staffOffset);
+    void ReadMusicXmlNote(pugi::xml_node, Measure *measure, std::string measureNum, int staffOffset, Section *section);
     void ReadMusicXmlPrint(pugi::xml_node, Section *section);
     ///@}
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1257,13 +1257,9 @@ void MusicXmlInput::ReadMusicXmlAttributes(
                 else
                     meiClef->SetDisPlace(STAFFREL_basic_above);
             }
-            bool afterBarline = false;
+            bool afterBarline = false; // read after-barline attribute of clef; default is false (thus: before barline)
             std::string afterBarlineText = clef.node().attribute("after-barline").as_string();
-            if (!afterBarlineText.empty()) {
-                LogMessage("Measure: %s %s, Clef: %s, after-barline: %s, durTotal: %d", measure->GetN().c_str(),
-                    measure->GetUuid().c_str(), meiClef->GetUuid().c_str(), afterBarlineText.c_str(), m_durTotal);
-                if (afterBarlineText.compare("yes") == 0) afterBarline = true;
-            }
+            if (!afterBarlineText.empty() && afterBarlineText.compare("yes") == 0) afterBarline = true;
             m_ClefChangeStack.push_back(musicxml::ClefChange(measureNum, staff, meiClef, m_durTotal, afterBarline));
         }
     }
@@ -1909,11 +1905,8 @@ void MusicXmlInput::ReadMusicXmlNote(
                         }
                         if (prevLayer == NULL)
                             AddLayerElement(layer, iter->m_clef);
-                        else {
+                        else
                             AddLayerElement(prevLayer, iter->m_clef);
-                            LogMessage("afterbarline Measure: %s %s, Previous measure: %d %s ", measure->GetN().c_str(),
-                                measure->GetUuid().c_str(), prevLayer->GetN(), prevLayer->GetUuid().c_str());
-                        }
                     }
                     else {
                         AddLayerElement(layer, iter->m_clef);


### PR DESCRIPTION
This PR addresses an issue described in #1287. 

The `after-barline` attribute of the `clef` element is now parsed into a boolean. The clef change is added to the same layer of the previous measure (before the barline in MEI), if `after-barline="no"`, or after the barline, if `after-barline="yes".  New default behavior: when no attribute is given, clefs are moved _before_ the barline.