### PR TITLE
Use pending measure x for new system start coordinate

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -935,6 +935,13 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
             params->m_currentSystem = new System();
             params->m_page->AddChild(params->m_currentSystem);
             params->m_shift = this->m_drawingXRel;
+            for (Object *oneOfPendingObjects : params->m_pendingObjects) {
+                if (oneOfPendingObjects->Is(MEASURE)) {
+                    Measure *firstPendingMesure = dynamic_cast<Measure *>(oneOfPendingObjects);
+                    assert(firstPendingMesure);
+                    params->m_shift = firstPendingMesure->m_drawingXRel;
+                }
+            }
         }
     }
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -940,6 +940,8 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
                     Measure *firstPendingMesure = dynamic_cast<Measure *>(oneOfPendingObjects);
                     assert(firstPendingMesure);
                     params->m_shift = firstPendingMesure->m_drawingXRel;
+                    // it has to be first measure
+                    break;
                 }
             }
         }


### PR DESCRIPTION
During the castOf process we start new system and set variable `params->m_shift` to start position of the last measure which can't be put in the current system line, although we have to set this variable to start x of first pending measure if it exists. After applying this change we expect that all systems (in the meaning of parts of a big system) will have width not wider than page width and we will be able to get rid of horizontal scaling of systems with width wider than page. This also fixes the issue about wrong spaces between syllable chunks.