### PR TITLE
Adjust measure right border if it doesn't cover all it's children

### DIFF
--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -297,6 +297,7 @@ public:
      * See Object::AdjustXOverflow
      */
     virtual int AdjustXOverflow(FunctorParams *functorParams);
+    virtual int AdjustXOverflowEnd(FunctorParams *functorParams);
 
     /**
      * See Object::AdjustXPos

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -864,6 +864,31 @@ int Measure::AdjustXOverflow(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Measure::AdjustXOverflowEnd(FunctorParams *functorParams)
+{
+    AdjustXOverflowParams *params = dynamic_cast<AdjustXOverflowParams *>(functorParams);
+
+    if (!params->m_currentWidest) {
+        return FUNCTOR_CONTINUE;
+    }
+
+    int measureRightX = GetDrawingX() + GetRightBarLineLeft() - params->m_margin;
+    if (measureRightX < params->m_currentWidest->GetContentRight()) {
+        LayerElement *objectX = dynamic_cast<LayerElement *>(params->m_currentWidest->GetObjectX());
+        if (!objectX) {
+            return FUNCTOR_CONTINUE;
+        }
+        Alignment *left = objectX->GetAlignment();
+        ArrayOfAdjustmentTuples boundaries{
+            std::make_tuple(left, params->m_lastMeasure->GetRightBarLine()->GetAlignment(),
+                            params->m_currentWidest->GetContentRight() - measureRightX) 
+        };
+        m_measureAligner.AdjustProportionally(boundaries);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Measure::SetAlignmentXPos(FunctorParams *functorParams)
 {
     SetAlignmentXPosParams *params = dynamic_cast<SetAlignmentXPosParams *>(functorParams);


### PR DESCRIPTION
As it was mentioned in this discussion https://github.com/rism-ch/verovio/issues/1460 the implementation of text-font support is not enough for fixing syllable overlapping issue. It turns out that DIR element affects measure layouting. If it's right border lays farther than the measure right border layouting inside it will be broken. In order to get rid of this problem corresponding method for adjusting X coordinates should be implemented.