### PR TITLE
Fix for #1299. Center system divider between systems

### DIFF
--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -202,6 +202,12 @@ public:
     Staff *GetTopVisibleStaff();
 
     /**
+     * Return the botoom (last) visible staff in the measure (if any).
+     * Takes into account system optimization
+     */
+    Staff *GetBottomVisibleStaff();
+
+    /**
      * Check if the measure encloses the given time (in millisecond)
      * Return the playing repeat time (1-based), 0 otherwise
      */

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -209,6 +209,7 @@ protected:
     void DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
     void DrawLayer(DeviceContext *dc, Layer *layer, Staff *staff, Measure *measure);
     void DrawLayerList(DeviceContext *dc, Layer *layer, Staff *staff, Measure *measure, const ClassId classId);
+    void DrawSystemDivider(DeviceContext *dc, System *system, Measure *firstMeasure);
     ///@}
 
     /**

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -372,6 +372,23 @@ Staff *Measure::GetTopVisibleStaff()
     return staff;
 }
 
+Staff *Measure::GetBottomVisibleStaff()
+{
+    Staff *bottomStaff = NULL;
+    ListOfObjects staves;
+    ClassIdComparison matchType(STAFF);
+    this->FindAllDescendantByComparison(&staves, &matchType, 1);
+    for (auto &child : staves) {
+        Staff* staff = dynamic_cast<Staff *>(child);
+        assert(staff);
+        if (!staff->DrawingIsVisible()) {
+            break;
+        }
+        bottomStaff = staff;
+    }
+    return bottomStaff;
+}
+
 int Measure::EnclosesTime(int time) const
 {
     int repeat = 1;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -378,11 +378,11 @@ Staff *Measure::GetBottomVisibleStaff()
     ListOfObjects staves;
     ClassIdComparison matchType(STAFF);
     this->FindAllDescendantByComparison(&staves, &matchType, 1);
-    for (auto &child : staves) {
+    for (const auto child : staves) {
         Staff* staff = dynamic_cast<Staff *>(child);
         assert(staff);
         if (!staff->DrawingIsVisible()) {
-            break;
+            continue;
         }
         bottomStaff = staff;
     }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1291,7 +1291,22 @@ void View::DrawSystemDivider(DeviceContext *dc, System *system, Measure *firstMe
     // Draw system divider (from the second one) if scoreDef is optimized
     if (!firstMeasure || (m_options->m_systemDivider.GetValue() == SYSTEMDIVIDER_none)) return;
     // initialize to zero, first measure is not supposed to have system divider
-    static int previousSystemBottomMarginY = 0;
+    int previousSystemBottomMarginY = 0;
+    Object *currentPage = system->GetFirstAncestor(PAGE);
+    if (currentPage) {
+        Object *previousSystem = currentPage->GetPrevious(system);
+        if (previousSystem) {
+            Measure *previousSystemMeasure = dynamic_cast<Measure *>(previousSystem->FindDescendantByType(MEASURE, 1));
+
+            Staff *bottomStaff = previousSystemMeasure->GetBottomVisibleStaff();
+            // set Y position to that of lowest (bottom) staff, substact space taken by staff lines and
+            // substract offset of the system divider symbol itself (added to y2 and y4)
+            previousSystemBottomMarginY = bottomStaff->GetDrawingY()
+                - (bottomStaff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(bottomStaff->m_drawingStaffSize)
+                - m_doc->GetDrawingUnit(100) * 5;
+        }
+    }
+
     if ((system->GetIdx() > 0) && system->IsDrawingOptimized()) {
         int y = system->GetDrawingY();
         Staff *staff = firstMeasure->GetTopVisibleStaff();
@@ -1323,13 +1338,7 @@ void View::DrawSystemDivider(DeviceContext *dc, System *system, Measure *firstMe
         }
 
         dc->EndCustomGraphic();
-    }
-    Staff *bottomStaff = firstMeasure->GetBottomVisibleStaff();
-    // set Y position to that of lowest (bottom) staff, substact space taken by staff lines and
-    // substract offset of the system divider symbol itself (added to y2 and y4)
-    previousSystemBottomMarginY = bottomStaff->GetDrawingY()
-        - (bottomStaff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(bottomStaff->m_drawingStaffSize)
-        - m_doc->GetDrawingUnit(100) * 5;
+    }  
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Base system divider position on locations of top of current system staff and bottom of previous system staff.