### PR TITLE
Do not add fTrem/bTrem to chords

### DIFF
--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -173,7 +173,10 @@ int FTrem::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    assert(this->GetElementCoords()->size() == 2);
+    if (GetElementCoords()->size() != 2) {
+        LogError("Stem calculation: <fTrem> element has invalid number of descendants.");
+        return FUNCTOR_STOP;
+    }
 
     this->m_beamSegment.InitCoordRefs(this->GetElementCoords());
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2982,7 +2982,7 @@ void MusicXmlInput::ReadMusicXmlNote(
 
     // tremolo end
     if (tremolo) {
-        if (HasAttributeWithValue(tremolo.node(), "type", "single")) {
+        if (HasAttributeWithValue(tremolo.node(), "type", "single") && !nextIsChord) {
             RemoveLastFromStack(BTREM, layer);
         }
         if (HasAttributeWithValue(tremolo.node(), "type", "stop")) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2353,8 +2353,10 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (tremolo) {
         if (HasAttributeWithValue(tremolo.node(), "type", "start")) {
             FTrem *fTrem = new FTrem();
-            AddLayerElement(layer, fTrem);
-            m_elementStackMap.at(layer).push_back(fTrem);
+            if (!isChord) {
+                AddLayerElement(layer, fTrem);
+                m_elementStackMap.at(layer).push_back(fTrem);
+            }
             int beamFloatNum = tremolo.node().text().as_int(); // number of floating beams
             int beamAttachedNum = 0; // number of attached beams
             while (beamStart && beamAttachedNum < 8) { // count number of (attached) beams, max 8
@@ -2368,8 +2370,10 @@ void MusicXmlInput::ReadMusicXmlNote(
         else if (!HasAttributeWithValue(tremolo.node(), "type", "stop")) {
             // this is default tremolo type in MusicXML
             BTrem *bTrem = new BTrem();
-            AddLayerElement(layer, bTrem);
-            if (!isChord) m_elementStackMap.at(layer).push_back(bTrem);
+            if (!isChord) {
+                AddLayerElement(layer, bTrem);
+                m_elementStackMap.at(layer).push_back(bTrem);
+            }
             tremSlashNum = tremolo.node().text().as_int();
             // if (HasAttributeWithValue(tremolo.node(), "type", "unmeasured")) bTrem->SetForm(bTremLog_FORM_unmeas);
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2369,7 +2369,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             // this is default tremolo type in MusicXML
             BTrem *bTrem = new BTrem();
             AddLayerElement(layer, bTrem);
-            m_elementStackMap.at(layer).push_back(bTrem);
+            if (!isChord) m_elementStackMap.at(layer).push_back(bTrem);
             tremSlashNum = tremolo.node().text().as_int();
             // if (HasAttributeWithValue(tremolo.node(), "type", "unmeasured")) bTrem->SetForm(bTremLog_FORM_unmeas);
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2543,7 +2543,10 @@ void MusicXmlInput::ReadMusicXmlNote(
                 && m_elementStackMap.at(layer).back()->Is(CHORD)) {
                 chord = dynamic_cast<Chord *>(m_elementStackMap.at(layer).back());
             }
-            assert(chord);
+            if (!chord) {
+                LogError("MusicXML import: Chord starting point has not been found.");
+                return;
+            }
             // Mark a chord as cue=true if and only if all its child notes are cue.
             // (This causes it to have a smaller stem).
             if (!cue) {

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -106,8 +106,10 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     }
     const ArrayOfBeamElementCoords *beamElementCoords = fTrem->GetElementCoords();
 
-    assert(beamElementCoords->size() == 2);
-
+    if (beamElementCoords->size() != 2) {
+        LogError("View draw: <fTrem> element has invalid number of descendants.");
+        return;
+    }
     BeamElementCoord *firstElement = beamElementCoords->at(0);
     BeamElementCoord *secondElement = beamElementCoords->at(1);
 


### PR DESCRIPTION
If current node already belongs to chord, do not add fTrem/bTrem to stack - this will cause a segfault when trying to find a chord. fTrem/bTrem cannot be children of chord in the first place, so most likely this is a repeated addition of the tremolo node. However, bTrems can be chords and we should not stop processing 'single' tremolos right away. E.g.:
```
<note default-x="79.27" default-y="-20.00">
  <pitch>
    <step>B</step>
    <octave>4</octave>
  </pitch>
  <duration>2</duration>
  <voice>1</voice>
  <type>quarter</type>
  <stem>down</stem>
  <notations>
    <ornaments>
      <tremolo type="single">2</tremolo>
    </ornaments>
  </notations>
</note>
<note default-x="79.27" default-y="-10.00">
  <chord/>
  <pitch>
    <step>D</step>
    <octave>5</octave>
  </pitch>
  <duration>2</duration>
  <voice>1</voice>
  <type>quarter</type>
  <stem>down</stem>
  <notations>
    <ornaments>
      <tremolo type="single">2</tremolo>
    </ornaments>
  </notations>
</note>
```