### PR TITLE
Increase speed a bit by eliminating deletion from the middle of vector

### DIFF
--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -294,11 +294,11 @@ typedef std::vector<std::pair<PlistInterface *, std::string> > ArrayOfPlistInter
 
 typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;
 
-typedef std::vector<std::pair<Object *, data_MEASUREBEAT> > ArrayOfObjectBeatPairs;
+typedef std::list<std::pair<Object *, data_MEASUREBEAT> > ArrayOfObjectBeatPairs;
 
-typedef std::vector<std::pair<TimePointInterface *, ClassId> > ArrayOfPointingInterClassIdPairs;
+typedef std::list<std::pair<TimePointInterface *, ClassId> > ArrayOfPointingInterClassIdPairs;
 
-typedef std::vector<std::pair<TimeSpanningInterface *, ClassId> > ArrayOfSpanningInterClassIdPairs;
+typedef std::list<std::pair<TimeSpanningInterface *, ClassId> > ArrayOfSpanningInterClassIdPairs;
 
 typedef std::vector<FloatingPositioner *> ArrayOfFloatingPositioners;
 


### PR DESCRIPTION
This fix adds about 10% speed gain in prepareDrawing on iOS