### PR TITLE
add VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "cmake",
+			"type": "shell",
+			"options": {
+				"cwd": "${workspaceRoot}/tools"
+			},
+			"command": "cmake",
+			"args": [
+				"../cmake"
+			]
+		},
+		{
+			"label": "make",
+			"type": "shell",
+			"command": "make",
+			"options": {
+				"cwd": "${workspaceRoot}/tools"
+			},
+			"dependsOn": [
+				"cmake"
+			],
+			"problemMatcher": [
+				"$gcc"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+	}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,8 @@
 			},
 			"command": "cmake",
 			"args": [
-				"../cmake"
+				"${workspaceRoot}/cmake",
+				"-DNO_HUMDRUM_SUPPORT=ON"
 			]
 		},
 		{


### PR DESCRIPTION
This PR adds a `tasks.json` to build Verovio directly from VSCode on hitting `Ctrl+Shift+B`. 
For now it simply invokes cmake and make, only needs gcc to be installed. We could add further tasks later to build the js or the java toolkit. 