### PR TITLE
Fix and improve support for extender lines

### DIFF
--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -27,8 +27,9 @@ class Dir : public ControlElement,
             public TextListInterface,
             public TextDirInterface,
             public TimeSpanningInterface,
-            public AttLang,
             public AttExtender,
+            public AttLang,
+            public AttLineRendBase,
             public AttVerticalGroup {
 public:
     /**

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -25,6 +25,7 @@ class Dynam : public ControlElement,
               public TextDirInterface,
               public TimeSpanningInterface,
               public AttExtender,
+              public AttLineRendBase,
               public AttVerticalGroup {
 public:
     /**

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -298,6 +298,7 @@ private:
     data_BARRENDITION ConvertStyleToRend(std::string value, bool repeat);
     data_BOOLEAN ConvertWordToBool(std::string value);
     data_DURATION ConvertTypeToDur(std::string value);
+    data_LINESTARTENDSYMBOL ConvertLineEndSymbol(std::string value);
     std::wstring ConvertTypeToVerovioText(std::string value);
     data_PITCHNAME ConvertStepToPitchName(std::string value);
     curvature_CURVEDIR ConvertOrientationToCurvedir(std::string);

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -31,12 +31,14 @@ Dir::Dir()
     , TextDirInterface()
     , TimeSpanningInterface()
     , AttLang()
+    , AttLineRendBase()
     , AttVerticalGroup()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_LANG);
     RegisterAttClass(ATT_EXTENDER);
+    RegisterAttClass(ATT_LINERENDBASE);
     RegisterAttClass(ATT_VERTICALGROUP);
 
     Reset();
@@ -49,8 +51,9 @@ void Dir::Reset()
     ControlElement::Reset();
     TextDirInterface::Reset();
     TimeSpanningInterface::Reset();
-    ResetLang();
     ResetExtender();
+    ResetLang();
+    ResetLineRendBase();
     ResetVerticalGroup();
 }
 

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -38,11 +38,13 @@ Dynam::Dynam()
     , TextDirInterface()
     , TimeSpanningInterface()
     , AttExtender()
+    , AttLineRendBase()
     , AttVerticalGroup()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_EXTENDER);
+    RegisterAttClass(ATT_LINERENDBASE);
     RegisterAttClass(ATT_VERTICALGROUP);
 
     Reset();
@@ -56,6 +58,7 @@ void Dynam::Reset()
     TextDirInterface::Reset();
     TimeSpanningInterface::Reset();
     ResetExtender();
+    ResetLineRendBase();
     ResetVerticalGroup();
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3254,7 +3254,7 @@ bool MeiInput::ReadBoundaryEnd(Object *parent, pugi::xml_node boundaryEnd)
         start = m_doc->FindDescendantByUuid(startUuid);
     }
     if (!start) {
-        LogError("Could not find start element '%s' for boundaryEnd", startUuid.c_str());
+        LogError("Could not find start element <%s> for boundaryEnd", startUuid.c_str());
         return false;
     }
 
@@ -3571,7 +3571,7 @@ bool MeiInput::ReadRunningChildren(Object *parent, pugi::xml_node parentNode, Ob
         }
         // unknown
         else {
-            LogWarning("Element %s is unknown and will be ignored", xmlElement.name());
+            LogWarning("Element <%s> is unknown and will be ignored", xmlElement.name());
         }
         i++;
     }
@@ -4316,7 +4316,7 @@ bool MeiInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         }
         // unknown
         else {
-            LogWarning("Element '%s' is unknown and will be ignored", xmlElement.name());
+            LogWarning("Element <%s> is unknown and will be ignored", xmlElement.name());
         }
     }
 
@@ -4944,7 +4944,7 @@ bool MeiInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
         }
         // unknown
         else {
-            LogWarning("Element %s is unknown and will be ignored", xmlElement.name());
+            LogWarning("Element <%s> is unknown and will be ignored", xmlElement.name());
         }
         i++;
     }
@@ -5987,7 +5987,7 @@ bool MeiInput::ReadSurface(Facsimile *parent, pugi::xml_node surface)
             ReadZone(vrvSurface, child);
         }
         else {
-            LogWarning("Unsupported element '%s' in <surface>", child.name());
+            LogWarning("Unsupported element <%s> in <surface>", child.name());
         }
     }
     parent->AddChild(vrvSurface);
@@ -6017,7 +6017,7 @@ bool MeiInput::ReadFacsimile(Doc *doc, pugi::xml_node facsimile)
             ReadSurface(vrvFacsimile, child);
         }
         else {
-            LogWarning("Unsupported element '%s' in <facsimile>", child.name());
+            LogWarning("Unsupported element <%s> in <facsimile>", child.name());
         }
     }
     doc->SetFacsimile(vrvFacsimile);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1154,6 +1154,7 @@ void MeiOutput::WriteDir(pugi::xml_node currentNode, Dir *dir)
     WriteTextDirInterface(currentNode, dir);
     WriteTimeSpanningInterface(currentNode, dir);
     dir->WriteLang(currentNode);
+    dir->WriteLineRendBase(currentNode);
     dir->WriteExtender(currentNode);
     dir->WriteVerticalGroup(currentNode);
 }
@@ -1166,6 +1167,7 @@ void MeiOutput::WriteDynam(pugi::xml_node currentNode, Dynam *dynam)
     WriteTextDirInterface(currentNode, dynam);
     WriteTimeSpanningInterface(currentNode, dynam);
     dynam->WriteExtender(currentNode);
+    dynam->WriteLineRendBase(currentNode);
     dynam->WriteVerticalGroup(currentNode);
 }
 
@@ -3869,6 +3871,7 @@ bool MeiInput::ReadDir(Object *parent, pugi::xml_node dir)
     ReadTextDirInterface(dir, vrvDir);
     ReadTimeSpanningInterface(dir, vrvDir);
     vrvDir->ReadLang(dir);
+    vrvDir->ReadLineRendBase(dir);
     vrvDir->ReadExtender(dir);
     vrvDir->ReadVerticalGroup(dir);
 
@@ -3885,6 +3888,7 @@ bool MeiInput::ReadDynam(Object *parent, pugi::xml_node dynam)
     ReadTextDirInterface(dynam, vrvDynam);
     ReadTimeSpanningInterface(dynam, vrvDynam);
     vrvDynam->ReadExtender(dynam);
+    vrvDynam->ReadLineRendBase(dynam);
     vrvDynam->ReadVerticalGroup(dynam);
 
     parent->AddChild(vrvDynam);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -416,8 +416,9 @@ void MusicXmlInput::TextRendition(pugi::xpath_node_set words, ControlElement *el
             rend->AddChild(text);
             element->AddChild(rend);
         }
-        else
+        else {
             element->AddChild(text);
+        }
     }
 }
 
@@ -640,6 +641,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             staffOffset += nbStaves;
         }
         else {
+            // do nothing
         }
     }
     // here we could check that we have that there is only one staffGrp left in m_staffGrpStack
@@ -1724,7 +1726,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
             m_controlElements.push_back(std::make_pair(measureNum, pedal));
             m_pedalStack.push_back(pedal);
         }
-        else LogWarning("MusicXML import: pedal lines are not supported");
+        else {
+            LogWarning("MusicXML import: pedal lines are not supported");
+        }
     }
 
     // Principal voice
@@ -1763,8 +1767,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
         if (words.size() != 0) TextRendition(words, tempo);
         if (metronome)
             PrintMetronome(metronome.node(), tempo);
-        else
+        else {
             tempo->SetMidiBpm(node.select_node("sound").node().attribute("tempo").as_int());
+        }
         m_controlElements.push_back(std::make_pair(measureNum, tempo));
         m_tempoStack.push_back(tempo);
     }
@@ -1907,10 +1912,12 @@ void MusicXmlInput::ReadMusicXmlNote(
                             prevLayer = dynamic_cast<Layer *>(*rit);
                             if (prevLayer->GetN() == layer->GetN()) break;
                         }
-                        if (prevLayer == NULL)
+                        if (prevLayer == NULL) {
                             AddLayerElement(layer, iter->m_clef);
-                        else
+                        }
+                        else {
                             AddLayerElement(prevLayer, iter->m_clef);
+                        }
                     }
                     else {
                         AddLayerElement(layer, iter->m_clef);
@@ -2012,8 +2019,10 @@ void MusicXmlInput::ReadMusicXmlNote(
             if (!typeStr.empty()) {
                 space->SetDur(ConvertTypeToDur(typeStr));
             }
-            // this should be mSpace
-            else space->SetDur(DURATION_1);
+            else {
+                // this should be mSpace
+                space->SetDur(DURATION_1);
+            }
             AddLayerElement(layer, space);
         }
         // we assume /note without /type or with duration of an entire bar to be mRest
@@ -2096,8 +2105,9 @@ void MusicXmlInput::ReadMusicXmlNote(
                     note->SetOct(atoi(octaveStr.c_str()) - m_octDis[staff->GetN()]);
                     note->SetOctGes(atoi(octaveStr.c_str()));
                 }
-                else
+                else {
                     note->SetOct(atoi(octaveStr.c_str()));
+                }
             }
             std::string alterStr = GetContentOfChild(pitch.node(), "alter");
             if (!alterStr.empty()) {
@@ -2489,8 +2499,9 @@ void MusicXmlInput::ReadMusicXmlNote(
                     arpeggio->SetOrder(arpegLog_ORDER_up);
                 else if (direction == "down")
                     arpeggio->SetOrder(arpegLog_ORDER_down);
-                else
+                else {
                     arpeggio->SetOrder(arpegLog_ORDER_NONE);
+                }
             }
             m_ArpeggioStack.push_back(std::make_pair(arpeggio, musicxml::OpenArpeggio(arpegN, onset)));
             m_controlElements.push_back(std::make_pair(measureNum, arpeggio));

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1730,7 +1730,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
     // Principal voice
     pugi::xpath_node lead = type.node().select_node("principal-voice");
     if (lead) {
-        int voiceNumber = wedge.node().attribute("number").as_int();
+        int voiceNumber = lead.node().attribute("number").as_int();
         voiceNumber = (voiceNumber < 1) ? 1 : voiceNumber;
         if (HasAttributeWithValue(lead.node(), "type", "stop")) {
             int measureDifference = m_measureCounts.at(measure) - m_bracketStack.front().second.m_lastMeasureCount;
@@ -1744,6 +1744,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             bracketSpan->SetColor(lead.node().attribute("color").as_string());
             // bracketSpan->SetPlace(bracketSpan->AttPlacement::StrToStaffrel(placeStr.c_str()));
             bracketSpan->SetFunc("analytical");
+            bracketSpan->SetLstartsym(ConvertLineEndSymbol(lead.node().attribute("symbol").as_string()));
             bracketSpan->SetTstamp(timeStamp);
             bracketSpan->SetType("principal-voice");
             m_controlElements.push_back(std::make_pair(measureNum, bracketSpan));
@@ -2784,6 +2785,23 @@ std::wstring MusicXmlInput::ConvertTypeToVerovioText(std::string value)
     else {
         LogWarning("MusicXML import: Unsupported type '%s'", value.c_str());
         return L"";
+    }
+}
+
+data_LINESTARTENDSYMBOL MusicXmlInput::ConvertLineEndSymbol(std::string value)
+{
+    if (value == "arrow")
+        return LINESTARTENDSYMBOL_arrow;
+    else if (value == "Hauptstimme")
+        return LINESTARTENDSYMBOL_H;
+    else if (value == "Nebenstimme")
+        return LINESTARTENDSYMBOL_N;
+    else if (value == "none")
+        return LINESTARTENDSYMBOL_none;
+    else if (value == "plain")
+        return LINESTARTENDSYMBOL_NONE;
+    else {
+        return LINESTARTENDSYMBOL_NONE;
     }
 }
 


### PR DESCRIPTION
The support for MusicXML `dashes` didn't work, now it does. 
Also this adds support for the import of `bracket` directions, whether as extender or stand alone objects. 
Additionally MEI `dir` and `dynam` now support import/export of line rendition, and the start symbol from MusicXML's prinicpal voice is imported correctly.