### PR TITLE
Improve tempo changes in MIDI output

### DIFF
--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -62,6 +62,11 @@ public:
     // Functors //
     //----------//
 
+    /**
+     * See Object::GenerateMIDI
+     */
+    virtual int GenerateMIDI(FunctorParams *functorParams);
+
 private:
     //
 public:

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1207,24 +1207,6 @@ int Measure::CalcMaxMeasureDuration(FunctorParams *functorParams)
     m_scoreTimeOffset.push_back(params->m_maxCurrentScoreTime);
     params->m_maxCurrentScoreTime += m_measureAligner.GetRightAlignment()->GetTime() * DURATION_4 / DUR_MAX;
 
-    // search for tempo marks in the measure
-    Tempo *tempo = dynamic_cast<Tempo *>(this->FindDescendantByType(TEMPO));
-    if (tempo && tempo->HasMidiBpm()) {
-        params->m_currentTempo = tempo->GetMidiBpm();
-    }
-    else if (tempo && tempo->HasMm()) {
-        int mm = tempo->GetMm();
-        int mmUnit = 4;
-        if (tempo->HasMmUnit() && (tempo->GetMmUnit() > DURATION_breve)) {
-            mmUnit = pow(2, (int)tempo->GetMmUnit() - 2);
-        }
-        if (tempo->HasMmDots()) {
-            mmUnit = 2 * mmUnit - (mmUnit / pow(2, tempo->GetMmDots()));
-        }
-        params->m_currentTempo = int(mm * 4.0 / mmUnit + 0.5);
-    }
-    m_currentTempo = params->m_currentTempo * params->m_tempoAdjustment;
-
     m_realTimeOffsetMilliseconds.clear();
     // m_realTimeOffsetMilliseconds.push_back(int(params->m_maxCurrentRealTimeSeconds * 1000.0 + 0.5));
     m_realTimeOffsetMilliseconds.push_back(params->m_maxCurrentRealTimeSeconds * 1000.0);

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -15,8 +15,15 @@
 
 #include "controlelement.h"
 #include "editorial.h"
+#include "functorparams.h"
+#include "horizontalaligner.h"
+#include "layerelement.h"
 #include "text.h"
 #include "vrv.h"
+
+//----------------------------------------------------------------------------
+
+#include "MidiFile.h"
 
 namespace vrv {
 
@@ -64,6 +71,37 @@ void Tempo::AddChild(Object *child)
     child->SetParent(this);
     m_children.push_back(child);
     Modify();
+}
+
+//----------------------------------------------------------------------------
+// Tempo functor methods
+//----------------------------------------------------------------------------
+
+int Tempo::GenerateMIDI(FunctorParams *functorParams)
+{
+    GenerateMIDIParams *params = dynamic_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+    
+    double tempoTime = GetStart()->GetAlignment()->GetTime() * DURATION_4 / DUR_MAX;
+    double starttime = params->m_totalTime + tempoTime;
+    int tpq = params->m_midiFile->getTPQ();
+    
+    if (this->HasMidiBpm()) {
+        params->m_midiFile->addTempo(0, (starttime * tpq), this->GetMidiBpm());
+    }
+    else if (this->HasMm()) {
+        int mm = this->GetMm();
+        int mmUnit = 4;
+        if (this->HasMmUnit() && (this->GetMmUnit() > DURATION_breve)) {
+            mmUnit = pow(2, (int)this->GetMmUnit() - 2);
+        }
+        if (this->HasMmDots()) {
+            mmUnit = 2 * mmUnit - (mmUnit / pow(2, this->GetMmDots()));
+        }
+        params->m_midiFile->addTempo(0, (starttime * tpq), int(mm * 4.0 / mmUnit + 0.5));
+    }
+
+    return FUNCTOR_CONTINUE;
 }
 
 } // namespace vrv


### PR DESCRIPTION
Until now tempo changes were moved to the beginning of the measure in MIDI output. 
I don't know what to do to change timemap generation accordingly.