### PR TITLE
add simple support pedal lines

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1402,8 +1402,13 @@ public:
 
 class PrepareFloatingGrpsParams : public FunctorParams {
 public:
-    PrepareFloatingGrpsParams() { m_previousEnding = NULL; }
+    PrepareFloatingGrpsParams()
+    {
+        m_previousEnding = NULL;
+        m_pedalLine = NULL;
+    }
     Ending *m_previousEnding;
+    Pedal *m_pedalLine;
     std::vector<Dynam *> m_dynams;
     std::vector<Hairpin *> m_hairpins;
     std::map<std::string, Harm *> m_harms;
@@ -1468,24 +1473,6 @@ public:
     ArrayOfLinkingInterfaceUuidPairs m_sameasUuidPairs;
     bool m_fillList;
 };
-
-//----------------------------------------------------------------------------
-// PreparePedalLine
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the current Pedal
- **/
-
-class PreparePedalLine : public FunctorParams {
-public:
-    PreparePedalLine()
-    {
-        m_pedalLine = NULL;
-    }
-    Pedal *m_pedalLine;
-};
-
 
 //----------------------------------------------------------------------------
 // PreparePlistParams

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -41,6 +41,7 @@ class MeterSig;
 class MRpt;
 class Object;
 class Page;
+class Pedal;
 class ScoreDef;
 class Slur;
 class Staff;
@@ -1467,6 +1468,24 @@ public:
     ArrayOfLinkingInterfaceUuidPairs m_sameasUuidPairs;
     bool m_fillList;
 };
+
+//----------------------------------------------------------------------------
+// PreparePedalLine
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the current Pedal
+ **/
+
+class PreparePedalLine : public FunctorParams {
+public:
+    PreparePedalLine()
+    {
+        m_pedalLine = NULL;
+    }
+    Pedal *m_pedalLine;
+};
+
 
 //----------------------------------------------------------------------------
 // PreparePlistParams

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -51,6 +51,14 @@ public:
     virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
     ////@}
 
+    /**
+     * @name Setter and getter of the bounce flag
+     */
+    ///@{
+    bool EndsWithBounce() const { return m_endsWithBounce; }
+    void EndsWithBounce(bool endsWithBounce) { m_endsWithBounce = endsWithBounce; }
+    ///@}
+
     //----------//
     // Functors //
     //----------//
@@ -65,14 +73,11 @@ public:
      */
     virtual int GenerateMIDI(FunctorParams *functorParams);
 
-protected:
-    //
 private:
-    //
-public:
-    //
-private:
-    //
+    /**
+     * Flag indicating whether or not the element was generated
+     */
+    bool m_endsWithBounce;
 };
 
 } // namespace vrv

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -65,6 +65,11 @@ public:
      */
     virtual int GenerateMIDI(FunctorParams *functorParams);
 
+    /**
+     * See Object::PreparePedalLine
+     */
+    virtual int PreparePedalLine(FunctorParams *functorParams);
+
 protected:
     //
 private:

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -75,7 +75,7 @@ public:
 
 private:
     /**
-     * Flag indicating whether or not the element was generated
+     * Flag indicating if following pedal mark is a bounce
      */
     bool m_endsWithBounce;
 };

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -23,7 +23,7 @@ namespace vrv {
  * This class models the MEI <pedal> element.
  */
 class Pedal : public ControlElement,
-              public TimePointInterface,
+              public TimeSpanningInterface,
               public AttColor,
               public AttPedalLog,
               public AttPedalVis,
@@ -48,6 +48,7 @@ public:
      */
     ///@{
     virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
     ////@}
 
     //----------//

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -65,11 +65,6 @@ public:
      */
     virtual int GenerateMIDI(FunctorParams *functorParams);
 
-    /**
-     * See Object::PreparePedalLine
-     */
-    virtual int PreparePedalLine(FunctorParams *functorParams);
-
 protected:
     //
 private:

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -403,7 +403,7 @@ protected:
 
     /**
      * @name Methods for drawing time spanning elements, connectors or extensions
-     * Called fomr DrawTimeSpanningElement
+     * Called from DrawTimeSpanningElement
      */
     ///@{
     void DrawControlElementConnector(DeviceContext *dc, ControlElement *element, int x1, int x2, Staff *staff,
@@ -418,6 +418,8 @@ protected:
         DeviceContext *dc, Hairpin *hairpin, int x1, int x2, Staff *staff, char spanningType, Object *graphic = NULL);
     void DrawOctave(
         DeviceContext *dc, Octave *octave, int x1, int x2, Staff *staff, char spanningType, Object *graphic = NULL);
+    void DrawPedalLine(
+        DeviceContext *dc, Pedal *pedal, int x1, int x2, Staff *staff, char spanningType, Object *graphic = NULL);
     void DrawSlur(
         DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff, char spanningType, Object *graphic = NULL);
     void DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, char spanningType, Object *graphic = NULL);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1907,6 +1907,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
             }
             pedal->SetTstamp(timeStamp);
+            if (pedalLine && (pedalType == "stop")) pedal->SetTstamp(timeStamp - 0.1);
             int defaultY = xmlPedal.node().attribute("default-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -90,27 +90,21 @@ int Pedal::GenerateMIDI(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Pedal::PrepareFloatingGrps(FunctorParams *)
+int Pedal::PrepareFloatingGrps(FunctorParams *functorParams)
 {
+    PrepareFloatingGrpsParams *params = dynamic_cast<PrepareFloatingGrpsParams *>(functorParams);
+    assert(params);
+
     if (this->HasVgrp()) {
         this->SetDrawingGrpId(-this->GetVgrp());
     }
 
-    return FUNCTOR_CONTINUE;
-}
-
-int Pedal::PreparePedalLine(FunctorParams *functorParams)
-{
-    class PreparePedalLine *params = dynamic_cast<class PreparePedalLine *>(functorParams);
-    assert(params);
-    
-    if (this->HasStart()) {
-        if (this->GetDir() == pedalLog_DIR_down && this->GetForm() == pedalVis_FORM_line) params->m_pedalLine = this;
-    }
-
-    // At this stage m_pedal is actually a started pedal line
     if (params->m_pedalLine && this->GetDir() == pedalLog_DIR_up) {
         params->m_pedalLine->SetEnd(this->GetStart());
+    }
+
+    if (this->GetDir() == pedalLog_DIR_down && this->GetForm() == pedalVis_FORM_line) {
+        params->m_pedalLine = this;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -86,6 +86,10 @@ int Pedal::GenerateMIDI(FunctorParams *functorParams)
         case pedalLog_DIR_up:
             params->m_midiFile->addSustainPedalOff(params->m_midiTrack, (starttime * tpq), params->m_midiChannel);
             break;
+        case pedalLog_DIR_bounce:
+            params->m_midiFile->addSustainPedalOff(params->m_midiTrack, (starttime * tpq), params->m_midiChannel);
+            params->m_midiFile->addSustainPedalOn(params->m_midiTrack, (starttime * tpq) + 0.1, params->m_midiChannel);
+            break;
         default: return FUNCTOR_CONTINUE;
     }
 

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -58,6 +58,8 @@ void Pedal::Reset()
     ResetPedalVis();
     ResetPlacement();
     ResetVerticalGroup();
+
+    m_endsWithBounce = false;
 }
 
 //----------------------------------------------------------------------------
@@ -99,11 +101,17 @@ int Pedal::PrepareFloatingGrps(FunctorParams *functorParams)
         this->SetDrawingGrpId(-this->GetVgrp());
     }
 
-    if (params->m_pedalLine && this->GetDir() == pedalLog_DIR_up) {
+    if (!this->HasDir()) return FUNCTOR_CONTINUE;
+
+    if (params->m_pedalLine && (this->GetDir() != pedalLog_DIR_down)) {
         params->m_pedalLine->SetEnd(this->GetStart());
+        if (this->GetDir() == pedalLog_DIR_bounce) {
+            params->m_pedalLine->EndsWithBounce(true);
+        }
+        params->m_pedalLine = NULL;
     }
 
-    if (this->GetDir() == pedalLog_DIR_down && this->GetForm() == pedalVis_FORM_line) {
+    if ((this->GetDir() != pedalLog_DIR_up) && (this->GetForm() == pedalVis_FORM_line)) {
         params->m_pedalLine = this;
     }
 

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -30,14 +30,14 @@ namespace vrv {
 
 Pedal::Pedal()
     : ControlElement("pedal-")
-    , TimePointInterface()
+    , TimeSpanningInterface()
     , AttColor()
     , AttPedalLog()
     , AttPedalVis()
     , AttPlacement()
     , AttVerticalGroup()
 {
-    RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
+    RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_PEDALLOG);
     RegisterAttClass(ATT_PEDALVIS);
@@ -52,7 +52,7 @@ Pedal::~Pedal() {}
 void Pedal::Reset()
 {
     ControlElement::Reset();
-    TimePointInterface::Reset();
+    TimeSpanningInterface::Reset();
     ResetColor();
     ResetPedalLog();
     ResetPedalVis();

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -99,4 +99,21 @@ int Pedal::PrepareFloatingGrps(FunctorParams *)
     return FUNCTOR_CONTINUE;
 }
 
+int Pedal::PreparePedalLine(FunctorParams *functorParams)
+{
+    class PreparePedalLine *params = dynamic_cast<class PreparePedalLine *>(functorParams);
+    assert(params);
+    
+    if (this->HasStart()) {
+        if (this->GetDir() == pedalLog_DIR_down && this->GetForm() == pedalVis_FORM_line) params->m_pedalLine = this;
+    }
+
+    // At this stage m_pedal is actually a started pedal line
+    if (params->m_pedalLine && this->GetDir() == pedalLog_DIR_up) {
+        params->m_pedalLine->SetEnd(this->GetStart());
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -25,6 +25,7 @@
 #include "measure.h"
 #include "page.h"
 #include "pages.h"
+#include "pedal.h"
 #include "section.h"
 #include "staff.h"
 #include "syl.h"
@@ -245,6 +246,13 @@ void System::AddToDrawingListIfNeccessary(Object *object)
         assert(dynam);
         if (dynam->GetEnd() || (dynam->GetNextLink() && (dynam->GetExtender() == BOOLEAN_true))) {
             this->AddToDrawingList(dynam);
+        }
+    }
+    else if (object->Is(PEDAL)) {
+        Pedal *pedal = dynamic_cast<Pedal *>(object);
+        assert(pedal);
+        if (pedal->GetEnd()) {
+            this->AddToDrawingList(pedal);
         }
     }
     else if (object->Is(TRILL)) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1915,43 +1915,47 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
     // just as without a dir attribute
     if (!pedal->HasDir()) return;
 
-    int x = pedal->GetStart()->GetDrawingX() + pedal->GetStart()->GetDrawingRadius(m_doc);
-
-    data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_center;
-    // center the pedal only with @startid
-    if (pedal->GetStart()->Is(TIMESTAMP_ATTR)) {
-        alignment = HORIZONTALALIGNMENT_left;
-    }
-
-    std::vector<Staff *>::iterator staffIter;
-    std::vector<Staff *> staffList = pedal->GetTstampStaves(measure);
-
-    int code = SMUFL_E655_keyboardPedalUp;
-    std::wstring str;
-    if (pedal->GetDir() == pedalLog_DIR_bounce && pedal->GetForm() != pedalVis_FORM_altpedstar) {
-        str.push_back(code);
-        // Get the staff size of the first staff
-        int staffSize = (staffList.begin() != staffList.end()) ? (*staffList.begin())->m_drawingStaffSize : 100;
-        TextExtend bounceOffset;
-        dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, false));
-        dc->GetSmuflTextExtent(str, &bounceOffset);
-        dc->ResetFont();
-        x -= bounceOffset.m_width;
-    }
-    if (pedal->GetDir() != pedalLog_DIR_up) {
-        if (pedal->GetFunc() == "sostenuto") {
-            code = SMUFL_E659_keyboardPedalSost;
-        }
-        else {
-            code = SMUFL_E650_keyboardPedalPed;
-        }
-    }
-    str.push_back(code);
-
     dc->StartGraphic(pedal, "", pedal->GetUuid());
 
-    // Don't draw a symbol, if it's a line
+    // Draw a symbol, if it's not a line
     if (pedal->GetForm() != pedalVis_FORM_line) {
+
+        bool bounceStar = true;
+        if (pedal->GetForm() == pedalVis_FORM_altpedstar) bounceStar = false;
+
+        int x = pedal->GetStart()->GetDrawingX() + pedal->GetStart()->GetDrawingRadius(m_doc);
+
+        data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_center;
+        // center the pedal only with @startid
+        if (pedal->GetStart()->Is(TIMESTAMP_ATTR)) {
+            alignment = HORIZONTALALIGNMENT_left;
+        }
+
+        std::vector<Staff *>::iterator staffIter;
+        std::vector<Staff *> staffList = pedal->GetTstampStaves(measure);
+
+        int code = SMUFL_E655_keyboardPedalUp;
+        std::wstring str;
+        if (bounceStar && (pedal->GetDir() == pedalLog_DIR_bounce)) {
+            str.push_back(code);
+            // Get the staff size of the first staff
+            int staffSize = (staffList.begin() != staffList.end()) ? (*staffList.begin())->m_drawingStaffSize : 100;
+            TextExtend bounceOffset;
+            dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, false));
+            dc->GetSmuflTextExtent(str, &bounceOffset);
+            dc->ResetFont();
+            x -= bounceOffset.m_width;
+        }
+        if (pedal->GetDir() != pedalLog_DIR_up) {
+            if (pedal->GetFunc() == "sostenuto") {
+                code = SMUFL_E659_keyboardPedalSost;
+            }
+            else {
+                code = SMUFL_E650_keyboardPedalPed;
+            }
+        }
+        str.push_back(code);
+
         for (staffIter = staffList.begin(); staffIter != staffList.end(); ++staffIter) {
             if (!system->SetCurrentFloatingPositioner((*staffIter)->GetN(), pedal, pedal->GetStart(), *staffIter)) {
                 continue;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1857,7 +1857,7 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
 
     int code = SMUFL_E655_keyboardPedalUp;
     std::wstring str;
-    if (pedal->GetDir() == pedalLog_DIR_bounce) {
+    if (pedal->GetDir() == pedalLog_DIR_bounce && pedal->GetForm() != pedalVis_FORM_altpedstar) {
         str.push_back(code);
         // Get the staff size of the first staff
         int staffSize = (staffList.begin() != staffList.end()) ? (*staffList.begin())->m_drawingStaffSize : 100;

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -203,6 +203,7 @@ void View::DrawSystem(DeviceContext *dc, System *system)
     DrawSystemList(dc, system, TRILL);
     DrawSystemList(dc, system, FIGURE);
     DrawSystemList(dc, system, OCTAVE);
+    DrawSystemList(dc, system, PEDAL);
     DrawSystemList(dc, system, TIE);
     DrawSystemList(dc, system, SLUR);
     DrawSystemList(dc, system, ENDING);
@@ -238,6 +239,9 @@ void View::DrawSystemList(DeviceContext *dc, System *system, const ClassId class
             DrawTimeSpanningElement(dc, *iter, system);
         }
         if ((*iter)->Is(classId) && (classId == OCTAVE)) {
+            DrawTimeSpanningElement(dc, *iter, system);
+        }
+        if ((*iter)->Is(classId) && (classId == PEDAL)) {
             DrawTimeSpanningElement(dc, *iter, system);
         }
         if ((*iter)->Is(classId) && (classId == SYL)) {


### PR DESCRIPTION
This PR adds simple rendition for pedal lines. For now, only `@dir="down"` and `@dir="up"` is taken into account for lines. In order to support `@dir="bounce"`, some things has to be reconsidered. 
Adapts the MusicXML import according. 
In addition, now `@dir="bounce"` is taken into account for MIDI output.

closes #967
closes #1425