### PR TITLE
Added adjustPageWidth option

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -462,6 +462,7 @@ public:
     OptionGrp m_general;
 
     OptionBool m_adjustPageHeight;
+    OptionBool m_adjustPageWidth;
     OptionIntMap m_breaks;
     OptionBool m_condenseEncoded;
     OptionBool m_condenseFirstPage;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -494,9 +494,13 @@ Options::Options()
     m_general.SetLabel("Input and page layout options", "1-general");
     m_grps.push_back(&m_general);
 
-    m_adjustPageHeight.SetInfo("Adjust page height", "Crop the page height to the height of the content");
+    m_adjustPageHeight.SetInfo("Adjust page height", "Adjust the page height to the height of the content");
     m_adjustPageHeight.Init(false);
     this->Register(&m_adjustPageHeight, "adjustPageHeight", &m_general);
+
+    m_adjustPageWidth.SetInfo("Adjust page width", "Adjust the page width to the width of the content");
+    m_adjustPageWidth.Init(false);
+    this->Register(&m_adjustPageWidth, "adjustPageWidth", &m_general);
 
     m_breaks.SetInfo("Breaks", "Define page and system breaks layout");
     m_breaks.Init(BREAKS_auto, &Option::s_breaks);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -476,6 +476,11 @@ void Page::JustifyHorizontally()
     // Make sure we have the correct page
     assert(this == doc->GetDrawingPage());
 
+    if ((doc->GetOptions()->m_adjustPageWidth.GetValue()))
+        doc->m_drawingPageWidth = GetContentWidth()
+            + doc->m_drawingPageMarginLeft
+            + doc->m_drawingPageMarginRight;
+
     // Justify X position
     Functor justifyX(&Object::JustifyX);
     JustifyXParams justifyXParams(&justifyX, doc);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1140,9 +1140,13 @@ bool Toolkit::RenderToDeviceContext(int pageNo, DeviceContext *deviceContext)
     // Adjusting page width and height according to the options
     int width = m_options->m_pageWidth.GetUnfactoredValue();
     int height = m_options->m_pageHeight.GetUnfactoredValue();
+    int breaks = m_options->m_breaks.GetValue();
+    bool adjustHeight = m_options->m_adjustPageHeight.GetValue();
+    bool adjustWidth = m_options->m_adjustPageWidth.GetValue();
 
-    if (m_options->m_breaks.GetValue() == BREAKS_none) width = m_doc.GetAdjustedDrawingPageWidth();
-    if (m_options->m_adjustPageHeight.GetValue() || (m_options->m_breaks.GetValue() == BREAKS_none))
+    if (adjustWidth || (breaks == BREAKS_none))
+        width = m_doc.GetAdjustedDrawingPageWidth();
+    if (adjustHeight || (breaks == BREAKS_none))
         height = m_doc.GetAdjustedDrawingPageHeight();
 
     if (m_doc.GetType() == Transcription) {


### PR DESCRIPTION
This is a suggested implementation of the adjust page width option:
https://github.com/rism-ch/verovio/issues/1276

This is being referred to as cropping, but in my opinion it is equally useful (like adjustPageHeight) for extending the width. I might be missing something fundamental, but I can't see any other reliable way of getting acceptable layout when breaks are encoded. Otherwise one have to do a magic guess for a suitable width that fits the content, which probably will lead to compressed content or blank trailing space.