### PR TITLE
improve percussion clefs

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3310,7 +3310,7 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
     cleffingLog.ReadCleffingLog(element);
     AttCleffingVis cleffingVis;
     cleffingVis.ReadCleffingVis(element);
-    if (cleffingLog.HasClefLine() && cleffingLog.HasClefShape()) {
+    if (cleffingLog.HasClefShape()) {
         Clef *vrvClef = new Clef();
         vrvClef->IsAttribute(true);
         vrvClef->SetShape(cleffingLog.GetClefShape());

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -901,11 +901,22 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
             xpath = StringFormat("clef[@number='%d']/line", i + 1);
             clefLine = it->select_node(xpath.c_str());
             if (!clefLine) {
-                clefLine = it->select_node("clef/line");
+                clefLine = it->select_node("clef/line[not(@number)]");
             }
             if (clefLine.node().text()) {
                 if (!clef) clef = new Clef();
-                clef->SetLine(clef->AttLineLoc::StrToInt(clefLine.node().text().as_string()));
+                if (clef->GetShape() != CLEFSHAPE_perc) {
+                    clef->SetLine(clefLine.node().text().as_int());
+                }
+            }
+            else if (clef) {
+                switch (clef->GetShape()) {
+                    case CLEFSHAPE_C: clef->SetLine(3); break;
+                    case CLEFSHAPE_F: clef->SetLine(4); break;
+                    case CLEFSHAPE_G: clef->SetLine(2); break;
+                    case CLEFSHAPE_TAB: clef->SetLine(5); break;
+                    default: break;
+                }
             }
             // clef octave change
             pugi::xpath_node clefOctaveChange;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1870,9 +1870,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
             octave->SetColor(xmlShift.node().attribute("color").as_string());
             octave->SetDisPlace(octave->AttOctaveDisplacement::StrToStaffrelBasic(placeStr.c_str()));
             octave->SetStaff(octave->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(staffN)));
-            octave->SetDis(
-                octave->AttOctaveDisplacement::StrToOctaveDis(xmlShift.node().attribute("size").as_string()));
-            m_octDis[staffN] = (xmlShift.node().attribute("size").as_int() + 2) / 8;
+            int octDisNum = xmlShift.node().attribute("size") ? xmlShift.node().attribute("size").as_int() : 8;
+            octave->SetDis(octave->AttOctaveDisplacement::StrToOctaveDis(std::to_string(octDisNum)));
+            m_octDis[staffN] = (octDisNum + 2) / 8;
             if (HasAttributeWithValue(xmlShift.node(), "type", "up")) {
                 octave->SetDisPlace(STAFFREL_basic_below);
                 m_octDis[staffN] = -1 * m_octDis[staffN];

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2309,7 +2309,8 @@ void MusicXmlInput::ReadMusicXmlNote(
 
         // stem direction - taken into account below for the chord or the note
         data_STEMDIRECTION stemDir = STEMDIRECTION_NONE;
-        std::string stemText = GetContentOfChild(node, "stem");
+        pugi::xpath_node stem = node.select_node("stem");
+        std::string stemText = stem.node().text().as_string();
         if (stemText == "down") {
             stemDir = STEMDIRECTION_down;
         }
@@ -2411,6 +2412,10 @@ void MusicXmlInput::ReadMusicXmlNote(
             note->SetDurPpq(atoi(GetContentOfChild(node, "duration").c_str()));
             if (dots > 0) note->SetDots(dots);
             note->SetStemDir(stemDir);
+            if (node.attribute("default-y") && stem.node().attribute("default-y")) {
+              float stemLen = abs (node.attribute("default-y").as_float() - stem.node().attribute("default-y").as_float()) / 5;
+              note->SetStemLen(stemLen);
+            }
             if (stemText == "none") note->SetStemVisible(BOOLEAN_false);
             if (tremSlashNum != 0)
                 note->SetStemMod(note->AttStems::StrToStemmodifier(std::to_string(tremSlashNum) + "slash"));

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -277,8 +277,6 @@ void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
         }
         // copy other attributes if present
         if (newStaffDef->HasLabel()) staffDef->SetLabel(newStaffDef->GetLabel());
-        // FIXME MEI 4.0.0
-        // if (newStaffDef->HasLabelAbbr()) staffDef->SetLabelAbbr(newStaffDef->GetLabelAbbr());
     }
     else {
         LogWarning("StaffDef with xml:id '%s' could not be found", newStaffDef->GetUuid().c_str());

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -613,44 +613,6 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     bool isMensural = Att::IsMensuralType(staff->m_drawingNotationType);
     bool isNeume = staff->m_drawingNotationType == NOTATIONTYPE_neume;
 
-    int shapeOctaveDis = Clef::ClefId(clef->GetShape(), 0, clef->GetDis(), clef->GetDisPlace());
-
-    if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        sym = SMUFL_E050_gClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        sym = SMUFL_E052_gClef8vb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
-        sym = SMUFL_E051_gClef15mb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
-        sym = SMUFL_E053_gClef8va;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
-        sym = SMUFL_E054_gClef15ma;
-    // C-clef
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        sym = SMUFL_E05C_cClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        sym = SMUFL_E05D_cClef8vb;
-    else if (clef->GetShape() == CLEFSHAPE_C)
-        sym = SMUFL_E05C_cClef;
-
-    // F-clef
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        sym = SMUFL_E062_fClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        sym = SMUFL_E064_fClef8vb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
-        sym = SMUFL_E063_fClef15mb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
-        sym = SMUFL_E065_fClef8va;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
-        sym = SMUFL_E066_fClef15ma;
-    else if (clef->GetShape() == CLEFSHAPE_F)
-        sym = SMUFL_E062_fClef;
-
-    // Perc
-    else if (clef->GetShape() == CLEFSHAPE_perc)
-        sym = SMUFL_E069_unpitchedPercussionClef1;
-
     // mensural clefs
     if (isMensural) {
         if (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black) {
@@ -671,19 +633,67 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
                 sym = SMUFL_E904_mensuralFclefPetrucci;
         }
     }
-
-    if (isNeume) {
+    // neume clefs
+    else if (isNeume) {
         if (clef->GetShape() == CLEFSHAPE_C)
             sym = SMUFL_E906_chantCclef;
         else if (clef->GetShape() == CLEFSHAPE_F)
             sym = SMUFL_E902_chantFclef;
+    }
+    // cmn clefs
+    else {
+        int shapeOctaveDis = Clef::ClefId(clef->GetShape(), 0, clef->GetDis(), clef->GetDisPlace());
+        // G clef
+        if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
+            sym = SMUFL_E050_gClef;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
+            sym = SMUFL_E052_gClef8vb;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
+            sym = SMUFL_E051_gClef15mb;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
+            sym = SMUFL_E053_gClef8va;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
+            sym = SMUFL_E054_gClef15ma;
+        // C clef
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
+            sym = SMUFL_E05C_cClef;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
+            sym = SMUFL_E05D_cClef8vb;
+        else if (clef->GetShape() == CLEFSHAPE_C)
+            sym = SMUFL_E05C_cClef;
+        // F clef
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
+            sym = SMUFL_E062_fClef;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
+            sym = SMUFL_E064_fClef8vb;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
+            sym = SMUFL_E063_fClef15mb;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
+            sym = SMUFL_E065_fClef8va;
+        else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
+            sym = SMUFL_E066_fClef15ma;
+        else if (clef->GetShape() == CLEFSHAPE_F)
+            sym = SMUFL_E062_fClef;
+        // Perc clef
+        else if (clef->GetShape() == CLEFSHAPE_perc)
+            sym = SMUFL_E069_unpitchedPercussionClef1;
     }
 
     if (sym == 0) {
         clef->SetEmptyBB();
         return;
     }
-    y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - clef->GetLine());
+
+    if (clef->HasLine()) {
+        y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - clef->GetLine());
+    }
+    else if (clef->GetShape() == CLEFSHAPE_perc) {
+        y -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
+    }
+    else {
+        // we have no information where to put it
+        return;
+    }
 
     bool cueSize = false;
     if (clef->GetAlignment() && (clef->GetAlignment()->GetType() == ALIGNMENT_CLEF)) {


### PR DESCRIPTION
This PR adds multiple default values in MusicXML import. 
Strangely, most MusicXML exporter add a `<line>2</line>` to percussion clefs, independent of its actual place. The importer now ignores this information and Verovio places unpitched percussion clefs correctly in the middle of the system.

![percussion](https://user-images.githubusercontent.com/7693447/81479012-2b860180-9221-11ea-8536-eb99c7d61ff4.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Percussion clefs without line</title>
        <respStmt>
          <persName>Klaus Rettinghaus</persName>
        </respStmt>
      </titleStmt>
      <pubStmt>
        <date>2020-05-09</date>
      </pubStmt>
      <notesStmt>
        <annot>Percussion clefs without line are centered on staff.</annot>
      </notesStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application version="2.7.0" label="2">
          <name>Verovio</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef>
            <staffGrp>
              <staffDef n="1" lines="1" clef.shape="perc" meter.count="4" meter.unit="4"/>
              <staffDef n="2" lines="2" clef.shape="perc" meter.count="4" meter.unit="4"/>
              <staffDef n="3" lines="3" clef.shape="perc" meter.count="4" meter.unit="4"/>
              <staffDef n="4" lines="4" clef.shape="perc" meter.count="4" meter.unit="4"/>
              <staffDef n="5" lines="5" clef.shape="perc" meter.count="4" meter.unit="4"/>
            </staffGrp>
          </scoreDef>
          <section>
            <measure n="1">
              <staff n="1">
                <layer>
                  <mRest/>
                </layer>
              </staff>
              <staff n="2">
                <layer>
                  <mRest/>
                </layer>
              </staff>
              <staff n="3">
                <layer>
                  <mRest/>
                </layer>
              </staff>
              <staff n="4">
                <layer>
                  <mRest/>
                </layer>
              </staff>
              <staff n="5">
                <layer>
                  <mRest/>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```