### PR TITLE
Improve btrem handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Improved bTrem handling (@rettinghaus)
 * Improved trill support (@rettinghaus)
 * Option for using encoded line breaks, but automatic page breaks (--breaks=line) (@earboxer)
 * Support for `trill@extender` (@rettinghaus)

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -443,6 +443,10 @@ int Stem::CalcStem(FunctorParams *functorParams)
         if ((this->GetStemLen() == 0) && flag) flag->m_drawingNbFlags = 0;
         return FUNCTOR_CONTINUE;
     }
+    if ((this->GetStemVisible() == BOOLEAN_false) && flag) {
+        flag->m_drawingNbFlags = 0;
+        return FUNCTOR_CONTINUE;
+    }
 
     // Do not adjust the length of grace notes - this is debatable and should probably become as styling option
     if (params->m_isGraceNote) return FUNCTOR_CONTINUE;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -192,7 +192,7 @@ int Rest::CalcDots(FunctorParams *functorParams)
     }
 
     switch (this->GetActualDur()) {
-        case DUR_1: loc -= 2; break;
+        case DUR_1: loc += 0; break;
         case DUR_2: loc += 0; break;
         case DUR_4: loc += 2; break;
         case DUR_8: loc += 2; break;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -491,14 +491,16 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         stemPoint = childNote->GetDrawingStemStart(childNote);
     }
 
-    if (bTrem->HasUnitdur()) {
-        switch (bTrem->GetUnitdur()) {
-            case (DUR_8): stemMod = STEMMODIFIER_1slash; break;
-            case (DUR_16): stemMod = STEMMODIFIER_2slash; break;
-            case (DUR_32): stemMod = STEMMODIFIER_3slash; break;
-            case (DUR_64): stemMod = STEMMODIFIER_4slash; break;
-            case (DUR_128): stemMod = STEMMODIFIER_5slash; break;
-            case (DUR_256): stemMod = STEMMODIFIER_6slash; break;
+    if (bTrem->HasUnitdur() && (stemMod == STEMMODIFIER_NONE)) {
+        int slashDur = bTrem->GetUnitdur() - drawingDur;
+        switch (slashDur) {
+            case (0): stemMod = STEMMODIFIER_NONE; break;
+            case (1): stemMod = STEMMODIFIER_1slash; break;
+            case (2): stemMod = STEMMODIFIER_2slash; break;
+            case (3): stemMod = STEMMODIFIER_3slash; break;
+            case (4): stemMod = STEMMODIFIER_4slash; break;
+            case (5): stemMod = STEMMODIFIER_5slash; break;
+            case (6): stemMod = STEMMODIFIER_6slash; break;
             default: break;
         }
     }
@@ -544,7 +546,7 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     int s;
     // by default draw 3 slashes (e.g., for a temolo on a whole note)
-    if (stemMod == STEMMODIFIER_NONE) stemMod = STEMMODIFIER_3slash;
+    if ((stemMod == STEMMODIFIER_NONE) && (drawingDur < DUR_2)) stemMod = STEMMODIFIER_3slash;
     for (s = 1; s < stemMod; ++s) {
         DrawObliquePolygon(dc, x - width / 2, y, x + width / 2, y + height, height);
         y += step;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -521,8 +521,13 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         else {
             // Take into account artic (not likely, though)
             y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize)
-                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 + (stemMod - 2) * step;
+                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) + (stemMod - 2) * step;
             x = childElement->GetDrawingX() + childElement->GetDrawingRadius(m_doc);
+        }
+        if (drawingDur > DUR_4) {
+            Flag *flag = NULL;
+            flag = dynamic_cast<Flag *>(childElement->FindDescendantByType(FLAG));
+            if (flag) y -= (drawingDur > DUR_8) ? 2 * step : step;
         }
         step = -step;
     }
@@ -537,6 +542,11 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
             y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize)
                 - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 - (stemMod - 2) * step;
             x = childElement->GetDrawingX() + childElement->GetDrawingRadius(m_doc);
+        }
+        if (drawingDur > DUR_4) {
+            Flag *flag = NULL;
+            flag = dynamic_cast<Flag *>(childElement->FindDescendantByType(FLAG));
+            if (flag) y += (drawingDur > DUR_8) ? 2 * step : step;
         }
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -514,13 +514,14 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     if (stemDir == STEMDIRECTION_up) {
         if (drawingDur > DUR_1) {
             // Since we are adding the slashing on the stem, ignore artic
-            y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize, false) - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2;
+            y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize, false)
+                - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2;
             x = stemPoint.x;
         }
         else {
             // Take into account artic (not likely, though)
             y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize)
-                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2;
+                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 + (stemMod - 2) * step;
             x = childElement->GetDrawingX() + childElement->GetDrawingRadius(m_doc);
         }
         step = -step;
@@ -528,12 +529,13 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     else {
         if (drawingDur > DUR_1) {
             // Idem as above
-            y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize, false) + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize, false)
+                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
             x = stemPoint.x + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
         }
         else {
             y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize)
-                - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 5;
+                - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 - (stemMod - 2) * step;
             x = childElement->GetDrawingX() + childElement->GetDrawingRadius(m_doc);
         }
     }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -508,19 +508,19 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int beamWidthBlack = m_doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, drawingCueSize);
     int beamWidthWhite = m_doc->GetDrawingBeamWhiteWidth(staff->m_drawingStaffSize, drawingCueSize);
     int width = m_doc->GetGlyphWidth(SMUFL_E0A3_noteheadHalf, staff->m_drawingStaffSize, drawingCueSize);
-    int height = beamWidthBlack * 7 / 10;
-    int step = height + beamWidthWhite;
+    int height = beamWidthBlack * 2 / 3;
+    int step = beamWidthBlack + beamWidthWhite;
 
     if (stemDir == STEMDIRECTION_up) {
         if (drawingDur > DUR_1) {
             // Since we are adding the slashing on the stem, ignore artic
-            y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize, false) - 3 * height;
+            y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize, false) - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2;
             x = stemPoint.x;
         }
         else {
             // Take into account artic (not likely, though)
             y = childElement->GetDrawingTop(m_doc, staff->m_drawingStaffSize)
-                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 3;
+                + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2;
             x = childElement->GetDrawingX() + childElement->GetDrawingRadius(m_doc);
         }
         step = -step;
@@ -528,8 +528,8 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     else {
         if (drawingDur > DUR_1) {
             // Idem as above
-            y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize, false) + 1 * height;
-            x = stemPoint.x + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+            y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize, false) + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            x = stemPoint.x + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
         }
         else {
             y = childElement->GetDrawingBottom(m_doc, staff->m_drawingStaffSize)
@@ -548,7 +548,7 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     // by default draw 3 slashes (e.g., for a temolo on a whole note)
     if ((stemMod == STEMMODIFIER_NONE) && (drawingDur < DUR_2)) stemMod = STEMMODIFIER_3slash;
     for (s = 1; s < stemMod; ++s) {
-        DrawObliquePolygon(dc, x - width / 2, y, x + width / 2, y + height, height);
+        DrawObliquePolygon(dc, x - width / 2, y - height / 2, x + width / 2, y + height / 2, beamWidthBlack);
         y += step;
     }
 


### PR DESCRIPTION
This PR improves internal logic and rendering rules for `<bTrem>`.
Stem length now is properly adjusted to match the number of slashes and the behavior of `@unitdur` has been fixed. 
Still not working correctly though are tremolos inside of beams, here they should match the slope of the beam.  

Before: 
![btrem](https://user-images.githubusercontent.com/7693447/79044185-0d1ded80-7c04-11ea-93b5-efd1fa06b4b2.png)

After:
![btrem_new](https://user-images.githubusercontent.com/7693447/79044183-0b542a00-7c04-11ea-837a-7ded76ef4ffc.png)

Test file:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Tremolo slashes</title>
      </titleStmt>
      <pubStmt>
        <respStmt>
          <persName>Klaus Rettinghaus</persName>
        </respStmt>
      </pubStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef system.leftline="true">
            <staffGrp bar.thru="false" symbol="none">
              <staffDef n="1" lines="5" clef.shape="G" clef.line="2"></staffDef>
            </staffGrp>
          </scoreDef>
          <section label="no unit duration">
            <measure>
              <staff n="1">
                <layer>
                  <bTrem>
                    <note dur="1" pname="g" oct="4" stem.mod="1slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="1" pname="g" oct="4" stem.mod="2slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="1" pname="g" oct="4" stem.mod="3slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="1" pname="g" oct="4" stem.mod="4slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="1" pname="g" oct="4" stem.mod="5slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="1" pname="g" oct="4" stem.mod="6slash" />
                  </bTrem>
                </layer>
              </staff>
            </measure>
            <measure>
              <staff n="1">
                <layer>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" />
                  </bTrem>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" stem.mod="1slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" stem.mod="2slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" stem.mod="3slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" stem.mod="4slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" stem.mod="5slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="4" pname="g" oct="4" stem.mod="6slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="8" pname="b" oct="4" stem.mod="1slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="8" pname="b" oct="4" stem.mod="2slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="8" pname="b" oct="4" stem.mod="3slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="8" pname="b" oct="4" stem.mod="4slash" />
                  </bTrem>
                  <beam>
                    <bTrem>
                      <note dur="8" pname="b" oct="4" stem.mod="1slash" />
                    </bTrem>
                    <bTrem>
                      <note dur="8" pname="b" oct="4" stem.mod="2slash" />
                    </bTrem>
                    <bTrem>
                      <note dur="8" pname="b" oct="4" stem.mod="3slash" />
                    </bTrem>
                    <bTrem>
                      <note dur="8" pname="b" oct="4" stem.mod="4slash" />
                    </bTrem>
                  </beam>
                  <bTrem>
                    <note dur="128" pname="e" oct="5" stem.mod="6slash" />
                  </bTrem>
                  <bTrem>
                    <note dur="128" pname="f" oct="4" stem.mod="6slash" />
                  </bTrem>
                </layer>
              </staff>
            </measure>
          </section>
          <section label="with unit duration">
            <measure>
              <staff n="1">
                <layer>
                  <note dur="4" pname="g" oct="4" />
                  <bTrem unitdur="8">
                    <note dur="4" pname="g" oct="4" stem.mod="1slash" />
                  </bTrem>
                  <bTrem unitdur="16">
                    <note dur="4" pname="g" oct="4" stem.mod="2slash" />
                  </bTrem>
                  <bTrem unitdur="32">
                    <note dur="4" pname="g" oct="4" stem.mod="3slash" />
                  </bTrem>
                  <bTrem unitdur="64">
                    <note dur="4" pname="g" oct="4" stem.mod="4slash" />
                  </bTrem>
                  <bTrem unitdur="128">
                    <note dur="4" pname="g" oct="4" stem.mod="5slash" />
                  </bTrem>
                  <bTrem unitdur="16">
                    <note dur="8" pname="b" oct="4" stem.mod="1slash" />
                  </bTrem>
                  <bTrem unitdur="32">
                    <note dur="8" pname="b" oct="4" stem.mod="2slash" />
                  </bTrem>
                  <bTrem unitdur="64">
                    <note dur="8" pname="b" oct="4" stem.mod="3slash" />
                  </bTrem>
                  <bTrem unitdur="128">
                    <note dur="8" pname="b" oct="4" stem.mod="4slash" />
                  </bTrem>
                  <beam>
                    <bTrem unitdur="16">
                      <note dur="8" pname="b" oct="4" />
                    </bTrem>
                    <bTrem unitdur="32">
                      <note dur="8" pname="b" oct="4" />
                    </bTrem>
                    <bTrem unitdur="64">
                      <note dur="8" pname="b" oct="4" />
                    </bTrem>
                    <bTrem unitdur="128">
                      <note dur="8" pname="b" oct="4" />
                    </bTrem>
                  </beam>
                  <bTrem unitdur="32">
                    <note dur="128" pname="e" oct="5" stem.mod="6slash" />
                  </bTrem>
                  <bTrem unitdur="64">
                    <note dur="128" pname="f" oct="4" stem.mod="6slash" />
                  </bTrem>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
