### PR TITLE
Fix of issue 1176 for the specific file that heavily uses linking

### DIFF
--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -288,7 +288,7 @@ typedef std::vector<BeamElementCoord *> ArrayOfBeamElementCoords;
 
 typedef std::vector<std::pair<int, int> > ArrayOfIntPairs;
 
-typedef std::vector<std::pair<LinkingInterface *, std::string> > ArrayOfLinkingInterfaceUuidPairs;
+typedef std::multimap<std::string, LinkingInterface *> ArrayOfLinkingInterfaceUuidPairs;
 
 typedef std::vector<std::pair<PlistInterface *, std::string> > ArrayOfPlistInterfaceUuidPairs;
 

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -87,10 +87,10 @@ int LinkingInterface::InterfacePrepareLinking(FunctorParams *functorParams, Obje
     this->SetUuidStr();
 
     if (!m_nextUuid.empty()) {
-        params->m_nextUuidPairs.push_back(std::make_pair(this, m_nextUuid));
+        params->m_nextUuidPairs.insert({m_nextUuid, this});
     }
     if (!m_sameasUuid.empty()) {
-        params->m_sameasUuidPairs.push_back(std::make_pair(this, m_sameasUuid));
+        params->m_sameasUuidPairs.insert({m_sameasUuid, this});
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1175,22 +1175,22 @@ int Object::PrepareLinking(FunctorParams *functorParams)
 
     // @next
     std::string uuid = this->GetUuid();
-    auto i = std::find_if(params->m_nextUuidPairs.begin(), params->m_nextUuidPairs.end(),
-        [uuid](std::pair<LinkingInterface *, std::string> pair) { return (pair.second == uuid); });
-    if (i != params->m_nextUuidPairs.end()) {
-        i->first->SetNextLink(this);
-        params->m_nextUuidPairs.erase(i);
+    auto r1 = params->m_nextUuidPairs.equal_range(uuid);
+    if (r1.first != params->m_nextUuidPairs.end()) {
+        for (auto i = r1.first; i != r1.second; ++i) {
+            i->second->SetNextLink(this);
+        }
+        params->m_nextUuidPairs.erase(r1.first, r1.second);
     }
 
     // @sameas
-    std::string sameas = this->GetUuid();
-    auto j = std::find_if(params->m_sameasUuidPairs.begin(), params->m_sameasUuidPairs.end(),
-        [uuid](std::pair<LinkingInterface *, std::string> pair) { return (pair.second == uuid); });
-    if (j != params->m_sameasUuidPairs.end()) {
-        j->first->SetSameasLink(this);
-        params->m_sameasUuidPairs.erase(j);
+    auto r2 = params->m_sameasUuidPairs.equal_range(uuid);
+    if (r2.first != params->m_sameasUuidPairs.end()) {
+        for (auto j = r2.first; j != r2.second;  ++j) {
+            j->second->SetSameasLink(this);
+        }
+        params->m_sameasUuidPairs.erase(r2.first, r2.second);
     }
-
     return FUNCTOR_CONTINUE;
 }
 


### PR DESCRIPTION
Use multimap instead of vector to ensure fast lookup and erase. Use iterator_range to ensure that every value with the same key was processed.