### PR TITLE
major trill rendering improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Improved trill support (@rettinghaus)
 * Support for `trill@extender` (@rettinghaus)
 * Support for `note@head.visible` (@rettinghaus)
 * Improved spacing with crossing voices (@rettinghaus)

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -26,6 +26,7 @@ class Trill : public ControlElement,
               public TimeSpanningInterface,
               public AttColor,
               public AttExtender,
+              public AttLineRend,
               public AttOrnamentAccid,
               public AttPlacement {
 public:

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -82,7 +82,7 @@ wchar_t Flag::GetSmuflCode(data_STEMDIRECTION stemDir)
             case 6: return SMUFL_E24A_flag256thUp;
             case 7: return SMUFL_E24C_flag512thUp;
             case 8: return SMUFL_E24E_flag1024thUp;
-            default: return 0; break;
+            default: return 0;
         }
     }
     else {
@@ -95,7 +95,7 @@ wchar_t Flag::GetSmuflCode(data_STEMDIRECTION stemDir)
             case 6: return SMUFL_E24B_flag256thDown;
             case 7: return SMUFL_E24D_flag512thDown;
             case 8: return SMUFL_E24F_flag1024thDown;
-            default: return 0; break;
+            default: return 0;
         }
     }
 }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2561,6 +2561,10 @@ void MusicXmlInput::ReadMusicXmlNote(
         trill->SetColor(xmlTrill.node().attribute("color").as_string());
         // place
         trill->SetPlace(trill->AttPlacement::StrToStaffrel(xmlTrill.node().attribute("placement").as_string()));
+        if (notations.node().select_node("ornaments/wavy-line")) {
+            trill->SetTstamp2(
+                std::pair<int, double>(0, (double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 0.99));
+        }
     }
 
     // turns

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -22,11 +22,18 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 Trill::Trill()
-    : ControlElement("trill-"), TimeSpanningInterface(), AttColor(), AttExtender(), AttOrnamentAccid(), AttPlacement()
+    : ControlElement("trill-")
+    , TimeSpanningInterface()
+    , AttColor()
+    , AttExtender()
+    , AttLineRend()
+    , AttOrnamentAccid()
+    , AttPlacement()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_EXTENDER);
+    RegisterAttClass(ATT_LINEREND);
     RegisterAttClass(ATT_ORNAMENTACCID);
     RegisterAttClass(ATT_PLACEMENT);
 
@@ -41,6 +48,7 @@ void Trill::Reset()
     TimeSpanningInterface::Reset();
     ResetColor();
     ResetExtender();
+    ResetLineRend();
     ResetOrnamentAccid();
     ResetPlacement();
 }


### PR DESCRIPTION
This PR adds support for `@lstartsym="none"` on trills and improves overall engraving rules for trills. Examples using IDs on the first line, time stamps on the second:

## Before:
![Trills-Leipzig_old](https://user-images.githubusercontent.com/7693447/78471747-e8bd9f00-7733-11ea-903d-a3830c1dabdb.png)

## After:
![Trills-Leipzig](https://user-images.githubusercontent.com/7693447/78471750-e9eecc00-7733-11ea-8771-da6bbd1661b1.png)

# Bravura
## Before:
![Trills-Bravura_old](https://user-images.githubusercontent.com/7693447/78471785-2f12fe00-7734-11ea-855e-826fb46f4f67.png)

## After:
![Trills-Bravura](https://user-images.githubusercontent.com/7693447/78471786-2fab9480-7734-11ea-87cf-8bdc150eecba.png)

# Gootville
## Before:
![Trills-Gootville_old](https://user-images.githubusercontent.com/7693447/78471787-30442b00-7734-11ea-8d4e-73193b2aacf8.png)

## After:
![Trills-Gootville](https://user-images.githubusercontent.com/7693447/78471788-30442b00-7734-11ea-906f-fdbf57d89d1e.png)

# Petaluma
## Before:
![Trills-Petaluma_old](https://user-images.githubusercontent.com/7693447/78471789-30dcc180-7734-11ea-98ed-2456e1f5b370.png)

## After:
![Trills-Petaluma](https://user-images.githubusercontent.com/7693447/78471791-30dcc180-7734-11ea-8459-77675e093196.png)

### Test file:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Trills without trill glyph</title>
      </titleStmt>
      <pubStmt>
        <respStmt>
          <persName>Klaus Rettinghaus</persName>
        </respStmt>
      </pubStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef system.leftline="true">
            <staffGrp bar.thru="false" symbol="none">
              <staffDef n="1" lines="1" clef.shape="perc" clef.line="1"></staffDef>
            </staffGrp>
          </scoreDef>
          <section label="using IDs">
            <pb />
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" xml:id="one" />
                </layer>
              </staff>
              <trill startid="#one" endid="#two" />
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" xml:id="two" />
                </layer>
              </staff>
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" xml:id="three" />
                </layer>
              </staff>
              <trill startid="#three" endid="#four" lstartsym="none" />
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" xml:id="four" />
                </layer>
              </staff>
            </measure>
          </section>
          <section label="using time stamps">
            <sb />
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" />
                </layer>
              </staff>
              <trill tstamp="1" tstamp2="1m+1" />
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" />
                </layer>
              </staff>
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" />
                </layer>
              </staff>
              <trill tstamp="1" tstamp2="1m+1" lstartsym="none" />
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <note dur="1" loc="0" />
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```

closes #807