### PR TITLE
Apply font parameters for syllable

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1390,14 +1390,14 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
 
     dc->SetBrush(m_currentColour, AxSOLID);
 
-    FontInfo currentFont;
-    if (staff->m_drawingStaffDef) {
-        currentFont = *m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize);
-        dc->SetFont(&currentFont);
+    FontInfo currentFont = *m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize);
+    if (syl->HasFontweight()) {
+        currentFont.SetWeight(syl->GetFontweight());
     }
-    else {
-        dc->SetFont(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize));
+    if (syl->HasFontstyle()) {
+        currentFont.SetStyle(syl->GetFontstyle());
     }
+    dc->SetFont(&currentFont);
 
     TextDrawingParams params;
     params.m_x = syl->GetDrawingX();


### PR DESCRIPTION
If syllable has own font parameters like weight and style, they have to be used for rendering.