### PR TITLE
Add reference to original id in class attribute of cross-system objects

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -227,6 +227,8 @@ public:
     void ResetUuid();
     static void SeedUuid(unsigned int seed = 0);
 
+    std::string GetSpanningClasses();
+
     std::string GetComment() const { return m_comment; }
     void SetComment(std::string comment) { m_comment = comment; }
     bool HasComment() { return !m_comment.empty(); }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -300,6 +300,22 @@ void Object::SwapUuid(Object *other)
     other->SetUuid(swapUuid);
 }
 
+/**
+ * Constructs classes that are used for objects that span multiple systems and
+ * are therefore rendered as multiple elements. Only one of the rendered
+ * elements can "inherit" the unique id of the object. Subsequent rendered
+ * elements are given a class of the for "id-" + id to make them identifiable as
+ * belonging together.
+ */
+std::string Object::GetSpanningClasses()
+{
+    std::string spanningClass = "spanning-" + m_classid;
+    // Remove trailing "-"
+    spanningClass.pop_back();
+    if (m_uuid.empty()) return spanningClass;
+    return spanningClass + " id-" + m_uuid;
+}
+
 void Object::ClearChildren()
 {
     if (m_isReferenceObject) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -369,7 +369,7 @@ void View::DrawBracketSpan(
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else {
-        dc->StartGraphic(bracketSpan, "spanning-bracketspan", "");
+        dc->StartGraphic(bracketSpan, bracketSpan->GetSpanningClasses(), "");
     }
 
     int bracketSize = 2 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
@@ -557,7 +557,7 @@ void View::DrawHairpin(
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(hairpin, "spanning-hairpin", "");
+        dc->StartGraphic(hairpin, hairpin->GetSpanningClasses(), "");
     // dc->DeactivateGraphic();
 
     DrawObliquePolygon(
@@ -607,7 +607,8 @@ void View::DrawOctave(
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(octave, "spanning-octave", "");
+        dc->StartGraphic(octave, octave->GetSpanningClasses(), "");
+
 
     int code = SMUFL_E511_ottavaAlta;
     if (disPlace == STAFFREL_basic_above) {
@@ -902,7 +903,7 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(tie, "spanning-tie", "");
+        dc->StartGraphic(tie, tie->GetSpanningClasses(), "");
     DrawThickBezierCurve(dc, bezier, thickness, staff->m_drawingStaffSize, 0, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
@@ -942,7 +943,8 @@ void View::DrawTrillExtension(
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(trill, "spanning-trill", "");
+        dc->StartGraphic(trill, trill->GetSpanningClasses(), "");
+
 
     DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, false, SMUFL_E59D_ornamentZigZagLineNoRightEnd, 0,
         SMUFL_E59E_ornamentZigZagLineWithRightEnd);
@@ -1013,7 +1015,8 @@ void View::DrawControlElementConnector(
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else {
-        dc->StartGraphic(element, "spanning-element", "");
+        dc->StartGraphic(element, element->GetSpanningClasses(), "");
+
     }
 
     bool deactivate = true;
@@ -1081,7 +1084,7 @@ void View::DrawFConnector(DeviceContext *dc, F *f, int x1, int x2, Staff *staff,
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else
-        dc->StartGraphic(&fConnector, "spanning-connector", "");
+        dc->StartGraphic(&fConnector, f->GetSpanningClasses(), "");
 
     dc->DeactivateGraphic();
 
@@ -1158,7 +1161,7 @@ void View::DrawSylConnector(
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else
-        dc->StartGraphic(&sylConnector, "spanning-connector", "");
+        dc->StartGraphic(&sylConnector, syl->GetSpanningClasses(), "");
 
     dc->DeactivateGraphic();
 
@@ -2143,7 +2146,8 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START))
         dc->ResumeGraphic(ending, ending->GetUuid());
     else
-        dc->StartGraphic(ending, "spanning-ending", "");
+        dc->StartGraphic(ending, ending->GetSpanningClasses(), "");
+
 
     std::vector<Staff *>::iterator staffIter;
     std::vector<Staff *> staffList;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -58,7 +58,7 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(slur, "spanning-slur", "");
+        dc->StartGraphic(slur, slur->GetSpanningClasses(), "");
 
     int penStyle = AxSOLID;
     switch (slur->GetLform()) {


### PR DESCRIPTION
For elements that are broken up by system breaks, it is useful to have a means of associating them (be it for highlighting with CSS or JavaScript interaction).

Before this is merged I'd like to discuss if we should instead follow an alternative approach instead:

To find out the original ID for a broken up element, one has to iterate over the `classList` and parse the class names. [`@data-id` attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/data-*) would make getting the original ID much more elegant. And they are just as simple to match with CSS selectors (like `[data-id=id1234]`).

The drawback is that they are only part of SVG 2, which is still in candidate recommendation status, and we're writing SVG 1.1. But then, we're also writing `@href` in addition to `@xlink:href`, which is also SVG 2 and thus our SVG 1.1 is not validating anyway.

I'd be very happy to scrap this pull request if we follow the IMO superior `@data-id` approach instead. With that approach I'd also suggest to make writing `@id`s optional – when used in a webpage, they can break the surrounding page because of ID clashes.