### PR TITLE
Improvements to podspec file

### DIFF
--- a/Verovio.podspec
+++ b/Verovio.podspec
@@ -20,9 +20,9 @@ Pod::Spec.new do |s|
                           'libmei/{atts_mensural,atts_midi,atts_neumes,atts_pagebased,atts_shared}.{h}',
                           'libmei/{atts_visual,atttypes}.{h}'
   s.resources      = 'data'
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.13'
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
       "CLANG_CXX_LANGUAGE_STANDARD" => "gnu++14",
       "CLANG_CXX_LIBRARY" => "libc++",
       "GCC_C_LANGUAGE_STANDARD" => "gnu11",
@@ -34,9 +34,8 @@ Pod::Spec.new do |s|
       "ENABLE_STRICT_OBJC_MSGSEND" => "YES",
       "MTL_FAST_MATH" => "YES",
       "SUPPORTS_UIKITFORMAC" => "NO",
-      "MTL_ENABLE_DEBUG_INFO" => "NO"
+      "MTL_ENABLE_DEBUG_INFO" => "NO",
+      "PRODUCT_BUNDLE_IDENTIFIER" => "com.rism.VerovioFramework"
     }
-  s.info_plist = {
-    'CFBundleIdentifier' => 'com.rism.VerovioFramework'
-  }
 end
+


### PR DESCRIPTION
Several improvements to the project's podspec for Apple platform integration with Cocoapods.
- Support iOS 10.0+.  We have been using Verovio with iOS 10.0+ without any issues.
- Scope `.xcconfig` changes only to the Verovio pod by specifying compiler settings with `pod_target_xcconfig`.
- Set bundle ID with `PRODUCT_BUNDLE_IDENTIFIER` so that it is consistent across the built framework, preventing a compiler warning.