### PR TITLE
support for opening attribute on hairpins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [unreleased]
+* Support for `hairpin@opening` (@rettinghaus)
+* Support for `@dynam.dist` and `@harm.dist` (@rettinghaus)
+* Support for pedal lines (@rettinghaus)
 
 ## [2.7.1] - 2020-05-22
 * Fix bug with mensural clefs not displaying

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -9,6 +9,7 @@
 #define __VRV_HAIRPIN_H__
 
 #include "atts_cmn.h"
+#include "atts_visual.h"
 #include "controlelement.h"
 #include "timeinterface.h"
 
@@ -25,6 +26,7 @@ class Hairpin : public ControlElement,
                 public TimeSpanningInterface,
                 public AttColor,
                 public AttHairpinLog,
+                public AttHairpinVis,
                 public AttPlacement,
                 public AttVerticalGroup {
 public:

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -309,14 +309,15 @@ private:
     data_BARRENDITION ConvertStyleToRend(std::string value, bool repeat);
     data_BOOLEAN ConvertWordToBool(std::string value);
     data_DURATION ConvertTypeToDur(std::string value);
+    data_HEADSHAPE ConvertNotehead(std::string value);
     data_LINESTARTENDSYMBOL ConvertLineEndSymbol(std::string value);
-    data_TEXTRENDITION ConvertEnclosure(std::string value);
-    std::wstring ConvertTypeToVerovioText(std::string value);
     data_PITCHNAME ConvertStepToPitchName(std::string value);
+    data_TEXTRENDITION ConvertEnclosure(std::string value);
     curvature_CURVEDIR InferCurvedir(pugi::xml_node slurOrTie);
     fermataVis_SHAPE ConvertFermataShape(std::string);
     pedalLog_DIR ConvertPedalTypeToDir(std::string value);
     tupletVis_NUMFORMAT ConvertTupletNumberValue(std::string value);
+    std::wstring ConvertTypeToVerovioText(std::string value);
     std::string ConvertAlterToSymbol(std::string value);
     std::string ConvertKindToSymbol(std::string value);
     std::string ConvertKindToText(std::string value);

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -31,12 +31,14 @@ Hairpin::Hairpin()
     , TimeSpanningInterface()
     , AttColor()
     , AttHairpinLog()
+    , AttHairpinVis()
     , AttPlacement()
     , AttVerticalGroup()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_HAIRPINLOG);
+    RegisterAttClass(ATT_HAIRPINVIS);
     RegisterAttClass(ATT_PLACEMENT);
     RegisterAttClass(ATT_VERTICALGROUP);
 
@@ -51,6 +53,7 @@ void Hairpin::Reset()
     TimeSpanningInterface::Reset();
     ResetColor();
     ResetHairpinLog();
+    ResetHairpinVis();
     ResetPlacement();
     ResetVerticalGroup();
 
@@ -65,6 +68,10 @@ int Hairpin::CalcHeight(
     assert(doc);
 
     int endY = doc->GetDrawingHairpinSize(staffSize, false);
+
+    if (this->HasOpening()) {
+        endY = this->GetOpening() * doc->GetDrawingUnit(staffSize);
+    }
 
     // Something is probably wrong before...
     if (!this->GetDrawingLength()) return endY;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1219,6 +1219,7 @@ void MEIOutput::WriteHairpin(pugi::xml_node currentNode, Hairpin *hairpin)
     WriteTimeSpanningInterface(currentNode, hairpin);
     hairpin->WriteColor(currentNode);
     hairpin->WriteHairpinLog(currentNode);
+    hairpin->WriteHairpinVis(currentNode);
     hairpin->WritePlacement(currentNode);
     hairpin->WriteVerticalGroup(currentNode);
 }
@@ -3985,6 +3986,7 @@ bool MEIInput::ReadHairpin(Object *parent, pugi::xml_node hairpin)
     ReadTimeSpanningInterface(hairpin, vrvHairpin);
     vrvHairpin->ReadColor(hairpin);
     vrvHairpin->ReadHairpinLog(hairpin);
+    vrvHairpin->ReadHairpinVis(hairpin);
     vrvHairpin->ReadPlacement(hairpin);
     vrvHairpin->ReadVerticalGroup(hairpin);
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1788,6 +1788,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 if (iter->second.m_dirN == hairpinNumber) {
                     int measureDifference = m_measureCounts.at(measure) - iter->second.m_lastMeasureCount;
                     iter->first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                    if (wedge.node().attribute("spread")) {
+                        iter->first->SetOpening(wedge.node().attribute("spread").as_double() / 5);
+                    }
                     m_hairpinStack.erase(iter);
                     return;
                 }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1808,6 +1808,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             else if (HasAttributeWithValue(wedge.node(), "type", "diminuendo")) {
                 hairpin->SetForm(hairpinLog_FORM_dim);
             }
+            // hairpin->SetLform(hairpin->AttLineRendBase::StrToLineform(wedge.node().attribute("line-type").as_string()));
             if (wedge.node().attribute("niente")) {
                 hairpin->SetNiente(ConvertWordToBool(wedge.node().attribute("niente").as_string()));
             }
@@ -2393,7 +2394,6 @@ void MusicXmlInput::ReadMusicXmlNote(
             note->SetHeadShape(ConvertNotehead(notehead.node().text().as_string()));
             if (notehead.node().attribute("parentheses").as_bool()) note->SetHeadMod(NOTEHEADMODIFIER_paren);
             if (!std::strncmp(notehead.node().text().as_string(), "none", 4)) note->SetHeadVisible(BOOLEAN_false);
-            // if (notehead.node().attribute("parentheses").as_bool()) note->SetEnclose(ENCLOSURE_paren);
         }
 
         // look at the next note to see if we are starting or ending a chord

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1808,6 +1808,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
             else if (HasAttributeWithValue(wedge.node(), "type", "diminuendo")) {
                 hairpin->SetForm(hairpinLog_FORM_dim);
             }
+            if (wedge.node().attribute("niente")) {
+                hairpin->SetNiente(ConvertWordToBool(wedge.node().attribute("niente").as_string()));
+            }
             hairpin->SetColor(wedge.node().attribute("color").as_string());
             hairpin->SetPlace(hairpin->AttPlacement::StrToStaffrel(placeStr.c_str()));
             hairpin->SetTstamp(timeStamp);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2384,6 +2384,9 @@ void MusicXmlInput::ReadMusicXmlNote(
         pugi::xpath_node notehead = node.select_node("notehead");
         if (notehead) {
             note->SetHeadColor(notehead.node().attribute("color").as_string());
+            note->SetHeadShape(ConvertNotehead(notehead.node().text().as_string()));
+            if (notehead.node().attribute("parentheses").as_bool()) note->SetHeadMod(NOTEHEADMODIFIER_paren);
+            if (!std::strncmp(notehead.node().text().as_string(), "none", 4)) note->SetHeadVisible(BOOLEAN_false);
             // if (notehead.node().attribute("parentheses").as_bool()) note->SetEnclose(ENCLOSURE_paren);
         }
 
@@ -3184,6 +3187,34 @@ std::wstring MusicXmlInput::ConvertTypeToVerovioText(std::string value)
         LogWarning("MusicXML import: Unsupported type '%s'", value.c_str());
         return L"";
     }
+}
+
+data_HEADSHAPE MusicXmlInput::ConvertNotehead(std::string value)
+{
+    if (value == "slash")
+        return HEADSHAPE_slash;
+    else if (value == "triangle")
+        return HEADSHAPE_rtriangle;
+    else if (value == "diamond")
+        return HEADSHAPE_diamond;
+    else if (value == "square")
+        return HEADSHAPE_square;
+    else if (value == "cross")
+        return HEADSHAPE_plus;
+    else if (value == "x")
+        return HEADSHAPE_slash;
+    else if (value == "circle-x")
+        return HEADSHAPE_slash;
+    else if (value == "inverted triangle")
+        return HEADSHAPE_slash;
+    else if (value == "arrow down")
+        return HEADSHAPE_slash;
+    else if (value == "arrow up")
+        return HEADSHAPE_slash;
+    else if (value == "circle dot")
+        return HEADSHAPE_circle;
+    else
+        return HEADSHAPE_NONE;
 }
 
 data_LINESTARTENDSYMBOL MusicXmlInput::ConvertLineEndSymbol(std::string value)


### PR DESCRIPTION
This adds support for `hairpin@opening` and adds note head shape conversion to MusicXML import.