### PR TITLE
Fixes doc comment in doc.h

### DIFF
--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -54,7 +54,7 @@ public:
      */
     virtual void AddChild(Object *object);
 
-    /*
+    /**
      * Clear the content of the document.
      */
     virtual void Reset();


### PR DESCRIPTION
Fixes doc comment.
Otherwise Xcode shows one method differently which is confusing.