### PR TITLE
change stem automatic shortening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Improve automatic stem shertening (@rettinghaus)
 * Complete beam refactoring
 * Support for mSpace elements (@rettinghaus)
 * Improved header in MusicXML import (@rettinghaus)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## [unreleased]
-* Improve automatic stem shertening (@rettinghaus)
 * Complete beam refactoring
 * Support for mSpace elements (@rettinghaus)
 * Improved header in MusicXML import (@rettinghaus)

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -132,7 +132,7 @@ public:
     ///@{
     virtual Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize);
     virtual Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize);
-    virtual int CalcStemLenInHalfUnits(Staff *staff);
+    virtual int CalcStemLenInThirdUnits(Staff *staff);
     ///@}
 
     /**

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -255,7 +255,7 @@ public:
     ///@{
     virtual Point GetStemUpSE(Doc *doc, int staffSize, bool graceSize) = 0;
     virtual Point GetStemDownNW(Doc *doc, int staffSize, bool graceSize) = 0;
-    virtual int CalcStemLenInHalfUnits(Staff *staff) = 0;
+    virtual int CalcStemLenInThirdUnits(Staff *staff) = 0;
     ///@}
 
 protected:

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -161,7 +161,7 @@ public:
     ///@{
     virtual Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize);
     virtual Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize);
-    virtual int CalcStemLenInHalfUnits(Staff *staff);
+    virtual int CalcStemLenInThirdUnits(Staff *staff);
     ///@}
 
     /**

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1033,8 +1033,8 @@ void BeamElementCoord::SetDrawingStemDir(
     bool extend = onStaffLine;
     const int standardStemLen = STANDARD_STEMLENGTH * 2;
     // Check if the stem has to be shortened because outside the staff
-    // In this case, Note::CalcStemLenInHalfUnits will return a value shorter than 2 * STANDARD_STEMLENGTH
-    int stemLenInHalfUnits = m_closestNote->CalcStemLenInHalfUnits(staff);
+    // In this case, Note::CalcStemLenInThirdUnits will return a value shorter than 2 * STANDARD_STEMLENGTH
+    int stemLenInHalfUnits = m_closestNote->CalcStemLenInThirdUnits(staff);
     // Do not extend when not on the staff line
     if (stemLenInHalfUnits != standardStemLen) {
         this->m_shortened = true;

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -352,19 +352,19 @@ Point Chord::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     return topNote->GetStemDownNW(doc, staffSize, isCueSize);
 }
 
-int Chord::CalcStemLenInHalfUnits(Staff *staff)
+int Chord::CalcStemLenInThirdUnits(Staff *staff)
 {
     assert(staff);
 
     if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
         Note *topNote = this->GetTopNote();
         assert(topNote);
-        return topNote->CalcStemLenInHalfUnits(staff);
+        return topNote->CalcStemLenInThirdUnits(staff);
     }
     else {
         Note *bottomNote = this->GetBottomNote();
         assert(bottomNote);
-        return bottomNote->CalcStemLenInHalfUnits(staff);
+        return bottomNote->CalcStemLenInThirdUnits(staff);
     }
 }
 

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -390,8 +390,8 @@ int Stem::CalcStem(FunctorParams *functorParams)
         baseStem = this->GetStemLen() * -params->m_doc->GetDrawingUnit(staffSize);
     }
     else {
-        int halfUnit = params->m_doc->GetDrawingUnit(staffSize) / 2;
-        baseStem = -(params->m_interface->CalcStemLenInHalfUnits(params->m_staff) * halfUnit);
+        int thirdUnit = params->m_doc->GetDrawingUnit(staffSize) / 3;
+        baseStem = -(params->m_interface->CalcStemLenInThirdUnits(params->m_staff) * thirdUnit);
         if (drawingCueSize) baseStem = params->m_doc->GetCueSize(baseStem);
     }
     // Even if a stem length is given we add the length of the chord content (however only if not 0)

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -317,11 +317,11 @@ Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     return p;
 }
 
-int Note::CalcStemLenInHalfUnits(Staff *staff)
+int Note::CalcStemLenInThirdUnits(Staff *staff)
 {
     assert(staff);
 
-    int baseStem = STANDARD_STEMLENGTH * 2;
+    int baseStem = STANDARD_STEMLENGTH * 3;
 
     int shortening = 0;
 
@@ -334,7 +334,8 @@ int Note::CalcStemLenInHalfUnits(Staff *staff)
             case 3: shortening = 2; break;
             case 2: shortening = 3; break;
             case 1: shortening = 4; break;
-            default: shortening = 4;
+            case 0: shortening = 5; break;
+            default: shortening = 6;
         }
     }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -342,10 +342,10 @@ int Note::CalcStemLenInThirdUnits(Staff *staff)
     // Limit shortening with duration shorter than quarter not when not in a beam
     if ((this->GetDrawingDur() > DUR_4) && !this->IsInBeam()) {
         if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
-            shortening = std::min(3, shortening);
+            shortening = std::min(4, shortening);
         }
         else {
-            shortening = std::min(2, shortening);
+            shortening = std::min(3, shortening);
         }
     }
 


### PR DESCRIPTION
This PR slightly improves the stem shortening outside a staff. It now follows the same rules as LilyPond and MuseScore.