### PR TITLE
Add support for 'perfecta' and 'imperfecta' when following the mensuration

### DIFF
--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -104,11 +104,11 @@ double DurationInterface::GetInterfaceAlignmentMensuralDuration(int num, int num
         num *= 3;
         numBase *= 2;
     }
-    // altera - that any other given value and not minor
-    else if (this->HasDurQuality() && (this->GetDurQuality() != DURQUALITY_mensural_minor)) {
+    // altera, maior, or duplex
+    else if (this->HasDurQuality() && (this->GetDurQuality() == DURQUALITY_mensural_altera || this->GetDurQuality() == DURQUALITY_mensural_maior || this->GetDurQuality() == DURQUALITY_mensural_duplex)) {
         num *= 1;
         numBase *= 2;
-    }
+    } // Any other case (minor, perfecta in tempus perfectum, and imperfecta in tempus imperfectum) follows the mensuration and has no @num and @numbase attributes
 
     if (currentMensur->HasNum()) num *= currentMensur->GetNum();
     if (currentMensur->HasNumbase()) numBase *= currentMensur->GetNumbase();


### PR DESCRIPTION
This pull request fixes an issue with the dur.quality attribute for the cases:

**(a)**  dur.quality = imperfecta for imperfect tempus
**(b)**  dur.quality = perfecta for perfect tempus

Previously, both cases were assigned a `num=1` and `numbase=2` values. However, they require none _num_ and _numbase_ values (since notes falling in these two cases should keep the default value given by the mensuration).

This was fixed by specifying the cases for which `num=1` and `numbase=2` should be used, which are: _altera_, _maior_, and _duplex_. Every other case (which includes _dur.quality = minor_ and cases **a** and **b**) won't be assigned any `num` and `numbase` values. 