### PR TITLE
MusicXML import: fix @staff for dyn, dir, hairpin at measure end

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -341,7 +341,7 @@ private:
     /* A maps of time stamps (score time) to indicate write pointer of a given layer */
     std::map<Layer *, int> m_layerEndTimes;
     /* To remember layer of last element (note) to handle chords */
-    Layer *m_prevLayer;
+    Layer *m_prevLayer = NULL;
     /* The stack for open slurs */
     std::vector<std::pair<Slur *, musicxml::OpenSlur> > m_slurStack;
     /* The stack for slur stops that might come before the slur has been opened */

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1294,6 +1294,9 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
     // clear arpeggio stack so no other notes may be added.
     if (!m_ArpeggioStack.empty()) m_ArpeggioStack.clear();
 
+    // clear prevLayer
+    m_prevLayer = NULL;
+
     return true;
 }
 
@@ -1611,6 +1614,11 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 dir->SetStaff(dir->AttStaffIdent::StrToXsdPositiveIntegerList(
                     std::to_string(staffNode.node().text().as_int() + staffOffset)));
             }
+            else if (m_prevLayer) {
+                dir->SetStaff(dir->AttStaffIdent::StrToXsdPositiveIntegerList(
+                    std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
+            }
+
             TextRendition(words, dir);
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
             dir->SetVgrp(defaultY);
@@ -1651,6 +1659,11 @@ void MusicXmlInput::ReadMusicXmlDirection(
             dynam->SetStaff(dynam->AttStaffIdent::StrToXsdPositiveIntegerList(
                 std::to_string(staffNode.node().text().as_int() + staffOffset)));
         }
+        else if (m_prevLayer) {
+            dynam->SetStaff(dynam->AttStaffIdent::StrToXsdPositiveIntegerList(
+                std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
+        }
+
         if (defaultY == 0) defaultY = dynamics.node().attribute("default-y").as_int();
         // parse the default_y attribute and transform to vgrp value, to vertically align dynamics and directives
         defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
@@ -1775,6 +1788,10 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 hairpin->SetStaff(hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(
                     std::to_string(staffNode.node().text().as_int() + staffOffset)));
             }
+            else if (m_prevLayer) {
+                hairpin->SetStaff(hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(
+                    std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
+            }
             int defaultY = wedge.node().attribute("default-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align hairpins
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
@@ -1785,10 +1802,8 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 if (std::get<2>(*iter).m_dirN == hairpinNumber) {
                     int measureDifference = std::get<2>(*iter).m_lastMeasureCount - m_measureCounts.at(measure);
                     hairpin->SetTstamp2(std::pair<int, double>(measureDifference, std::get<1>(*iter)));
-                    Staff *staff = dynamic_cast<Staff *>(measure->FindDescendantByType(STAFF));
-                    assert(staff);
                     hairpin->SetStaff(
-                        staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(std::get<0>(*iter))));
+                        hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(std::get<0>(*iter))));
                     m_controlElements.push_back(std::make_pair(measureNum, hairpin));
                     m_hairpinStopStack.erase(iter);
                     return;
@@ -1853,6 +1868,10 @@ void MusicXmlInput::ReadMusicXmlDirection(
             if (staffNode) {
                 pedal->SetStaff(pedal->AttStaffIdent::StrToXsdPositiveIntegerList(
                     std::to_string(staffNode.node().text().as_int() + staffOffset)));
+            }
+            else if (m_prevLayer) {
+                pedal->SetStaff(pedal->AttStaffIdent::StrToXsdPositiveIntegerList(
+                    std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN() + staffOffset)));
             }
             int defaultY = xmlPedal.node().attribute("default-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops
@@ -2034,7 +2053,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     assert(measure);
 
     Layer *layer;
-    if (!node.select_node("voice")) { // if no layer info, stay at previous layer
+    if (!node.select_node("voice") && m_prevLayer) { // if no layer info, stay at previous layer
         layer = m_prevLayer;
     }
     else {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1871,7 +1871,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             }
             else if (m_prevLayer) {
                 pedal->SetStaff(pedal->AttStaffIdent::StrToXsdPositiveIntegerList(
-                    std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN() + staffOffset)));
+                    std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
             }
             int defaultY = xmlPedal.node().attribute("default-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops


### PR DESCRIPTION
When `@staff` information is not provided in MusicXML for `dir`, `dynam`, `pedal`, and `hairpin` (`direction-type word`, `dynamics`, `pedal`, and `wedge`, respectively), it is currently added from the following note. However, this causes problems, when these three element types occur at the end of a measure/ end of a part.

Finale file:

![grafik](https://user-images.githubusercontent.com/45632600/78989574-438c3780-7b34-11ea-93f0-3ec4efbe7283.png)

Current import:

![DirDynHairpin-Test_001](https://user-images.githubusercontent.com/45632600/78989208-463a5d00-7b33-11ea-9cb0-c3915fc2c937.png)

(The cresc. hairpin is not rendered, because it lacks a `@staff` attribute; the `dir "fine1"`  is shown in wrong staff, `dir "fine2"` has no `@staff` and is not rendered.

This PR uses `m_prevLayer` (the layer pointer of the previous element) to add staff information, if present.

PR import:

![DirDynHairpin-Test-PR](https://user-images.githubusercontent.com/45632600/78989198-3f134f00-7b33-11ea-9cbe-8d45ede371b3.png)

MusicXML: 
```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <movement-title>DirDynHairpinStaff</movement-title>
  <identification>
    <rights>©</rights>
    <encoding>
      <software>Finale v26 for Mac</software>
      <encoding-date>2020-04-10</encoding-date>
      <supports attribute="new-system" element="print" type="yes" value="yes"/>
      <supports attribute="new-page" element="print" type="yes" value="yes"/>
      <supports element="accidental" type="yes"/>
      <supports element="beam" type="yes"/>
      <supports element="stem" type="yes"/>
    </encoding>
  </identification>
  <defaults>
    <scaling>
      <millimeters>5.7856</millimeters>
      <tenths>40</tenths>
    </scaling>
    <page-layout>
      <page-height>2054</page-height>
      <page-width>1452</page-width>
      <page-margins type="both">
        <left-margin>176</left-margin>
        <right-margin>88</right-margin>
        <top-margin>88</top-margin>
        <bottom-margin>88</bottom-margin>
      </page-margins>
    </page-layout>
    <system-layout>
      <system-margins>
        <left-margin>0</left-margin>
        <right-margin>0</right-margin>
      </system-margins>
      <system-distance>117</system-distance>
      <top-system-distance>66</top-system-distance>
    </system-layout>
    <staff-layout>
      <staff-distance>80</staff-distance>
    </staff-layout>
    <appearance>
      <line-width type="stem">1.1784</line-width>
      <line-width type="beam">5</line-width>
      <line-width type="staff">1.1784</line-width>
      <line-width type="light barline">1.1784</line-width>
      <line-width type="heavy barline">5</line-width>
      <line-width type="leger">1.6536</line-width>
      <line-width type="ending">0.918</line-width>
      <line-width type="wedge">1.1784</line-width>
      <line-width type="enclosure">1.1784</line-width>
      <line-width type="tuplet bracket">1.1784</line-width>
      <note-size type="grace">60</note-size>
      <note-size type="cue">60</note-size>
      <distance type="hyphen">120</distance>
      <distance type="beam">8</distance>
    </appearance>
    <music-font font-family="Maestro,engraved" font-size="16.4"/>
    <word-font font-family="Times New Roman" font-size="8.2"/>
  </defaults>
  <credit page="1">
    <credit-type>title</credit-type>
    <credit-words default-x="770" default-y="1966" font-size="19.2" justify="center" valign="top">DirDynHairpinStaff</credit-words>
  </credit>
  <credit page="1">
    <credit-type>rights</credit-type>
    <credit-words default-x="770" default-y="70" font-size="8" justify="center" valign="bottom">©</credit-words>
  </credit>
  <credit page="1">
    <credit-words default-x="176" default-y="1969" font-size="9.6" valign="top">Partitur</credit-words>
  </credit>
  <part-list>
    <score-part id="P1">
      <part-name print-object="no">MusicXML Part</part-name>
      <score-instrument id="P1-I1">
        <instrument-name>ARIA Player</instrument-name>
        <instrument-sound>keyboard.piano</instrument-sound>
        <virtual-instrument>
          <virtual-library>Garritan Instruments for Finale</virtual-library>
          <virtual-name>005. Keyboards/Steinway Piano</virtual-name>
        </virtual-instrument>
      </score-instrument>
      <midi-device>ARIA Player</midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>1</midi-program>
        <volume>80</volume>
        <pan>0</pan>
      </midi-instrument>
    </score-part>
    <score-part id="P2">
      <part-name print-object="no">MusicXML Part</part-name>
      <score-instrument id="P2-I1">
        <instrument-name>ARIA Player</instrument-name>
        <instrument-sound>keyboard.piano</instrument-sound>
        <virtual-instrument>
          <virtual-library>Garritan Instruments for Finale</virtual-library>
          <virtual-name>005. Keyboards/Steinway Piano</virtual-name>
        </virtual-instrument>
      </score-instrument>
      <midi-device>ARIA Player</midi-device>
      <midi-instrument id="P2-I1">
        <midi-channel>1</midi-channel>
        <midi-program>1</midi-program>
        <volume>80</volume>
        <pan>0</pan>
      </midi-instrument>
    </score-part>
  </part-list>
  <!--=========================================================-->
  <part id="P1">
    <measure number="1" width="374">
      <print>
        <system-layout>
          <system-margins>
            <left-margin>70</left-margin>
            <right-margin>0</right-margin>
          </system-margins>
          <top-system-distance>177</top-system-distance>
        </system-layout>
        <measure-numbering>system</measure-numbering>
      </print>
      <attributes>
        <divisions>2</divisions>
        <key>
          <fifths>2</fifths>
          <mode>major</mode>
        </key>
        <time>
          <beats>3</beats>
          <beat-type>8</beat-type>
        </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
        </clef>
      </attributes>
      <sound tempo="120"/>
      <note default-x="123">
        <pitch>
          <step>B</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-55">down</stem>
        <beam number="1">begin</beam>
      </note>
      <note default-x="206">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>5</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-52.5">down</stem>
        <beam number="1">continue</beam>
      </note>
      <note default-x="290">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-49.5">down</stem>
        <beam number="1">end</beam>
      </note>
      <direction placement="below">
        <direction-type>
          <dynamics default-y="-59" halign="center" relative-x="-40">
            <ff/>
          </dynamics>
        </direction-type>
        <sound dynamics="112"/>
      </direction>
    </measure>
    <!--=======================================================-->
    <measure number="2" width="262">
      <note default-x="16">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>5</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-55">down</stem>
        <beam number="1">begin</beam>
      </note>
      <note default-x="98">
        <pitch>
          <step>B</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-57.5">down</stem>
        <beam number="1">continue</beam>
      </note>
      <note default-x="179">
        <pitch>
          <step>A</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-60">down</stem>
        <beam number="1">end</beam>
      </note>
    </measure>
    <!--=======================================================-->
    <measure number="3" width="250">
      <note default-x="14">
        <pitch>
          <step>G</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="10">up</stem>
        <beam number="1">begin</beam>
      </note>
      <note default-x="92">
        <pitch>
          <step>A</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="13">up</stem>
        <beam number="1">continue</beam>
      </note>
      <note default-x="170">
        <pitch>
          <step>B</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="15">up</stem>
        <beam number="1">end</beam>
      </note>
      <direction placement="below">
        <direction-type>
          <words default-y="-68" font-style="italic" relative-x="-39">rit1.</words>
        </direction-type>
      </direction>
    </measure>
    <!--=======================================================-->
    <measure number="4" width="232">
      <note default-x="16">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="-49.5">down</stem>
      </note>
      <note default-x="143">
        <rest/>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
      </note>
      <direction placement="below">
        <direction-type>
          <words default-y="-68" font-style="italic" relative-x="-39">fine1</words>
        </direction-type>
      </direction>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
      </barline>
    </measure>
  </part>
  <!--=========================================================-->
  <part id="P2">
    <measure number="1" width="374">
      <print>
        <measure-numbering>none</measure-numbering>
      </print>
      <attributes>
        <divisions>2</divisions>
        <key>
          <fifths>2</fifths>
          <mode>major</mode>
        </key>
        <time>
          <beats>3</beats>
          <beat-type>8</beat-type>
        </time>
        <clef>
          <sign>F</sign>
          <line>4</line>
        </clef>
      </attributes>
      <sound tempo="120"/>
      <note default-x="123">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-25">down</stem>
        <beam number="1">begin</beam>
      </note>
      <note default-x="206">
        <pitch>
          <step>D</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-22">down</stem>
        <beam number="1">continue</beam>
      </note>
      <note default-x="290">
        <pitch>
          <step>E</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-20">down</stem>
        <beam number="1">end</beam>
      </note>
      <direction placement="below">
        <direction-type>
          <dynamics default-y="-68" halign="center" relative-x="-40">
            <fp/>
          </dynamics>
        </direction-type>
      </direction>
    </measure>
    <!--=======================================================-->
    <measure number="2" width="262">
      <note default-x="16">
        <pitch>
          <step>D</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-25">down</stem>
        <beam number="1">begin</beam>
      </note>
      <note default-x="98">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-27">down</stem>
        <beam number="1">continue</beam>
      </note>
      <note default-x="179">
        <pitch>
          <step>B</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-29.5">down</stem>
        <beam number="1">end</beam>
      </note>
      <direction placement="below">
        <direction-type>
          <wedge default-y="-59" relative-x="-40" type="crescendo"/>
        </direction-type>
        <offset>-1</offset>
      </direction>
      <direction>
        <direction-type>
          <wedge relative-x="20" spread="11" type="stop"/>
        </direction-type>
      </direction>
    </measure>
    <!--=======================================================-->
    <measure number="3" width="250">
      <direction placement="below">
        <direction-type>
          <wedge default-y="-59" relative-x="-10" spread="11" type="diminuendo"/>
        </direction-type>
      </direction>
      <note default-x="14">
        <pitch>
          <step>A</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-35">down</stem>
        <beam number="1">begin</beam>
      </note>
      <direction>
        <direction-type>
          <wedge relative-x="10" type="stop"/>
        </direction-type>
      </direction>
      <note default-x="92">
        <pitch>
          <step>B</step>
          <octave>3</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-32.5">down</stem>
        <beam number="1">continue</beam>
      </note>
      <note default-x="170">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem default-y="-29.5">down</stem>
        <beam number="1">end</beam>
      </note>
      <direction placement="below">
        <direction-type>
          <words default-y="-62" font-style="italic" relative-x="-39">rit2.</words>
        </direction-type>
      </direction>
    </measure>
    <!--=======================================================-->
    <measure number="4" width="232">
      <note default-x="16">
        <pitch>
          <step>D</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem default-y="-20">down</stem>
      </note>
      <note default-x="143">
        <rest/>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
      </note>
      <direction placement="below">
        <direction-type>
          <words default-y="-68" font-style="italic" relative-x="-39">fine2</words>
        </direction-type>
      </direction>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
      </barline>
    </measure>
  </part>
  <!--=========================================================-->
</score-partwise>
```

