### PR TITLE
Improve staffGrp

### DIFF
--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -30,7 +30,8 @@ class ScoreDefInterface : public Interface,
                           public AttLyricStyle,
                           public AttMeasureNumbers,
                           public AttMidiTempo,
-                          public AttMultinumMeasures {
+                          public AttMultinumMeasures,
+                          public AttSystems {
 public:
     /**
      * @name Constructors, destructors, reset methods

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -192,6 +192,7 @@ protected:
     void DrawLabels(DeviceContext *dc, Measure *measure, System *system, Object *object, int x, int y,
         bool abbreviations, int staffSize, int space);
     void DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize);
+    void DrawBracketsq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
     void DrawBarLine(DeviceContext *dc, int y_top, int y_bottom, BarLine *barLine, bool eraseIntersections = false);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -971,6 +971,7 @@ void MeiOutput::WriteScoreDefElement(pugi::xml_node currentNode, ScoreDefElement
 
     WriteXmlId(currentNode, scoreDefElement);
     scoreDefElement->WriteMeasureNumbers(currentNode);
+    scoreDefElement->WriteSystems(currentNode);
     scoreDefElement->WriteTyped(currentNode);
 }
 
@@ -3286,6 +3287,7 @@ bool MeiInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
 {
     SetMeiUuid(element, object);
     object->ReadMeasureNumbers(element);
+    object->ReadSystems(element);
     object->ReadTyped(element);
 
     AttCleffingLog cleffingLog;
@@ -4467,7 +4469,7 @@ bool MeiInput::ReadBeatRpt(Object *parent, pugi::xml_node beatRpt)
 
     vrvBeatRpt->ReadColor(beatRpt);
     vrvBeatRpt->ReadBeatRptVis(beatRpt);
-    
+
     if (m_version < MEI_4_0_0) {
         UpgradeBeatRptTo_4_0_0(beatRpt, vrvBeatRpt);
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -530,14 +530,17 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                 StaffGrp *staffGrp = new StaffGrp();
                 // read the group-symbol (MEI @symbol)
                 std::string groupGymbol = GetContentOfChild(xpathNode.node(), "group-symbol");
-                if (groupGymbol == "bracket") {
-                    staffGrp->SetSymbol(staffGroupingSym_SYMBOL_bracket);
-                }
-                else if (groupGymbol == "brace") {
+                if (groupGymbol == "brace") {
                     staffGrp->SetSymbol(staffGroupingSym_SYMBOL_brace);
                 }
                 else if (groupGymbol == "line") {
                     staffGrp->SetSymbol(staffGroupingSym_SYMBOL_line);
+                }
+                else if (groupGymbol == "bracket") {
+                    staffGrp->SetSymbol(staffGroupingSym_SYMBOL_bracket);
+                }
+                else if (groupGymbol == "square") {
+                    staffGrp->SetSymbol(staffGroupingSym_SYMBOL_bracketsq);
                 }
                 // now stack it
                 m_staffGrpStack.back()->AddChild(staffGrp);

--- a/src/scoredefinterface.cpp
+++ b/src/scoredefinterface.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 ScoreDefInterface::ScoreDefInterface()
-    : Interface(), AttLyricStyle(), AttMeasureNumbers(), AttMidiTempo(), AttMultinumMeasures()
+    : Interface(), AttLyricStyle(), AttMeasureNumbers(), AttMidiTempo(), AttMultinumMeasures(), AttSystems()
 {
     RegisterInterfaceAttClass(ATT_LYRICSTYLE);
     RegisterInterfaceAttClass(ATT_MEASURENUMBERS);
@@ -32,6 +32,7 @@ ScoreDefInterface::ScoreDefInterface()
     RegisterInterfaceAttClass(ATT_METERSIGDEFAULTVIS);
     RegisterInterfaceAttClass(ATT_MIDITEMPO);
     RegisterInterfaceAttClass(ATT_MULTINUMMEASURES);
+    RegisterInterfaceAttClass(ATT_SYSTEMS);
 
     Reset();
 }
@@ -44,6 +45,7 @@ void ScoreDefInterface::Reset()
     ResetMeasureNumbers();
     ResetMidiTempo();
     ResetMultinumMeasures();
+    ResetSystems();
 }
 
 } // namespace vrv


### PR DESCRIPTION
This PR adds support for `bracketsq` as group symbol and changes `line` according to MEI4. 
Additionally it adds support for `@system.leftline` on `<scoreDef>`. Now even single staff systems get a starting barline, when they carry a group symbol. 