### PR TITLE
support for dynam.dist and harm.dist

### DIFF
--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -107,7 +107,11 @@ private:
  * This class represents a MEI scoreDef.
  * It contains StaffGrp objects.
  */
-class ScoreDef : public ScoreDefElement, public ObjectListInterface, public AttEndings, public AttOptimization {
+class ScoreDef : public ScoreDefElement,
+                 public ObjectListInterface,
+                 public AttDistances,
+                 public AttEndings,
+                 public AttOptimization {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -793,7 +793,8 @@ void Doc::CastOffDocBase(bool useSectionBreaks, bool usePageBreaks)
     // By default, optimize scores
     bool optimize = (m_mdivScoreDef.GetOptimize() != BOOLEAN_false);
     // However, if nothing specified, do not if there is only one staffGrp
-    if ((m_mdivScoreDef.GetOptimize() == BOOLEAN_NONE) && (m_mdivScoreDef.GetChildCount(STAFFGRP, UNLIMITED_DEPTH) < 2)) {
+    if ((m_mdivScoreDef.GetOptimize() == BOOLEAN_NONE)
+        && (m_mdivScoreDef.GetChildCount(STAFFGRP, UNLIMITED_DEPTH) < 2)) {
         optimize = false;
     }
 
@@ -1565,14 +1566,28 @@ double Doc::GetRightMargin(const ClassId classId) const
 
 double Doc::GetBottomMargin(const ClassId classId) const
 {
-    if (classId == HARM) return m_options->m_bottomMarginHarm.GetValue();
-    return m_options->m_defaultBottomMargin.GetValue();
+    int margin = m_options->m_defaultBottomMargin.GetValue();
+    if (classId == DYNAM) {
+        margin = this->m_mdivScoreDef.HasDynamDist() ? this->m_mdivScoreDef.GetDynamDist() : margin;
+    }
+    else if (classId == HARM) {
+        margin = this->m_mdivScoreDef.HasHarmDist() ? this->m_mdivScoreDef.GetHarmDist()
+                                                    : m_options->m_bottomMarginHarm.GetValue();
+    }
+    return margin;
 }
 
 double Doc::GetTopMargin(const ClassId classId) const
 {
-    if (classId == HARM) return m_options->m_topMarginHarm.GetValue();
-    return m_options->m_defaultTopMargin.GetValue();
+    int margin = m_options->m_defaultTopMargin.GetValue();
+    if (classId == DYNAM) {
+        margin = this->m_mdivScoreDef.HasDynamDist() ? this->m_mdivScoreDef.GetDynamDist() : margin;
+    }
+    else if (classId == HARM) {
+        margin = this->m_mdivScoreDef.HasHarmDist() ? this->m_mdivScoreDef.GetHarmDist()
+                                                    : m_options->m_topMarginHarm.GetValue();
+    }
+    return margin;
 }
 
 Page *Doc::SetDrawingPage(int pageIdx)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -991,6 +991,7 @@ void MEIOutput::WriteScoreDef(pugi::xml_node currentNode, ScoreDef *scoreDef)
 
     WriteScoreDefElement(currentNode, scoreDef);
     WriteScoreDefInterface(currentNode, scoreDef);
+    scoreDef->WriteDistances(currentNode);
     scoreDef->WriteEndings(currentNode);
     scoreDef->WriteOptimization(currentNode);
 }
@@ -3407,6 +3408,7 @@ bool MEIInput::ReadScoreDef(Object *parent, pugi::xml_node scoreDef)
     }
 
     ReadScoreDefInterface(scoreDef, vrvScoreDef);
+    vrvScoreDef->ReadDistances(scoreDef);
     vrvScoreDef->ReadEndings(scoreDef);
     vrvScoreDef->ReadOptimization(scoreDef);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -835,7 +835,7 @@ Options::Options()
     /// custom bottom
 
     m_bottomMarginHarm.SetInfo("Bottom margin harm", "The margin for harm in MEI units");
-    m_bottomMarginHarm.Init(0.5, 0.0, 10.0);
+    m_bottomMarginHarm.Init(1.0, 0.0, 10.0);
     this->Register(&m_bottomMarginHarm, "bottomMarginHarm", &m_elementMargins);
 
     /// custom left
@@ -973,7 +973,7 @@ Options::Options()
     /// custom top
 
     m_topMarginHarm.SetInfo("Top margin harm", "The margin for harm in MEI units");
-    m_topMarginHarm.Init(0.5, 0.0, 10.0);
+    m_topMarginHarm.Init(1.0, 0.0, 10.0);
     this->Register(&m_topMarginHarm, "topMarginHarm", &m_elementMargins);
 
     /*

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -144,8 +144,10 @@ MeterSig *ScoreDefElement::GetMeterSigCopy()
 // ScoreDef
 //----------------------------------------------------------------------------
 
-ScoreDef::ScoreDef() : ScoreDefElement("scoredef-"), ObjectListInterface(), AttEndings(), AttOptimization()
+ScoreDef::ScoreDef()
+    : ScoreDefElement("scoredef-"), ObjectListInterface(), AttDistances(), AttEndings(), AttOptimization()
 {
+    RegisterAttClass(ATT_DISTANCES);
     RegisterAttClass(ATT_ENDINGS);
     RegisterAttClass(ATT_OPTIMIZATION);
 
@@ -157,6 +159,7 @@ ScoreDef::~ScoreDef() {}
 void ScoreDef::Reset()
 {
     ScoreDefElement::Reset();
+    ResetDistances();
     ResetEndings();
     ResetOptimization();
 


### PR DESCRIPTION
This adds global setting of `@dynam.dist` and `@harm.dist` through `scoreDef`. 
Default distance for `harm` is now set to one. 

closes #1108