### PR TITLE
Add data-component-class attributes on html5 noteheads

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1275,27 +1275,29 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         if (drawingDur < DUR_1) {
             DrawMaximaToBrevis(dc, noteY, element, layer, staff);
         }
-        // Whole notes
-        else if (drawingDur == DUR_1) {
-            if (note->GetColored() == BOOLEAN_true) {
-                fontNo = SMUFL_E0FA_noteheadWholeFilled;
-            }
-            else {
-                fontNo = SMUFL_E0A2_noteheadWhole;
-            }
-
-            DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true);
-        }
-        // Other values
         else {
-            if ((note->GetColored() == BOOLEAN_true) || drawingDur == DUR_2) {
-                fontNo = SMUFL_E0A3_noteheadHalf;
+            // Whole notes
+            if (drawingDur == DUR_1) {
+                if (note->GetColored() == BOOLEAN_true) {
+                    fontNo = SMUFL_E0FA_noteheadWholeFilled;
+                }
+                else {
+                    fontNo = SMUFL_E0A2_noteheadWhole;
+                }
             }
+            // Other values
             else {
-                fontNo = SMUFL_E0A4_noteheadBlack;
+                if ((note->GetColored() == BOOLEAN_true) || drawingDur == DUR_2) {
+                    fontNo = SMUFL_E0A3_noteheadHalf;
+                }
+                else {
+                    fontNo = SMUFL_E0A4_noteheadBlack;
+                }
             }
 
+            dc->StartCustomGraphic("notehead");
             DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true);
+            dc->EndCustomGraphic();
         }
     }
 

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -85,7 +85,9 @@ void View::DrawMensuralNote(DeviceContext *dc, LayerElement *element, Layer *lay
     // Semibrevis and shorter
     else {
         wchar_t code = note->GetMensuralSmuflNoteHead();
+        dc->StartCustomGraphic("notehead");
         DrawSmuflCode(dc, xNote, yNote, code, staff->m_drawingStaffSize, false);
+        dc->EndCustomGraphic();
         // For semibrevis with stem in black notation, encoded with an explicit stem direction
         if (((drawingDur > DUR_1) || (note->GetStemDir() != STEMDIRECTION_NONE))
             && note->GetStemVisible() != BOOLEAN_false) {
@@ -345,6 +347,8 @@ void View::DrawMaximaToBrevis(DeviceContext *dc, int y, LayerElement *element, L
     int sides[4];
     this->CalcBrevisPoints(note, staff, &topLeft, &bottomRight, sides, shape, isMensuralBlack);
 
+    dc->StartCustomGraphic("notehead");
+
     if (!fillNotehead) {
         // double the bases of rectangles
         DrawObliquePolygon(dc, topLeft.x + stemWidth, topLeft.y, bottomRight.x - stemWidth, topLeft.y, -strokeWidth);
@@ -357,7 +361,19 @@ void View::DrawMaximaToBrevis(DeviceContext *dc, int y, LayerElement *element, L
 
     // serifs and / or stem
     DrawFilledRectangle(dc, topLeft.x, sides[0], topLeft.x + stemWidth, sides[1]);
-    DrawFilledRectangle(dc, bottomRight.x - stemWidth, sides[2], bottomRight.x, sides[3]);
+
+    if (note->GetActualDur() != DUR_BR) {
+        // Right side is a stem - end the notehead first
+        dc->EndCustomGraphic();
+        dc->StartCustomGraphic("stem");
+        DrawFilledRectangle(dc, bottomRight.x - stemWidth, sides[2], bottomRight.x, sides[3]);
+        dc->EndCustomGraphic();
+    }
+    else {
+        // Right side is a serif
+        DrawFilledRectangle(dc, bottomRight.x - stemWidth, sides[2], bottomRight.x, sides[3]);
+        dc->EndCustomGraphic();
+    }
 
     return;
 }


### PR DESCRIPTION
For reliably getting hold of noteheads in the output for testing, interaction, highlighting etc.  The mechanism for adding `data-component-class` attributes can also be used for things other than noteheads in the future.

Please advise. Mensural notes drawn with `DrawLigatureNote()` and `DrawMaximaToBrevis()` are not covered yet. Should I put all the components of maxima and longa except for the stem part in a notehead group?

Also, I'd be grateful for a check if the default arguments make sense like that (e.g. should `NULL` be used instead of the empty string?), and maybe an opinion if the order of the two default arguments of `DrawSmuflCode` (`setBBGlyph` and `componentClass`) should be swapped.