### PR TITLE
add support for trill att.extender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Support for `trill@extender` (@rettinghaus)
 * Support for `note@head.visible` (@rettinghaus)
 * Improved spacing with crossing voices (@rettinghaus)
 * Complete beam refactoring

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -25,6 +25,7 @@ namespace vrv {
 class Trill : public ControlElement,
               public TimeSpanningInterface,
               public AttColor,
+              public AttExtender,
               public AttOrnamentAccid,
               public AttPlacement {
 public:

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1334,6 +1334,7 @@ void MEIOutput::WriteTrill(pugi::xml_node currentNode, Trill *trill)
     WriteControlElement(currentNode, trill);
     WriteTimeSpanningInterface(currentNode, trill);
     trill->WriteColor(currentNode);
+    trill->WriteExtender(currentNode);
     trill->WriteOrnamentAccid(currentNode);
     trill->WritePlacement(currentNode);
 }
@@ -4096,6 +4097,7 @@ bool MEIInput::ReadTrill(Object *parent, pugi::xml_node trill)
 
     ReadTimeSpanningInterface(trill, vrvTrill);
     vrvTrill->ReadColor(trill);
+    vrvTrill->ReadExtender(trill);
     vrvTrill->ReadOrnamentAccid(trill);
     vrvTrill->ReadPlacement(trill);
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -250,7 +250,7 @@ void System::AddToDrawingListIfNeccessary(Object *object)
     else if (object->Is(TRILL)) {
         Trill *trill = dynamic_cast<Trill *>(object);
         assert(trill);
-        if (trill->GetEnd()) {
+        if (trill->GetEnd() && (trill->GetExtender() != BOOLEAN_false)) {
             this->AddToDrawingList(trill);
         }
     }

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -21,10 +21,12 @@ namespace vrv {
 // Trill
 //----------------------------------------------------------------------------
 
-Trill::Trill() : ControlElement("trill-"), TimeSpanningInterface(), AttColor(), AttOrnamentAccid(), AttPlacement()
+Trill::Trill()
+    : ControlElement("trill-"), TimeSpanningInterface(), AttColor(), AttExtender(), AttOrnamentAccid(), AttPlacement()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_EXTENDER);
     RegisterAttClass(ATT_ORNAMENTACCID);
     RegisterAttClass(ATT_PLACEMENT);
 
@@ -38,6 +40,7 @@ void Trill::Reset()
     ControlElement::Reset();
     TimeSpanningInterface::Reset();
     ResetColor();
+    ResetExtender();
     ResetOrnamentAccid();
     ResetPlacement();
 }


### PR DESCRIPTION
This adds support for `@extender` to hide extender lines on trills.