### PR TITLE
Fix MusicXML import of lyrics with elisions and extenders

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2531,11 +2531,11 @@ void MusicXmlInput::ReadMusicXmlNote(
                     std::string textStr = textNode.text().as_string();
                     Syl *syl = new Syl();
                     syl->SetLang(lang.c_str());
-                    if (lyric.select_node("extend")) {
-                        syl->SetCon(sylLog_CON_u);
-                    }
-                    else if (textNode.next_sibling("elision")) {
+                    if (textNode.next_sibling("elision")) {
                         syl->SetCon(sylLog_CON_b);
+                    }
+                    else if (lyric.select_node("extend")) {
+                        syl->SetCon(sylLog_CON_u);
                     }
                     else if (GetContentOfChild(lyric, "syllabic") == "single") {
                         syl->SetCon(sylLog_CON_s);


### PR DESCRIPTION
Situations like this would fail to import correctly:

```xml
<lyric number='1' name='verse'>
    <syllabic>single</syllabic>
    <text>a</text>
    <elision>‿</elision>
    <syllabic>single</syllabic>
    <text>b</text>
    <extend/>
</lyric>
```

Previous wrong import:

```xml
 <verse label="verse" n="1">
    <syl con="u">a</syl>
    <syl con="u">b</syl>
 </verse>
```

Correct import now:


```xml
 <verse label="verse" n="1">
    <syl con="b">a</syl>
    <syl con="u">b</syl>
 </verse>
```

Full example file:

```xml
<?xml version='1.0' encoding='UTF-16' standalone='no'?>
<!DOCTYPE score-partwise PUBLIC '-//Recordare//DTD MusicXML 3.0 Partwise//EN' 'http://www.musicxml.org/dtds/partwise.dtd'>
<score-partwise version='3.0'>
	<identification>
		<rights>Copyright © </rights>
		<encoding>
			<software>Sibelius 19.9</software>
			<software>Dolet 6.6 for Sibelius</software>
			<encoding-date>2020-06-25</encoding-date>
			<supports element='accidental' type='yes'/>
			<supports element='transpose' type='no'/>
			<supports attribute='new-page' element='print' type='yes' value='yes'/>
			<supports attribute='new-system' element='print' type='yes' value='yes'/>
		</encoding>
	</identification>
	<defaults>
		<scaling>
			<millimeters>7</millimeters>
			<tenths>40</tenths>
		</scaling>
		<page-layout>
			<page-height>1697</page-height>
			<page-width>1200</page-width>
			<page-margins type='odd'>
				<left-margin>72.5714</left-margin>
				<right-margin>72.5714</right-margin>
				<top-margin>72.5714</top-margin>
				<bottom-margin>72.5714</bottom-margin>
			</page-margins>
			<page-margins type='even'>
				<left-margin>72.5714</left-margin>
				<right-margin>72.5714</right-margin>
				<top-margin>72.5714</top-margin>
				<bottom-margin>72.5714</bottom-margin>
			</page-margins>
		</page-layout>
		<system-layout>
			<system-margins>
				<left-margin>22.1875</left-margin>
				<right-margin>0</right-margin>
			</system-margins>
			<system-distance>92.5</system-distance>
			<top-system-distance>72.8125</top-system-distance>
		</system-layout>
		<?DoletSibelius StaffJustificationPercentage=65?>
		<appearance>
			<line-width type='beam'>5</line-width>
			<line-width type='heavy barline'>5</line-width>
			<line-width type='leger'>1.5625</line-width>
			<line-width type='light barline'>1.5625</line-width>
			<line-width type='slur middle'>2.1875</line-width>
			<line-width type='slur tip'>0.625</line-width>
			<line-width type='staff'>0.9375</line-width>
			<line-width type='stem'>0.9375</line-width>
			<line-width type='tie middle'>2.1875</line-width>
			<line-width type='tie tip'>0.625</line-width>
			<note-size type='grace'>60</note-size>
			<note-size type='cue'>75</note-size>
		</appearance>
		<music-font font-family='Opus Std,music'/>
		<word-font font-family='Times New Roman'/>
	</defaults>
	<part-list>
		<score-part id='P1'>
			<part-name print-object='no'>[Unnamed (treble staff)]</part-name>
			<score-instrument id='P1-I1'>
				<instrument-name></instrument-name>
				<instrument-sound>keyboard.piano.grand</instrument-sound>
			</score-instrument>
			<midi-instrument id='P1-I1'>
				<volume>79</volume>
				<pan>0</pan>
			</midi-instrument>
		</score-part>
	</part-list>
<!--=========================================================-->
	<part id='P1'>
		<measure number='1'>
			<print>
				<system-layout>
					<system-margins>
						<left-margin>22.1875</left-margin>
						<right-margin>0</right-margin>
					</system-margins>
					<top-system-distance>217.8125</top-system-distance>
				</system-layout>
				<staff-layout>
					<?DoletSibelius ExtraSpacesAbove=3?>
				</staff-layout>
			</print>
			<attributes>
				<divisions>768</divisions>
				<key>
					<fifths>0</fifths>
					<mode>major</mode>
				</key>
				<time>
					<beats>4</beats>
					<beat-type>4</beat-type>
				</time>
				<clef>
					<sign>G</sign>
					<line>2</line>
				</clef>
			</attributes>
			<note>
				<pitch>
					<step>A</step>
					<octave>4</octave>
				</pitch>
				<duration>1536</duration>
				<voice>1</voice>
				<type>half</type>
				<stem>up</stem>
				<notations>
					<slur type='start' number='1'/>
				</notations>
				<lyric number='1' name='verse' default-y='-80'>
					<syllabic>single</syllabic>
					<text>a</text>
					<elision>‿</elision>
					<syllabic>single</syllabic>
					<text>b</text>
					<extend/>
				</lyric>
			</note>
			<note>
				<pitch>
					<step>G</step>
					<octave>4</octave>
				</pitch>
				<duration>1536</duration>
				<voice>1</voice>
				<type>half</type>
				<stem>up</stem>
				<notations>
					<slur type='stop' number='1'/>
				</notations>
			</note>
			<barline location='right'>
				<bar-style>light-heavy</bar-style>
			</barline>
		</measure>
	</part>
<!--=========================================================-->
</score-partwise>
```
```