### PR TITLE
Add data-id attributes to SVG

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -113,7 +113,8 @@ public:
      * @name Method for starting and ending a graphic
      */
     ///@{
-    virtual void StartGraphic(Object *object, std::string gClass, std::string gId, bool prepend = false);
+    virtual void StartGraphic(
+        Object *object, std::string gClass, std::string gId, bool primary = true, bool prepend = false);
     virtual void EndGraphic(Object *object, View *view);
     ///@}
 

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -199,7 +199,9 @@ public:
      * For example, the method can be used for grouping shapes in <g></g> in SVG
      */
     ///@{
-    virtual void StartGraphic(Object *object, std::string gClass, std::string gId, bool preprend = false) = 0;
+    virtual void StartGraphic(
+        Object *object, std::string gClass, std::string gId, bool primary = true, bool preprend = false)
+        = 0;
     virtual void EndGraphic(Object *object, View *view) = 0;
     ///@}
 

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -491,6 +491,7 @@ public:
     OptionString m_expand;
     OptionBool m_svgBoundingBoxes;
     OptionBool m_svgViewBox;
+    OptionBool m_svgHtml5;
     OptionInt m_unit;
     OptionBool m_useFacsimile;
     OptionBool m_usePgFooterForAll;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -109,7 +109,8 @@ public:
      * @name Method for starting and ending a graphic
      */
     ///@{
-    virtual void StartGraphic(Object *object, std::string gClass, std::string gId, bool prepend = false);
+    virtual void StartGraphic(
+        Object *object, std::string gClass, std::string gId, bool primary = true, bool prepend = false);
     virtual void EndGraphic(Object *object, View *view);
     ///@}
 
@@ -160,6 +161,11 @@ public:
     ///@}
 
     /**
+     * Add id, data-id and class attributes
+     */
+    void AppendIdAndClass(std::string gId, std::string baseClass, std::string addedClasses, bool primary = true);
+
+    /**
      * In SVG use global styling but not with mm output (for pdf generation)
      */
     virtual bool UseGlobalStyling() { return !m_mmOutput; }
@@ -181,6 +187,11 @@ public:
      * Setting m_svgViewBox flag (false by default)
      */
     void SetSvgViewBox(bool svgViewBox) { m_svgViewBox = svgViewBox; }
+
+    /**
+     * Setting m_html5 flag (false by default)
+     */
+    void SetHtml5(bool html5) { m_html5 = html5; }
 
 private:
     /**
@@ -253,6 +264,8 @@ private:
     bool m_svgBoundingBoxes;
     // use viewbox on svg root element
     bool m_svgViewBox;
+    // output HTML5 data-* attributes
+    bool m_html5;
 };
 
 } // namespace vrv

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -45,7 +45,7 @@ BBoxDeviceContext::BBoxDeviceContext(View *view, int width, int height, unsigned
 
 BBoxDeviceContext::~BBoxDeviceContext() {}
 
-void BBoxDeviceContext::StartGraphic(Object *object, std::string gClass, std::string gId, bool prepend)
+void BBoxDeviceContext::StartGraphic(Object *object, std::string gClass, std::string gId, bool primary, bool prepend)
 {
     // add the object object
     object->BoundingBox::ResetBoundingBox();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -617,6 +617,10 @@ Options::Options()
     m_svgViewBox.Init(false);
     this->Register(&m_svgViewBox, "svgViewBox", &m_general);
 
+    m_svgHtml5.SetInfo("Output SVG for HTML5 embedding", "Write data-id and data-class attributes for JS usage and id clash avoidance.");
+    m_svgHtml5.Init(false);
+    this->Register(&m_svgHtml5, "svgHtml5", &m_general);
+
     m_unit.SetInfo("Unit", "The MEI unit (1⁄2 of the distance between the staff lines)");
     m_unit.Init(9, 6, 20, true);
     this->Register(&m_unit, "unit", &m_general);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1257,6 +1257,8 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
         svg.SetSvgViewBox(true);
     }
 
+    svg.SetHtml5(m_options->m_svgHtml5.GetValue());
+
     // render the page
     RenderToDeviceContext(pageNo, &svg);
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -369,7 +369,7 @@ void View::DrawBracketSpan(
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else {
-        dc->StartGraphic(bracketSpan, "spanning-bracketspan", "");
+        dc->StartGraphic(bracketSpan, "", bracketSpan->GetUuid(), false);
     }
 
     int bracketSize = 2 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
@@ -557,7 +557,7 @@ void View::DrawHairpin(
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(hairpin, "spanning-hairpin", "");
+        dc->StartGraphic(hairpin, "", hairpin->GetUuid(), false);
     // dc->DeactivateGraphic();
 
     DrawObliquePolygon(
@@ -607,7 +607,7 @@ void View::DrawOctave(
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(octave, "spanning-octave", "");
+        dc->StartGraphic(octave, "", octave->GetUuid(), false);
 
     int code = SMUFL_E511_ottavaAlta;
     if (disPlace == STAFFREL_basic_above) {
@@ -902,7 +902,7 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(tie, "spanning-tie", "");
+        dc->StartGraphic(tie, "", tie->GetUuid(), false);
     DrawThickBezierCurve(dc, bezier, thickness, staff->m_drawingStaffSize, 0, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
@@ -942,7 +942,7 @@ void View::DrawTrillExtension(
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(trill, "spanning-trill", "");
+        dc->StartGraphic(trill, "", trill->GetUuid(), false);
 
     DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, false, SMUFL_E59D_ornamentZigZagLineNoRightEnd, 0,
         SMUFL_E59E_ornamentZigZagLineWithRightEnd);
@@ -1013,7 +1013,7 @@ void View::DrawControlElementConnector(
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else {
-        dc->StartGraphic(element, "spanning-element", "");
+        dc->StartGraphic(element, "", element->GetUuid(), false);
     }
 
     bool deactivate = true;
@@ -1081,7 +1081,7 @@ void View::DrawFConnector(DeviceContext *dc, F *f, int x1, int x2, Staff *staff,
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else
-        dc->StartGraphic(&fConnector, "spanning-connector", "");
+        dc->StartGraphic(&fConnector, "", f->GetUuid(), false);
 
     dc->DeactivateGraphic();
 
@@ -1158,7 +1158,7 @@ void View::DrawSylConnector(
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     }
     else
-        dc->StartGraphic(&sylConnector, "spanning-connector", "");
+        dc->StartGraphic(&sylConnector, "", syl->GetUuid(), false);
 
     dc->DeactivateGraphic();
 
@@ -2159,7 +2159,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START))
         dc->ResumeGraphic(ending, ending->GetUuid());
     else
-        dc->StartGraphic(ending, "spanning-ending", "");
+        dc->StartGraphic(ending, "", ending->GetUuid(), false);
 
     std::vector<Staff *>::iterator staffIter;
     std::vector<Staff *> staffList;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -58,7 +58,7 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
-        dc->StartGraphic(slur, "spanning-slur", "");
+        dc->StartGraphic(slur, "", slur->GetUuid(), false);
 
     int penStyle = AxSOLID;
     switch (slur->GetLform()) {


### PR DESCRIPTION
Alternative to #1356. ~~`@data-*" attributes are not valid SVG 1.1, but SVG output is not valid SVG 1.1. anyway.~~

Allows associating all output SVG elements with the original MEI element. 