### PR TITLE
- Redo Layout: Work when line breaks mode is being used

### DIFF
--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1167,7 +1167,12 @@ void Toolkit::RedoLayout()
     }
 
     m_doc.UnCastOffDoc();
-    m_doc.CastOffDoc();
+    if (m_options->m_breaks.GetValue() == BREAKS_line) {
+        m_doc.CastOffLineDoc();
+    }
+    else {
+        m_doc.CastOffDoc();
+    }
 }
 
 void Toolkit::RedoPagePitchPosLayout()


### PR DESCRIPTION
This is a follow up to https://github.com/rism-ch/verovio/pull/1069 to work better with the javascript toolkit.