### PR TITLE
Modified Page::GetContentWidth to take max width from all systems

### DIFF
--- a/src/page.cpp
+++ b/src/page.cpp
@@ -592,14 +592,19 @@ int Page::GetContentWidth() const
     // Make sure we have the correct page
     assert(this == doc->GetDrawingPage());
 
-    System *first = dynamic_cast<System *>(m_children.front());
-    assert(first);
-
+    int maxWidth = 0;
+    for (auto & child : m_children) {
+        System *system = dynamic_cast<System *>(child);
+        if (system) {
+            // we include the left margin and the right margin
+            int systemWidth = system->m_drawingTotalWidth + system->m_systemLeftMar + system->m_systemRightMar;
+            maxWidth = std::max(systemWidth, maxWidth);
+        }
+    }
     // For avoiding unused variable warning in non debug mode
     doc = NULL;
 
-    // we include the left margin and the right margin
-    return first->m_drawingTotalWidth + first->m_systemLeftMar + first->m_systemRightMar;
+    return maxWidth;
 }
 
 int Page::CalcJustificationStepSize(bool systemsOnly) const


### PR DESCRIPTION
It seems that for the adjustPageWidth to work properly, it should take all systems into consideration, so I added a loop through all of them. Not sure if m_children could have entries other than System*, and if you would prefer assert(system) rather than if(system)