### PR TITLE
Introduced shrink-to-fit option

### DIFF
--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -65,6 +65,7 @@ public:
         m_isDeactivatedY = false;
         m_width = 0;
         m_height = 0;
+        m_contentHeight = 0;
         m_userScaleX = 1.0;
         m_userScaleY = 1.0;
     }
@@ -80,13 +81,15 @@ public:
     ///@{
     void SetWidth(int width) { m_width = width; }
     void SetHeight(int height) { m_height = height; }
+    void SetContentHeight(int height) { m_contentHeight = height; }
     void SetUserScale(double scaleX, double scaleY)
     {
         m_userScaleX = scaleX;
         m_userScaleY = scaleY;
     }
-    int GetWidth() { return m_width; }
-    int GetHeight() { return m_height; }
+    int GetWidth() const { return m_width; }
+    int GetHeight() const { return m_height; }
+    int GetContentHeight() const { return m_contentHeight; }
     double GetUserScaleX() { return m_userScaleX; }
     double GetUserScaleY() { return m_userScaleY; }
     ///@}
@@ -289,6 +292,9 @@ private:
     /** stores the width and height of the device context */
     int m_width;
     int m_height;
+
+    /** stores the height of graphic content */
+    int m_contentHeight;
 
     /** stores the scale as requested by the used */
     double m_userScaleX;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -478,6 +478,7 @@ public:
     OptionInt m_pageMarginTop;
     OptionInt m_pageWidth;
     OptionString m_expand;
+    OptionBool m_shrinkToFit;
     OptionBool m_svgBoundingBoxes;
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -617,6 +617,10 @@ Options::Options()
     m_expand.Init("");
     this->Register(&m_expand, "expand", &m_general);
 
+    m_shrinkToFit.SetInfo("Shrink content to fit page", "Scale down page content to fit the page height if needed");
+    m_shrinkToFit.Init(false);
+    this->Register(&m_shrinkToFit, "shrinkToFit", &m_general);
+
     m_svgBoundingBoxes.SetInfo("Svg bounding boxes viewbox on svg root", "Include bounding boxes in SVG output");
     m_svgBoundingBoxes.Init(false);
     this->Register(&m_svgBoundingBoxes, "svgBoundingBoxes", &m_general);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -572,6 +572,10 @@ int Page::GetContentHeight() const
     // Make sure we have the correct page
     assert(this == doc->GetDrawingPage());
 
+    if (!GetChildCount()) {
+        return 0;
+    }
+
     System *last = dynamic_cast<System *>(m_children.back());
     assert(last);
     int height = doc->m_drawingPageContentHeight - last->GetDrawingYRel() + last->GetHeight();

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -404,7 +404,7 @@ void SvgDeviceContext::StartPage()
     }
     else {
         m_currentNode.append_attribute("viewBox")
-            = StringFormat("0 0 %d %d", GetWidth() * DEFINITION_FACTOR, GetHeight() * DEFINITION_FACTOR).c_str();
+            = StringFormat("0 0 %d %d", GetWidth() * DEFINITION_FACTOR, GetContentHeight() * DEFINITION_FACTOR).c_str();
     }
 
     // a graphic for the origin

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -73,8 +73,14 @@ void View::DrawCurrentPage(DeviceContext *dc, bool background)
     // The page one has previously been set by Object::SetCurrentScoreDef
     m_drawingScoreDef = m_currentPage->m_drawingScoreDef;
 
-    // if (background) dc->DrawRectangle(0, 0, m_doc->m_drawingPageWidth, m_doc->m_drawingPageHeight);
+    if (m_options->m_shrinkToFit.GetValue()) {
+        dc->SetContentHeight(m_doc->GetAdjustedDrawingPageHeight());
+    }
+    else {
+        dc->SetContentHeight(dc->GetHeight());
+    }
 
+    // if (background) dc->DrawRectangle(0, 0, m_doc->m_drawingPageWidth, m_doc->m_drawingPageHeight);
     dc->DrawBackgroundImage();
 
     Point origin = dc->GetLogicalOrigin();


### PR DESCRIPTION
Introduced shrink-to-fit option. If that option is active and the bounding box of the image is higher than the page, the image will be scaled down to fit the height precisely. Addresses [#1572](https://github.com/rism-ch/verovio/issues/1572).