### PR TITLE
System max per page

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -532,6 +532,7 @@ public:
     OptionDbl m_staffLineWidth;
     OptionDbl m_stemWidth;
     OptionIntMap m_systemDivider;
+    OptionInt m_systemMaxPerPage;
     OptionDbl m_tieThickness;
 
     /**

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -764,6 +764,10 @@ Options::Options()
     m_systemDivider.Init(SYSTEMDIVIDER_left, &Option::s_systemDivider);
     this->Register(&m_systemDivider, "systemDivider", &m_generalLayout);
 
+    m_systemMaxPerPage.SetInfo("Max. System per Page", "Maximun number of systems per page");
+    m_systemMaxPerPage.Init(0, 0, 24);
+    this->Register(&m_systemMaxPerPage, "systemMaxPerPage", &m_generalLayout);
+
     m_tieThickness.SetInfo("Tie thickness", "The tie thickness in MEI units");
     m_tieThickness.Init(0.5, 0.2, 1.0);
     this->Register(&m_tieThickness, "tieThickness", &m_generalLayout);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -769,7 +769,10 @@ int System::CastOffPages(FunctorParams *functorParams)
         currentShift += params->m_pgHead2Height + params->m_pgFoot2Height;
     }
 
-    if ((params->m_currentPage->GetChildCount() > 0) && (this->m_drawingYRel - this->GetHeight() - currentShift < 0)) {
+    const int systemMaxPerPage = params->m_doc->GetOptions()->m_systemMaxPerPage.GetValue();
+    const int childCount = params->m_currentPage->GetChildCount();
+    if ((systemMaxPerPage && systemMaxPerPage == childCount)
+        || (childCount > 0 && (this->m_drawingYRel - this->GetHeight() - currentShift < 0))) {
         params->m_currentPage = new Page();
         // Use VRV_UNSET value as a flag
         params->m_pgHeadHeight = VRV_UNSET;


### PR DESCRIPTION
Added new option which supposed to be used in combination with the
foolowing options (incl. sample values):
--spacing-system 0
--spacing-staff 0
--justify-vertically
--justify-systems-only
--justify-include-last-page
--system-max-per-page 5