### PR TITLE
Adjust measure

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -102,8 +102,8 @@ public:
     {
         m_pointSize = 0;
         m_family = 0; // was wxFONTFAMILY_DEFAULT;
-        m_style = FONTSTYLE_normal;
-        m_weight = FONTWEIGHT_normal;
+        m_style = FONTSTYLE_NONE;
+        m_weight = FONTWEIGHT_NONE;
         m_underlined = false;
         m_supSubScript = false;
         m_faceName.clear();

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -102,8 +102,8 @@ public:
     {
         m_pointSize = 0;
         m_family = 0; // was wxFONTFAMILY_DEFAULT;
-        m_style = FONTSTYLE_NONE;
-        m_weight = FONTWEIGHT_NONE;
+        m_style = FONTSTYLE_normal;
+        m_weight = FONTWEIGHT_normal;
         m_underlined = false;
         m_supSubScript = false;
         m_faceName.clear();
@@ -113,8 +113,8 @@ public:
 
     // accessors and modifiers for the font elements
     int GetPointSize() { return m_pointSize; }
-    int GetStyle() { return m_style; }
-    int GetWeight() { return m_weight; }
+    data_FONTSTYLE GetStyle() { return m_style; }
+    data_FONTWEIGHT GetWeight() { return m_weight; }
     bool GetUnderlined() { return m_underlined; }
     bool GetSupSubScript() { return m_supSubScript; }
     std::string GetFaceName() { return m_faceName; }

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -297,6 +297,7 @@ public:
      * See Object::AdjustXOverflow
      */
     virtual int AdjustXOverflow(FunctorParams *functorParams);
+    virtual int AdjustXOverflowEnd(FunctorParams *functorParams);
 
     /**
      * See Object::AdjustXPos

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -138,8 +138,8 @@ public:
      */
     ///@{
     /** Resource path */
-    static std::string GetPath() { return m_path; }
-    static void SetPath(const std::string &path) { m_path = path; }
+    static std::string GetPath() { return s_path; }
+    static void SetPath(const std::string &path) { s_path = path; }
     /** Init the SMufL music and text fonts */
     static bool InitFonts();
     /** Init the text font (bounding boxes and ASCII only) */
@@ -159,12 +159,12 @@ private:
 
 private:
     /** The path to the resources directory (e.g., for the svg/ subdirectory with fonts as XML */
-    static std::string m_path;
+    static std::string s_path;
     /** The loaded SMuFL font */
-    static GlyphMap m_font;
+    static GlyphMap s_font;
     /** A text font used for bounding box calculations */
-    static GlyphTextMap m_textFont;
-    static StyleAttributes m_currentStyle;
+    static GlyphTextMap s_textFont;
+    static StyleAttributes s_currentStyle;
     static const StyleAttributes k_defaultStyle;
 };
 

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -21,6 +21,8 @@
 #include <time.h>
 #endif
 
+#include "atttypes.h"
+
 namespace vrv {
 
 class Glyph;
@@ -128,35 +130,42 @@ bool Check(Object *object);
 
 class Resources {
 public:
+    using StyleAttributes = std::pair<data_FONTWEIGHT, data_FONTSTYLE>;
+    using GlyphMap = std::map<wchar_t, Glyph>;
+    using GlyphTextMap = std::map<StyleAttributes, GlyphMap>;
     /**
      * @name Setters and getters for static environment variables
      */
     ///@{
     /** Resource path */
     static std::string GetPath() { return m_path; }
-    static void SetPath(std::string path) { m_path = path; }
+    static void SetPath(const std::string &path) { m_path = path; }
     /** Init the SMufL music and text fonts */
     static bool InitFonts();
     /** Init the text font (bounding boxes and ASCII only) */
-    static bool InitTextFont(std::string fontName);
+    static bool InitTextFont(const std::string &fontName, const StyleAttributes &style);
     /** Select a particular font */
-    static bool SetFont(std::string fontName);
+    static bool SetFont(const std::string &fontName);
     /** Returns the glyph (if exists) for the current SMuFL font */
     static Glyph *GetGlyph(wchar_t smuflCode);
+    /** Set current text style*/
+    static void SelectTextFont(data_FONTWEIGHT fontWeight, data_FONTSTYLE fontStyle);
     /** Returns the glyph (if exists) for the text font (bounding box and ASCII only) */
     static Glyph *GetTextGlyph(wchar_t code);
     ///@}
 
 private:
-    static bool LoadFont(std::string fontName);
+    static bool LoadFont(const std::string &fontName);
 
 private:
     /** The path to the resources directory (e.g., for the svg/ subdirectory with fonts as XML */
     static std::string m_path;
     /** The loaded SMuFL font */
-    static std::map<wchar_t, Glyph> m_font;
+    static GlyphMap m_font;
     /** A text font used for bounding box calculations */
-    static std::map<wchar_t, Glyph> m_textFont;
+    static GlyphTextMap m_textFont;
+    static StyleAttributes m_currentStyle;
+    static const StyleAttributes k_defaultStyle;
 };
 
 //----------------------------------------------------------------------------

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -864,6 +864,31 @@ int Measure::AdjustXOverflow(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Measure::AdjustXOverflowEnd(FunctorParams *functorParams)
+{
+    AdjustXOverflowParams *params = dynamic_cast<AdjustXOverflowParams *>(functorParams);
+
+    if (!params->m_currentWidest) {
+        return FUNCTOR_CONTINUE;
+    }
+
+    int measureRightX = GetDrawingX() + GetRightBarLineLeft() - params->m_margin;
+    if (measureRightX < params->m_currentWidest->GetContentRight()) {
+        LayerElement *objectX = dynamic_cast<LayerElement *>(params->m_currentWidest->GetObjectX());
+        if (!objectX) {
+            return FUNCTOR_CONTINUE;
+        }
+        Alignment *left = objectX->GetAlignment();
+        ArrayOfAdjustmentTuples boundaries{
+            std::make_tuple(left, params->m_lastMeasure->GetRightBarLine()->GetAlignment(),
+                            params->m_currentWidest->GetContentRight() - measureRightX) 
+        };
+        m_measureAligner.AdjustProportionally(boundaries);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Measure::SetAlignmentXPos(FunctorParams *functorParams)
 {
     SetAlignmentXPosParams *params = dynamic_cast<SetAlignmentXPosParams *>(functorParams);

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -138,6 +138,7 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
             Syl *syl = dynamic_cast<Syl *>(*iter);
             assert(syl);
             syl->SetDrawingXRel(previousSylShift);
+            auto t = syl->GetUuid();
             previousSylShift += syl->GetContentX2() + syl->CalcConnectorSpacing(params->m_doc, params->m_staffSize);
             ++iter;
         }
@@ -175,7 +176,11 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
 
     // Use the syl because the content bounding box of the verse might be invalid at this stage
     int overlap = params->m_lastSyl->GetContentRight() - (firstSyl->GetContentLeft() + xShift);
-    overlap += lastSyl->CalcConnectorSpacing(params->m_doc, params->m_staffSize);
+    overlap += params->m_lastSyl->CalcConnectorSpacing(params->m_doc, params->m_staffSize);
+
+    if (params->m_lastSyl->GetUuid() == "syl-0000001599481773") {
+        int d = params->m_doc->GetDrawingUnit(params->m_staffSize);
+    }
 
     int nextFreeSpace = params->m_previousVerse->AdjustPosition(overlap, params->m_freeSpace, params->m_doc);
 

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -138,7 +138,6 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
             Syl *syl = dynamic_cast<Syl *>(*iter);
             assert(syl);
             syl->SetDrawingXRel(previousSylShift);
-            auto t = syl->GetUuid();
             previousSylShift += syl->GetContentX2() + syl->CalcConnectorSpacing(params->m_doc, params->m_staffSize);
             ++iter;
         }
@@ -177,10 +176,6 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
     // Use the syl because the content bounding box of the verse might be invalid at this stage
     int overlap = params->m_lastSyl->GetContentRight() - (firstSyl->GetContentLeft() + xShift);
     overlap += params->m_lastSyl->CalcConnectorSpacing(params->m_doc, params->m_staffSize);
-
-    if (params->m_lastSyl->GetUuid() == "syl-0000001599481773") {
-        int d = params->m_doc->GetDrawingUnit(params->m_staffSize);
-    }
 
     int nextFreeSpace = params->m_previousVerse->AdjustPosition(overlap, params->m_freeSpace, params->m_doc);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1399,6 +1399,9 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
         dc->SetFont(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize));
     }
 
+    dc->GetFont()->SetStyle(syl->HasFontstyle() ? syl->GetFontstyle() : data_FONTSTYLE::FONTSTYLE_normal);
+    dc->GetFont()->SetWeight(syl->HasFontweight() ? syl->GetFontweight() : data_FONTWEIGHT::FONTWEIGHT_normal);
+
     TextDrawingParams params;
     params.m_x = syl->GetDrawingX();
     params.m_y = syl->GetDrawingY();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1399,9 +1399,6 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
         dc->SetFont(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize));
     }
 
-    dc->GetFont()->SetStyle(syl->HasFontstyle() ? syl->GetFontstyle() : data_FONTSTYLE::FONTSTYLE_normal);
-    dc->GetFont()->SetWeight(syl->HasFontweight() ? syl->GetFontweight() : data_FONTWEIGHT::FONTWEIGHT_normal);
-
     TextDrawingParams params;
     params.m_x = syl->GetDrawingX();
     params.m_y = syl->GetDrawingY();

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -356,6 +356,10 @@ void View::DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params)
 
     dc->StartTextGraphic(text, "", text->GetUuid());
 
+    if(dc->GetFont()->GetWeight() != FONTWEIGHT_NONE && dc->GetFont()->GetStyle() != FONTSTYLE_NONE) {
+        Resources::SelectTextFont(dc->GetFont()->GetWeight(), dc->GetFont()->GetStyle());
+    }
+
     if (params.m_newLine) {
         dc->MoveTextTo(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), HORIZONTALALIGNMENT_NONE);
         params.m_newLine = false;

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -356,9 +356,7 @@ void View::DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params)
 
     dc->StartTextGraphic(text, "", text->GetUuid());
 
-    if(dc->GetFont()->GetWeight() != FONTWEIGHT_NONE && dc->GetFont()->GetStyle() != FONTSTYLE_NONE) {
-        Resources::SelectTextFont(dc->GetFont()->GetWeight(), dc->GetFont()->GetStyle());
-    }
+    Resources::SelectTextFont(dc->GetFont()->GetWeight(), dc->GetFont()->GetStyle());
 
     if (params.m_newLine) {
         dc->MoveTextTo(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), HORIZONTALALIGNMENT_NONE);

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -122,6 +122,14 @@ Glyph *Resources::GetGlyph(wchar_t smuflCode)
 
 void Resources::SelectTextFont(data_FONTWEIGHT fontWeight, data_FONTSTYLE fontStyle)
 {
+    if(fontWeight == FONTWEIGHT_NONE) {
+        fontWeight = FONTWEIGHT_normal;
+    }
+
+    if (fontStyle == FONTSTYLE_NONE) {
+        fontStyle = FONTSTYLE_normal;
+    }
+
     m_currentStyle = std::make_pair(fontWeight, fontStyle);
     if (m_textFont.count(m_currentStyle) == 0) {
         LogWarning("Text font for style (%d, %d) is not loaded. Use default", fontWeight, fontStyle);


### PR DESCRIPTION
As it was mentioned in this discussion https://github.com/rism-ch/verovio/issues/1460 the implementation of text-font support is not enough for fixing syllable overlapping issue. It turns out that DIR element affects measure layouting. If it's right border lays farther than the measure right border layouting inside it will be broken. In order to get rid of this problem corresponding method for adjusting X coordinates should be implemented.