### PR TITLE
* measure @bar.len and @bar.place: Count upwards instead of downwards

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1415,7 +1415,8 @@ void MusicXmlInput::ReadMusicXmlBarLine(pugi::xml_node node, Measure *measure, s
                 if (barStyle == "short")
                     measure->SetBarPlace(2);
                 else
-                    measure->SetBarPlace(-2);
+                    // bar.place counts in note order (high values are vertically higher).
+                    measure->SetBarPlace(6);
             }
         }
     }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -636,15 +636,16 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                 if (staff->GetVisible() == BOOLEAN_false) {
                     continue;
                 }
-                int yTop = staff->GetDrawingY();
-                if (measure->HasBarPlace()) {
-                    yTop += measure->GetBarPlace() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-                }
                 // for the bottom position we need to take into account the number of lines and the staff size
                 int yBottom = staff->GetDrawingY()
                     - (childStaffDef->GetLines() - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+                if (measure->HasBarPlace()) {
+                    // bar.place counts upwards (note order).
+                    yBottom += measure->GetBarPlace() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+                }
+                int yTop = staff->GetDrawingY();
                 if (measure->HasBarLen()) {
-                    yBottom = yTop - (measure->GetBarLen() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
+                    yTop = yBottom + (measure->GetBarLen() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
                 }
                 // Make sure barlines are visible with a single line
                 if (childStaffDef->GetLines() == 1) {


### PR DESCRIPTION
Close #1286

Implements bar.place (and bar.len) as described in https://github.com/rism-ch/verovio/issues/1286#issuecomment-580469649 (and fixes the musicXML conversion of 'tick' and 'short' barlines).

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <work>
    <work-title>Tick, then Short</work-title>
    </work>
  <part-list>
    <score-part id="P1">
      <part-name>Piano</part-name>
      <part-abbreviation>Pno.</part-abbreviation>
      </score-part>
    </part-list>
  <part id="P1">
    <measure number="1" width="190.50">
      <attributes>
        <divisions>1</divisions>
        <key>
          <fifths>0</fifths>
          </key>
        <time>
          <beats>4</beats>
          <beat-type>4</beat-type>
          </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
          </clef>
        </attributes>
      <note>
        <rest/>
        <duration>4</duration>
        <voice>1</voice>
        </note>
      <barline location="right">
        <bar-style>tick</bar-style>
        </barline>
      </measure>
    <measure number="2" width="136.83">
      <note>
        <rest/>
        <duration>4</duration>
        <voice>1</voice>
        </note>
      <barline location="right">
        <bar-style>short</bar-style>
        </barline>
      </measure>
    </part>
  </score-partwise>
```

Produces the following MEI
```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Tick, then Short</title>
                <respStmt />
            </titleStmt>
            <pubStmt></pubStmt>
        </fileDesc>
        <encodingDesc xml:id="encodingdesc-0000001341597462">
            <appInfo xml:id="appinfo-0000001797733981">
                <application xml:id="application-0000001567589024" isodate="2020-01-31T10:43:17" version="2.5.0-dev-374b0cd-dirty">
                    <name xml:id="name-0000001139344972">Verovio</name>
                    <p xml:id="p-0000002006747752">Transcoded from MusicXML</p>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mdiv-0000001178791729">
                <score xml:id="score-0000001415945728">
                    <scoreDef xml:id="scoredef-0000000992837636">
                        <staffGrp xml:id="staffgrp-0000000412070529">
                            <staffDef xml:id="staffdef-0000001588334219" n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4">
                                <keySig xml:id="keysig-0000000449474472" sig="0" />
                                <label xml:id="label-0000000034619328">Piano</label>
                                <labelAbbr xml:id="labelAbbr-0000001786970069">Pno.</labelAbbr>
                            </staffDef>
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="section-0000001533558089">
                        <measure xml:id="measure-0000001876251109" bar.len="4.000000" bar.place="6" right="single" n="1">
                            <staff xml:id="staff-0000001697924409" n="1">
                                <layer xml:id="layer-0000001252840727" n="1">
                                    <mRest xml:id="mrest-0000000416939854" />
                                </layer>
                            </staff>
                        </measure>
                        <measure xml:id="measure-0000000268986017" bar.len="4.000000" bar.place="2" right="single" n="2">
                            <staff xml:id="staff-0000001220642293" n="1">
                                <layer xml:id="layer-0000000423738660" n="1">
                                    <mRest xml:id="mrest-0000000719885168" />
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```

Which produces the following score:

<img width="349" alt="Screen Shot 2020-01-31 at 10 45 01" src="https://user-images.githubusercontent.com/12452738/73552771-d6af3f80-4416-11ea-879b-3f47bd1f13de.png">