### PR TITLE
Container staffGrp brackets and braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [unreleased]
+* Container brackets and braces in grpSym (@rettinghaus)
+* Support for reh elements (@rettinghaus)
+* Improved extender lines in MusicXML import (@rettinghaus)
+* Fix bug with choice and mdiv (@rettinghaus)
+* Fix tempo placement (@rettinghaus)
 * Fix Leipzig font validation issues
 
 ## [2.5.0] - 2020-02-03
@@ -14,7 +19,7 @@
 * Options --format and --type deprecated (use --from and --to instead)
 
 ## [2.4.0] - 2020-01-15
-* Support for short and tick barlines  with `measure@bar.len` and `measure@bar.place` (@earboxer)
+* Support for short and tick barlines with `measure@bar.len` and `measure@bar.place` (@earboxer)
 * Support for dashed and dotted slurs and ties (@earboxer and @napulen)
 * Option to use xml entities for SMuFL charachters (--outputSmuflXmlEntities)
 * Options for controlling system divider display (--systemDivider "none|left|left-right")
@@ -32,7 +37,7 @@
 * Fix bug with mordent when loading MEI 3.0 files
 
 ## [2.3.1] - 2019-11-16
-* Fix  bug with scoreDef / staffDef redefinition
+* Fix bug with scoreDef / staffDef redefinition
 
 ## [2.3.0] - 2019-11-04
 * Support for 512th and 1024th duration

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -515,14 +515,19 @@ void View::DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     x2 = x - m_doc->GetDrawingBeamWidth(staffSize, false);
     x1 = x2 - m_doc->GetDrawingBeamWidth(staffSize, false);
 
+    dc->StartCustomGraphic("grpSym");
+
     DrawSmuflCode(dc, x1, y1, SMUFL_E003_bracketTop, staffSize, false);
-    DrawSmuflCode(dc, x1, y2, SMUFL_E004_bracketBottom, staffSize, false);
 
     // adjust to top and bottom position so we make sure there is no white space between
     // the glyphs and the line
     y1 += m_doc->GetDrawingStemWidth(staffSize);
     y2 -= m_doc->GetDrawingStemWidth(staffSize);
     DrawFilledRectangle(dc, x1, y1, x2, y2);
+
+    DrawSmuflCode(dc, x1, y2, SMUFL_E004_bracketBottom, staffSize, false);
+
+    dc->EndCustomGraphic();
 
     return;
 }
@@ -572,6 +577,8 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     bez2[2] = points[2];
     bez2[3] = points[3];
 
+    dc->StartCustomGraphic("grpSym");
+
     dc->SetPen(m_currentColour, std::max(1, penWidth), AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);
 
@@ -600,6 +607,8 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
 
     dc->ResetPen();
     dc->ResetBrush();
+
+    dc->EndCustomGraphic();
 
     return;
 }


### PR DESCRIPTION
Brackets and braces from `<staffGrp>` are now contained within a `<g class="grpSym">` referencing the MEI element `<grpSym>` until it's supported natively. 