### PR TITLE
Avoid duplicate braces in MusicXML import

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -679,7 +679,9 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             int nbStaves = ReadMusicXmlPartAttributesAsStaffDef(partFirstMeasure.node(), partStaffGrp, staffOffset);
             // if we have more than one staff in the part we create a new staffGrp
             if (nbStaves > 1) {
-                partStaffGrp->SetSymbol(staffGroupingSym_SYMBOL_brace);
+                if (m_staffGrpStack.back()->GetSymbol() != staffGroupingSym_SYMBOL_brace) {
+                    partStaffGrp->SetSymbol(staffGroupingSym_SYMBOL_brace);
+                }
                 partStaffGrp->SetBarThru(BOOLEAN_true);
                 m_staffGrpStack.back()->AddChild(partStaffGrp);
             }


### PR DESCRIPTION
If the `<part-group>` already has a brace `<group-symbol>`, then we don't have to add another brace.

Example of unintended rendering:

![grafik](https://user-images.githubusercontent.com/1147152/85535340-9b99ec80-b601-11ea-8cbb-a392d9a712d5.png)

Sibelius export:

```xml
<?xml version="1.0" encoding='UTF-8' standalone='no' ?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.0">
 <work>
  <work-title />
 </work>
 <identification>
  <rights>Copyright © </rights>
  <encoding>
   <encoding-date>2020-06-24</encoding-date>
   <encoder>tom</encoder>
   <software>Sibelius 19.9.0</software>
   <software>Direct export, not from Dolet</software>
   <encoding-description>Sibelius / MusicXML 3.0</encoding-description>
   <supports element="print" type="yes" value="yes" attribute="new-system" />
   <supports element="print" type="yes" value="yes" attribute="new-page" />
   <supports element="accidental" type="yes" />
   <supports element="beam" type="yes" />
   <supports element="stem" type="yes" />
  </encoding>
 </identification>
 <defaults>
  <scaling>
   <millimeters>210</millimeters>
   <tenths>1200</tenths>
  </scaling>
  <page-layout>
   <page-height>1697</page-height>
   <page-width>1200</page-width>
   <page-margins type="both">
    <left-margin>72</left-margin>
    <right-margin>72</right-margin>
    <top-margin>72</top-margin>
    <bottom-margin>72</bottom-margin>
   </page-margins>
  </page-layout>
  <system-layout>
   <system-margins>
    <left-margin>75</left-margin>
    <right-margin>0</right-margin>
   </system-margins>
   <system-distance>92</system-distance>
  </system-layout>
  <appearance>
   <line-width type="stem">0.9375</line-width>
   <line-width type="beam">5</line-width>
   <line-width type="staff">0.9375</line-width>
   <line-width type="light barline">1.5625</line-width>
   <line-width type="heavy barline">5</line-width>
   <line-width type="leger">1.5625</line-width>
   <line-width type="ending">1.5625</line-width>
   <line-width type="wedge">1.25</line-width>
   <line-width type="enclosure">0.9375</line-width>
   <line-width type="tuplet bracket">1.25</line-width>
   <line-width type="bracket">5</line-width>
   <line-width type="dashes">1.5625</line-width>
   <line-width type="extend">0.9375</line-width>
   <line-width type="octave shift">1.5625</line-width>
   <line-width type="pedal">1.5625</line-width>
   <line-width type="slur middle">1.5625</line-width>
   <line-width type="slur tip">0.625</line-width>
   <line-width type="tie middle">1.5625</line-width>
   <line-width type="tie tip">0.625</line-width>
   <note-size type="cue">75</note-size>
   <note-size type="grace">60</note-size>
  </appearance>
  <music-font font-family="Opus Std" font-size="19.8425" />
  <word-font font-family="Times New Roman" font-size="11.9365" />
  <lyric-font font-family="Times New Roman" font-size="11.4715" />
  <lyric-language xml:lang="en" />
 </defaults>
 <part-list>
  <score-part id="P1">
   <identification>
    <miscellaneous>
     <miscellaneous-field name="show-rhythms">false</miscellaneous-field>
    </miscellaneous>
   </identification>
   <part-name>Voice</part-name>
   <part-name-display>
    <display-text>Voice</display-text>
   </part-name-display>
   <part-abbreviation>Voice</part-abbreviation>
   <part-abbreviation-display>
    <display-text>Voice</display-text>
   </part-abbreviation-display>
   <score-instrument id="P1-I1">
    <instrument-name>Voice (2)</instrument-name>
    <virtual-instrument>
     <virtual-library>General MIDI</virtual-library>
     <virtual-name>Choir Aahs</virtual-name>
    </virtual-instrument>
   </score-instrument>
  </score-part>
  <part-group type="start" number="1">
   <group-symbol>brace</group-symbol>
  </part-group>
  <score-part id="P2">
   <identification>
    <miscellaneous>
     <miscellaneous-field name="show-rhythms">false</miscellaneous-field>
    </miscellaneous>
   </identification>
   <part-name>Piano</part-name>
   <part-name-display>
    <display-text>Piano</display-text>
   </part-name-display>
   <part-abbreviation>Pno.</part-abbreviation>
   <part-abbreviation-display>
    <display-text>Pno.</display-text>
   </part-abbreviation-display>
   <score-instrument id="P2-I1">
    <instrument-name>Piano (2)</instrument-name>
    <instrument-sound>keyboard.piano.grand</instrument-sound>
    <solo />
    <virtual-instrument>
     <virtual-library>General MIDI</virtual-library>
     <virtual-name>Acoustic Piano</virtual-name>
    </virtual-instrument>
   </score-instrument>
  </score-part>
  <part-group type="stop" number="1" />
 </part-list>
 <part id="P1">
  <!--============== Part: P1, Measure: 1 ==============-->
  <measure number="1" width="1033">
   <print new-page="yes">
    <system-layout>
     <system-margins>
      <left-margin>22</left-margin>
      <right-margin>0</right-margin>
     </system-margins>
     <top-system-distance>218</top-system-distance>
    </system-layout>
   </print>
   <attributes>
    <divisions>256</divisions>
    <key color="#000000">
     <fifths>0</fifths>
     <mode>major</mode>
    </key>
    <time color="#000000">
     <beats>4</beats>
     <beat-type>4</beat-type>
    </time>
    <staves>1</staves>
    <clef number="1" color="#000000">
     <sign>G</sign>
     <line>2</line>
    </clef>
    <staff-details number="1" print-object="yes" />
   </attributes>
   <note default-x="43">
    <rest />
    <duration>1024</duration>
    <instrument id="P1-I1" />
    <voice>1</voice>
    <type>whole</type>
    <staff>1</staff>
   </note>
   <barline>
    <bar-style>light-heavy</bar-style>
   </barline>
  </measure>
 </part>
 <part id="P2">
  <!--============== Part: P2, Measure: 1 ==============-->
  <measure number="1" width="1033">
   <print new-page="yes">
    <system-layout>
     <system-margins>
      <left-margin>22</left-margin>
      <right-margin>0</right-margin>
     </system-margins>
    </system-layout>
    <staff-layout number="2">
     <staff-distance>55</staff-distance>
    </staff-layout>
   </print>
   <attributes>
    <divisions>256</divisions>
    <key color="#000000">
     <fifths>0</fifths>
     <mode>major</mode>
    </key>
    <time color="#000000">
     <beats>4</beats>
     <beat-type>4</beat-type>
    </time>
    <staves>2</staves>
    <clef number="1" color="#000000">
     <sign>G</sign>
     <line>2</line>
    </clef>
    <clef number="2" color="#000000">
     <sign>F</sign>
     <line>4</line>
    </clef>
    <staff-details number="1" print-object="yes" />
    <staff-details number="2" print-object="yes" />
   </attributes>
   <note default-x="43">
    <rest />
    <duration>1024</duration>
    <instrument id="P2-I1" />
    <voice>1</voice>
    <type>whole</type>
    <staff>1</staff>
   </note>
   <barline>
    <bar-style>light-heavy</bar-style>
   </barline>
   <backup>
    <duration>1024</duration>
   </backup>
   <note default-x="43">
    <rest />
    <duration>1024</duration>
    <instrument id="P2-I1" />
    <voice>2</voice>
    <type>whole</type>
    <staff>2</staff>
   </note>
  </measure>
 </part>
</score-partwise>
```