### PR TITLE
Avoid code duplication for musxml slur and tie direction

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -301,7 +301,7 @@ private:
     data_LINESTARTENDSYMBOL ConvertLineEndSymbol(std::string value);
     std::wstring ConvertTypeToVerovioText(std::string value);
     data_PITCHNAME ConvertStepToPitchName(std::string value);
-    curvature_CURVEDIR ConvertOrientationToCurvedir(std::string);
+    curvature_CURVEDIR InferCurvedir(pugi::xml_node slurOrTie);
     fermataVis_SHAPE ConvertFermataShape(std::string);
     pedalLog_DIR ConvertPedalTypeToDir(std::string value);
     tupletVis_NUMFORMAT ConvertTupletNumberValue(std::string value);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2429,11 +2429,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             // color
             tie->SetColor(startTie.node().attribute("color").as_string());
             // placement and orientation
-            tie->SetCurvedir(
-                tie->AttCurvature::StrToCurvatureCurvedir(startTie.node().attribute("placement").as_string()));
-            if (!startTie.node().attribute("orientation").empty()) { // override only with non-empty attribute
-                tie->SetCurvedir(ConvertOrientationToCurvedir(startTie.node().attribute("orientation").as_string()));
-            }
+            tie->SetCurvedir(InferCurvedir(startTie.node()));
             tie->SetLform(tie->AttCurveRend::StrToLineform(startTie.node().attribute("line-type").as_string()));
 
             // add it to the stack
@@ -2691,10 +2687,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             // lineform
             meiSlur->SetLform(meiSlur->AttCurveRend::StrToLineform(slur.attribute("line-type").as_string()));
             // placement and orientation
-            meiSlur->SetCurvedir(ConvertOrientationToCurvedir(slur.attribute("orientation").as_string()));
-            std::string placement = slur.attribute("placement").as_string();
-            if (!placement.empty())
-                meiSlur->SetCurvedir(meiSlur->AttCurvature::StrToCurvatureCurvedir(placement.c_str()));
+            meiSlur->SetCurvedir(InferCurvedir(slur));
             // add it to the stack
             m_controlElements.push_back(std::make_pair(measureNum, meiSlur));
             OpenSlur(measure, slurNumber, meiSlur);
@@ -3008,14 +3001,21 @@ data_PITCHNAME MusicXmlInput::ConvertStepToPitchName(std::string value)
     }
 }
 
-curvature_CURVEDIR MusicXmlInput::ConvertOrientationToCurvedir(std::string value)
+curvature_CURVEDIR MusicXmlInput::InferCurvedir(pugi::xml_node slurOrTie)
 {
-    if (value == "over")
+    std::string orientation = slurOrTie.attribute("orientation").as_string();
+    if (orientation == "over")
         return curvature_CURVEDIR_above;
-    else if (value == "under")
+    if (orientation == "under")
         return curvature_CURVEDIR_below;
-    else
-        return curvature_CURVEDIR_NONE;
+
+    std::string placement = slurOrTie.attribute("placement").as_string();
+    if (placement == "above")
+        return curvature_CURVEDIR_above;
+    if (placement == "below")
+        return curvature_CURVEDIR_below;
+
+    return curvature_CURVEDIR_NONE;
 }
 
 fermataVis_SHAPE MusicXmlInput::ConvertFermataShape(std::string value)


### PR DESCRIPTION
dc8d1cf already fixed the problem that `@orientation` was ignored on slurs, but now we have two different solutions for the same problem that are inconsistent (one favoring `@orientation`, the other `@placement`).