### PR TITLE
* MusicXML: Convert rights into <availability><distributor>

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -802,6 +802,17 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
         persName.append_attribute("role").set_value(creator.node().attribute("type").as_string());
     }
 
+    // Convert rights into availability
+    pugi::xml_node availability = pubStmt.append_child("availability");
+
+    pugi::xpath_node_set rightses = root.select_nodes("/score-partwise/identification/rights");
+    for (pugi::xpath_node_set::const_iterator it = rightses.begin(); it != rightses.end(); ++it) {
+        pugi::xpath_node rights = *it;
+        availability.append_child("distributor")
+            .append_child(pugi::node_pcdata)
+            .set_value(rights.node().text().as_string());
+    }
+
     pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
     GenerateUuid(encodingDesc);
     pugi::xml_node appInfo = encodingDesc.append_child("appInfo");


### PR DESCRIPTION
As suggested by https://github.com/rism-ch/verovio/issues/1352#issuecomment-602068000.

Note that availability cannot contain raw text, so we put it inside distributor.

I assume that availability can contain multiple distributors. https://music-encoding.org/guidelines/v4/elements/availability.html#mayContain

This does the semantic part of https://github.com/rism-ch/verovio/issues/1352 (we should place this into pgFoot and pgFoot2 if footer=auto and no other footer exists, I think)