### PR TITLE
Develop hyphen

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -511,7 +511,7 @@ public:
     OptionBool m_graceRightAlign;
     OptionDbl m_hairpinSize;
     OptionDbl m_lyricHyphenLength;
-    OptionDbl m_lyricHyphenWidth;
+    OptionDbl m_lyricLineThickness;
     OptionBool m_lyricNoStartHyphen;
     OptionDbl m_lyricSize;
     OptionDbl m_lyricTopMinMargin;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -680,9 +680,9 @@ Options::Options()
     m_lyricHyphenLength.Init(1.20, 0.50, 3.00);
     this->Register(&m_lyricHyphenLength, "lyricHyphenLength", &m_generalLayout);
 
-    m_lyricHyphenWidth.SetInfo("Lyric hyphen width", "The lyric hyphen and dash width");
-    m_lyricHyphenWidth.Init(0.20, 0.10, 0.50);
-    this->Register(&m_lyricHyphenWidth, "lyricHyphenWidth", &m_generalLayout);
+    m_lyricLineThickness.SetInfo("Lyric line thickness", "The lyric extender line thickness");
+    m_lyricLineThickness.Init(0.25, 0.10, 0.50);
+    this->Register(&m_lyricLineThickness, "lyricLineThickness", &m_generalLayout);
 
     m_lyricNoStartHyphen.SetInfo("Lyric no start hyphen", "Do not show hyphens at the beginning of a system");
     m_lyricNoStartHyphen.Init(false);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -313,6 +313,8 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
             DrawSlur(dc, dynamic_cast<Slur *>(element), x1, x2, *staffIter, spanningType, graphic);
         }
         else if (element->Is(SYL)) {
+            // prolong to the end of the notehead
+            x2 += endRadius;
             // cast to Syl check in DrawSylConnector
             DrawSylConnector(dc, dynamic_cast<Syl *>(element), x1, x2, *staffIter, spanningType, graphic);
         }
@@ -1150,7 +1152,7 @@ void View::DrawSylConnector(
         if (syl->m_nextWordSyl) {
             x2 = syl->m_nextWordSyl->GetContentLeft();
         }
-        x1 -= (dashLength / 2);
+        x1 -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
     }
     // Rare case where neither the first note nor the last note are in the current system - draw the connector
     // throughout the system

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -992,7 +992,7 @@ void View::DrawControlElementConnector(
         }
     }
 
-    int width = m_options->m_lyricHyphenWidth.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    int width = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     // the length of the dash and the space between them - can be made a parameter
     int dashLength = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 4 / 3;
@@ -1093,7 +1093,7 @@ void View::DrawFConnector(DeviceContext *dc, F *f, int x1, int x2, Staff *staff,
 
     dc->DeactivateGraphic();
 
-    int width = m_options->m_lyricHyphenWidth.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    int width = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     // Adjust it proportionally to the lyric size
     width *= m_options->m_lyricSize.GetValue() / m_options->m_lyricSize.GetDefault();
     DrawFilledRectangle(dc, x1, y, x2, y + width);
@@ -1135,7 +1135,7 @@ void View::DrawSylConnector(
     }
     // We are in the system of the last note - draw the connector from the beginning of the system
     else if (spanningType == SPANNING_END) {
-        // If we do not want to show hyphens at start of a syatem and the the end is at time 0.0
+        // If we do not want to show hyphens at the start of a system and the end is at time 0.0
         if (m_options->m_lyricNoStartHyphen.GetValue() && (syl->GetEnd()->GetAlignment()->GetTime() == 0.0)) {
             // Return but only if the end is in the first measure of the system...
             Measure *measure = dynamic_cast<Measure *>(syl->GetEnd()->GetFirstAncestor(MEASURE));
@@ -1187,9 +1187,9 @@ void View::DrawSylConnectorLines(DeviceContext *dc, int x1, int x2, int y, Syl *
         return;
     }
 
-    int width = m_options->m_lyricHyphenWidth.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    int thickness = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     // Adjust it proportionally to the lyric size
-    width *= m_options->m_lyricSize.GetValue() / m_options->m_lyricSize.GetDefault();
+    thickness *= m_options->m_lyricSize.GetValue() / m_options->m_lyricSize.GetDefault();
 
     if (syl->GetCon() == sylLog_CON_d) {
 
@@ -1223,14 +1223,14 @@ void View::DrawSylConnectorLines(DeviceContext *dc, int x1, int x2, int y, Syl *
             int x = x1 + margin + (i * dashSpace);
             x = std::max(x, x1);
 
-            DrawFilledRectangle(dc, x - halfDashLength, y, x + halfDashLength, y + width);
+            DrawFilledRectangle(dc, x - halfDashLength, y, x + halfDashLength, y + thickness);
         }
         // DrawFilledRectangle(dc, x1, y, x2, y + width);
     }
     else if (syl->GetCon() == sylLog_CON_u) {
         x1 += (int)m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
         if (x2 > x1) {
-            DrawFilledRectangle(dc, x1, y, x2, y + width);
+            DrawFilledRectangle(dc, x1, y, x2, y + thickness);
         }
     }
 }


### PR DESCRIPTION
This PR
* changes the misleading `lyricHyphenWidth` to `lyricLineThickness` to match SMuFL's `engravingDefaults` names
* slightly improves placement of system starting dashes and the end points of underscores