### PR TITLE
Clean up code for the slur shift calculation

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -278,7 +278,7 @@ void Slur::AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve,
 
     int maxShiftLeft = 0;
     int maxShiftRight = 0;
-    int shift, leftShift, rightShift;
+    int leftShift, rightShift;
 
     int dist = abs(p2.x - p1.x);
     float posXRatio = 1.0;
@@ -317,18 +317,11 @@ void Slur::AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve,
         }
         if (dist != 0) posXRatio = (float)posX / ((float)dist / 2.0);
 
-        shift = 0;
-        // Keep the maximum shift on the left and right
-        if (curveDir == curvature_CURVEDIR_above) {
-            shift = intersection;
-        }
-        else {
-            shift = intersection;
-        }
-        // shift += doc->GetDrawingUnit(100);
-        if (shift > 0) {
-            leftShift = (forceBothSides || leftPoint) ? shift : shift * posXRatio;
-            rightShift = (forceBothSides || !leftPoint) ? shift : shift * posXRatio;
+        // intersection += doc->GetDrawingUnit(100);
+        if (intersection > 0) {
+            leftShift = (forceBothSides || leftPoint) ? intersection : intersection * posXRatio;
+            rightShift = (forceBothSides || !leftPoint) ? intersection : intersection * posXRatio;
+            // Keep the maximum shift on the left and right
             maxShiftLeft = leftShift > maxShiftLeft ? leftShift : maxShiftLeft;
             maxShiftRight = rightShift > maxShiftRight ? rightShift : maxShiftRight;
         }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -278,7 +278,6 @@ void Slur::AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve,
 
     int maxShiftLeft = 0;
     int maxShiftRight = 0;
-    int leftShift, rightShift;
 
     int dist = abs(p2.x - p1.x);
     float posXRatio = 1.0;
@@ -319,8 +318,8 @@ void Slur::AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve,
 
         // intersection += doc->GetDrawingUnit(100);
         if (intersection > 0) {
-            leftShift = (forceBothSides || leftPoint) ? intersection : intersection * posXRatio;
-            rightShift = (forceBothSides || !leftPoint) ? intersection : intersection * posXRatio;
+            int leftShift = (forceBothSides || leftPoint) ? intersection : intersection * posXRatio;
+            int rightShift = (forceBothSides || !leftPoint) ? intersection : intersection * posXRatio;
             // Keep the maximum shift on the left and right
             maxShiftLeft = leftShift > maxShiftLeft ? leftShift : maxShiftLeft;
             maxShiftRight = rightShift > maxShiftRight ? rightShift : maxShiftRight;


### PR DESCRIPTION
As mentioned in the comment to the first commit, intersection is supposed to be the same for both conditions. Sign calculation (plus or minus) happens few lines below, when we determine y position for both points. Changing value to negative here or just removing else condition (while leaving if intact) actually would make this a bug. 

To illustrate, this is how slurs are drawn with current behavior (same behavior kept after fix):
![image](https://user-images.githubusercontent.com/1819669/85032443-84ce4280-b188-11ea-9f08-c2e2b3959dd4.png)

And this is how it looks, if we just removed else:
![image](https://user-images.githubusercontent.com/1819669/85032635-b8a96800-b188-11ea-95d3-77e304406c5d.png)

With that said, even if behavior is correct, if-else condition is just redundant, so I've removed it.

