### PR TITLE
Vertical staves/systems spacing calculation and justification improvements

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -605,6 +605,7 @@ public:
         m_staffIdx = 0;
         m_staffN = 0;
         m_cumulatedShift = 0;
+        m_justificationSum = 0;
         m_pageWidth = 0;
         m_functor = functor;
         m_functorEnd = functorEnd;
@@ -614,6 +615,7 @@ public:
     int m_staffIdx;
     int m_staffN;
     int m_cumulatedShift;
+    int m_justificationSum;
     int m_pageWidth;
     Functor *m_functor;
     Functor *m_functorEnd;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -466,12 +466,9 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: the previous staff height
- * member 1: the extra staff height
- * member 2  the previous verse count
- * member 3: the cumulated shift
- * member 4: the doc
- * member 5: the functor to be redirected to SystemAligner
+ * member 0: the cumulated shift
+ * member 1: the doc
+ * member 2: the functor to be redirected to SystemAligner
  **/
 
 class AdjustYPosParams : public FunctorParams {
@@ -559,7 +556,9 @@ public:
 /**
  * member 0: the cumulated shift
  * member 1: the system margin
- * member 2: the doc
+ * member 2: the overflow below of previous system
+ * member 3: the sum of justification factors per page
+ * member 4: the doc
  **/
 
 class AlignSystemsParams : public FunctorParams {
@@ -588,9 +587,11 @@ public:
  * member 1: the staffIdx
  * member 2: the staffN
  * member 3: the cumulated shift for the default alignment
- * member 4: the functor (for redirecting from page running elements)
- * member 4: the end functor (for redirecting from measure)
- * member 5: the doc
+ * member 4: the sum of justification factors per page
+ * member 5: the page width
+ * member 6: the functor (for redirecting from page running elements)
+ * member 7: the end functor (for redirecting from measure)
+ * member 8: the doc
  **/
 
 class AlignVerticallyParams : public FunctorParams {
@@ -1318,21 +1319,25 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: the justification ratio
- * member 4: the functor to be redirected to the MeasureAligner
- * member 5: the doc
+ * member 0: the cumulated shift
+ * member 1: the amount of space for distribution
+ * member 2: the sum of justification factors per page
+ * member 3: the functor to be redirected to the MeasureAligner
+ * member 4: the doc
  **/
 
 class JustifyYParams : public FunctorParams {
 public:
     JustifyYParams(Functor *functor, Doc *doc)
     {
+        m_cumulatedShift = 0;
         m_spaceToDistribute = 0;
-        m_justificationSum = 0;
+        m_justificationSum = 0.;
         m_functor = functor;
         m_doc = doc;
     }
 
+    int m_cumulatedShift;
     int m_spaceToDistribute;
     double m_justificationSum;
     Functor *m_functor;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -478,14 +478,10 @@ class AdjustYPosParams : public FunctorParams {
 public:
     AdjustYPosParams(Doc *doc, Functor *functor)
     {
-        m_previousOverflowBelow = 0;
-        m_previousVerseCount = 0;
         m_cumulatedShift = 0;
         m_doc = doc;
         m_functor = functor;
     }
-    int m_previousOverflowBelow;
-    int m_previousVerseCount;
     int m_cumulatedShift;
     Doc *m_doc;
     Functor *m_functor;
@@ -572,16 +568,14 @@ public:
     {
         m_shift = 0;
         m_systemMargin = 0;
-        m_justifiableSystems = 0;
-        m_justifiableStaves = 0;
         m_prevBottomOverflow = 0;
+        m_justificationSum = 0.;
         m_doc = doc;
     }
     int m_shift;
     int m_systemMargin;
-    int m_justifiableSystems;
-    int m_justifiableStaves;
     int m_prevBottomOverflow;
+    double m_justificationSum;
     Doc *m_doc;
 };
 
@@ -607,7 +601,7 @@ public:
         m_staffIdx = 0;
         m_staffN = 0;
         m_cumulatedShift = 0;
-        m_justificationSum = 0;
+        m_justificationSum = 0.;
         m_pageWidth = 0;
         m_functor = functor;
         m_functorEnd = functorEnd;
@@ -1333,15 +1327,14 @@ class JustifyYParams : public FunctorParams {
 public:
     JustifyYParams(Functor *functor, Doc *doc)
     {
-        m_stepSize = 0;
-        m_stepCount = 0;
-        m_stepCountStaff = 0;
+        m_spaceToDistribute = 0;
+        m_justificationSum = 0;
         m_functor = functor;
         m_doc = doc;
     }
-    int m_stepSize;
-    int m_stepCount;
-    int m_stepCountStaff;
+
+    int m_spaceToDistribute;
+    double m_justificationSum;
     Functor *m_functor;
     Doc *m_doc;
 };

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -574,12 +574,14 @@ public:
         m_systemMargin = 0;
         m_justifiableSystems = 0;
         m_justifiableStaves = 0;
+        m_prevBottomOverflow = 0;
         m_doc = doc;
     }
     int m_shift;
     int m_systemMargin;
     int m_justifiableSystems;
     int m_justifiableStaves;
+    int m_prevBottomOverflow;
     Doc *m_doc;
 };
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -287,8 +287,8 @@ public:
      * Returns NULL is not found
      */
     ///@{
-    Object *GetNext(Object *child, const ClassId classId = UNSPECIFIED);
-    Object *GetPrevious(Object *child, const ClassId classId = UNSPECIFIED);
+    Object *GetNext(const Object *child, const ClassId classId = UNSPECIFIED);
+    Object *GetPrevious(const Object *child, const ClassId classId = UNSPECIFIED);
     ///@}
 
     /**

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -457,7 +457,6 @@ public:
     OptionBool m_evenNoteSpacing;
     OptionBool m_humType;
     OptionBool m_justifyIncludeLastPage;
-    OptionBool m_justifySystemsOnly;
     OptionBool m_justifyVertically;
     OptionBool m_landscape;
     OptionBool m_mensuralToMeasure;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -520,6 +520,8 @@ public:
     OptionDbl m_spacingNonLinear;
     OptionInt m_spacingStaff;
     OptionInt m_spacingSystem;
+    OptionInt m_spacingBracketGroup;
+    OptionInt m_spacingBraceGroup;
     OptionDbl m_staffLineWidth;
     OptionDbl m_stemWidth;
     OptionIntMap m_systemDivider;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -522,6 +522,10 @@ public:
     OptionInt m_spacingSystem;
     OptionInt m_spacingBracketGroup;
     OptionInt m_spacingBraceGroup;
+    OptionDbl m_justificationStaff;
+    OptionDbl m_justificationSystem;
+    OptionDbl m_justificationBraceGroup;
+    OptionDbl m_justificationBracketGroup;
     OptionDbl m_staffLineWidth;
     OptionDbl m_stemWidth;
     OptionIntMap m_systemDivider;

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -134,11 +134,6 @@ public:
      */
     int GetContentWidth() const;
 
-    /**
-     * Calculate the justification step for a page according.
-     */
-    int CalcJustificationStepSize(bool systemsOnly) const;
-
     //----------//
     // Functors //
     //----------//
@@ -214,14 +209,10 @@ public:
     int m_drawingJustifiableHeight;
 
     /**
-     * The number of systems to justify in the page
-     */
-    int m_drawingJustifiableStaves;
-
-    /**
-     * The numberof staves to justify in the page
-     */
-    int m_drawingJustifiableSystems;
+    * the sum of justification factors for each type of spacing in between
+    * systems and staves (staff, brace group, bracket group)
+    */
+    double m_justificationSum;
 
 private:
     /**

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -204,6 +204,7 @@ public:
     /**
      * See Object::AlignVertically
      */
+    virtual int AlignVertically(FunctorParams *functorParams);
     virtual int AlignVerticallyEnd(FunctorParams *functorParams);
 
     /**

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -242,6 +242,18 @@ public:
     //
 private:
     /**
+    * This enumeration defines spacing type between current staff and previous one
+    */
+    enum class SpacingType {
+        System,
+        Staff,
+        Brace,
+        Bracket,
+        None
+    };
+    SpacingType m_spacingType = SpacingType::None;
+
+    /**
      * The list of FloatingPositioner for the staff.
      */
     ArrayOfFloatingPositioners m_floatingPositioners;

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -8,7 +8,6 @@
 #ifndef __VRV_VERTICAL_ALIGNER_H__
 #define __VRV_VERTICAL_ALIGNER_H__
 
-#include "atts_shared.h"
 #include "object.h"
 
 namespace vrv {
@@ -75,6 +74,11 @@ public:
      */
     void FindAllIntersectionPoints(
         SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin);
+    /**
+     * Get System Overflows
+     */
+    int GetOverflowAbove() const;
+    int GetOverflowBelow() const;
 
 private:
     //

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -77,8 +77,13 @@ public:
     /**
      * Get System Overflows
      */
-    int GetOverflowAbove() const;
-    int GetOverflowBelow() const;
+    int GetOverflowAbove(const Doc *doc) const;
+    int GetOverflowBelow(const Doc *doc) const;
+
+    /**
+    * Get justification sum
+    */
+    double GetJustificationSum(const Doc *doc) const;
 
 private:
     //
@@ -167,6 +172,14 @@ public:
     ///@}
 
     /**
+     * @name Set of functions for spacing calculations
+     */
+    ///@{
+    int GetMinimumSpacing(const Doc *doc) const;
+    int CalcMinimumRequiredSpacing(const Doc *doc) const;
+    ///@}
+
+    /**
      * @name Setter and getter for overflow and overlap values
      */
     ///@{
@@ -177,6 +190,13 @@ public:
     void SetOverlap(int overlap);
     int GetOverlap() const { return m_overlap; }
     int GetStaffHeight() const { return m_staffHeight; }
+    ///@}
+
+    /**
+     * @name Returns justification factor based on staff type
+     */
+    ///@{
+    double GetJustificationFactor(const Doc *doc) const;
     ///@}
 
     /**
@@ -208,7 +228,6 @@ public:
     /**
      * See Object::AlignVertically
      */
-    virtual int AlignVertically(FunctorParams *functorParams);
     virtual int AlignVerticallyEnd(FunctorParams *functorParams);
 
     /**
@@ -247,15 +266,9 @@ public:
     //
 private:
     /**
-    * This enumeration defines spacing type between current staff and previous one
-    */
-    enum class SpacingType {
-        System,
-        Staff,
-        Brace,
-        Bracket,
-        None
-    };
+     * Defines spacing type between current staff and previous one
+     */
+    enum class SpacingType { System, Staff, Brace, Bracket, None };
     SpacingType m_spacingType = SpacingType::None;
 
     /**

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -391,7 +391,7 @@ Object *Object::GetNext()
     return (m_iteratorCurrent == m_iteratorEnd) ? NULL : *m_iteratorCurrent;
 }
 
-Object *Object::GetNext(Object *child, const ClassId classId)
+Object *Object::GetNext(const Object *child, const ClassId classId)
 {
     ArrayOfObjects::iterator iteratorEnd, iteratorCurrent;
     iteratorEnd = m_children.end();
@@ -403,7 +403,7 @@ Object *Object::GetNext(Object *child, const ClassId classId)
     return (iteratorCurrent == iteratorEnd) ? NULL : *iteratorCurrent;
 }
 
-Object *Object::GetPrevious(Object *child, const ClassId classId)
+Object *Object::GetPrevious(const Object *child, const ClassId classId)
 {
     ArrayOfObjects::reverse_iterator riteratorEnd, riteratorCurrent;
     riteratorEnd = m_children.rend();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -531,10 +531,6 @@ Options::Options()
     m_justifyIncludeLastPage.Init(false);
     this->Register(&m_justifyIncludeLastPage, "justifyIncludeLastPage", &m_general);
 
-    m_justifySystemsOnly.SetInfo("Justify systems only", "Justify systems only and not staves");
-    m_justifySystemsOnly.Init(false);
-    this->Register(&m_justifySystemsOnly, "justifySystemsOnly", &m_general);
-
     m_justifyVertically.SetInfo("Justify vertically", "Justify spacing vertically to fill the page");
     m_justifyVertically.Init(false);
     this->Register(&m_justifyVertically, "justifyVertically", &m_general);
@@ -762,19 +758,19 @@ Options::Options()
     this->Register(&m_spacingNonLinear, "spacingNonLinear", &m_generalLayout);
 
     m_spacingStaff.SetInfo("Spacing staff", "The staff minimal spacing in MEI units");
-    m_spacingStaff.Init(8, 0, 24);
+    m_spacingStaff.Init(12, 0, 36);
     this->Register(&m_spacingStaff, "spacingStaff", &m_generalLayout);
 
     m_spacingSystem.SetInfo("Spacing system", "The system minimal spacing in MEI units");
-    m_spacingSystem.Init(8, 0, 24);
+    m_spacingSystem.Init(12, 0, 48);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
 
     m_spacingBracketGroup.SetInfo("Spacing bracket group", "Minimum space between staves inside a bracketed group in MEI units");
-    m_spacingBracketGroup.Init(3, 0, 12);
+    m_spacingBracketGroup.Init(12, 0, 36);
     this->Register(&m_spacingBracketGroup, "spacingBracketGroup", &m_generalLayout);
 
     m_spacingBraceGroup.SetInfo("Spacing brace group", "Minimum space between staves inside a braced group in MEI units");
-    m_spacingBraceGroup.Init(3, 0, 12);
+    m_spacingBraceGroup.Init(12, 0, 36);
     this->Register(&m_spacingBraceGroup, "spacingBraceGroup", &m_generalLayout);
 
     m_justificationStaff.SetInfo("Spacing staff justification", "The staff justification");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -766,7 +766,7 @@ Options::Options()
     this->Register(&m_spacingStaff, "spacingStaff", &m_generalLayout);
 
     m_spacingSystem.SetInfo("Spacing system", "The system minimal spacing in MEI units");
-    m_spacingSystem.Init(3, 0, 12);
+    m_spacingSystem.Init(8, 0, 24);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
 
     m_spacingBracketGroup.SetInfo("Spacing bracket group", "Minimum space between staves inside a bracketed group in MEI units");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -777,6 +777,22 @@ Options::Options()
     m_spacingBraceGroup.Init(3, 0, 12);
     this->Register(&m_spacingBraceGroup, "spacingBraceGroup", &m_generalLayout);
 
+    m_justificationStaff.SetInfo("Spacing staff justification", "The staff justification");
+    m_justificationStaff.Init(1., 0., 10.);
+    this->Register(&m_justificationStaff, "justificationStaff", &m_generalLayout);
+
+    m_justificationSystem.SetInfo("Spacing system justification", "The system spacing justification");
+    m_justificationSystem.Init(1., 0., 10.);
+    this->Register(&m_justificationSystem, "justificationSystem", &m_generalLayout);
+
+    m_justificationBracketGroup.SetInfo("Spacing bracket group justification", "Space between staves inside a bracketed group justification");
+    m_justificationBracketGroup.Init(1., 0., 10.);
+    this->Register(&m_justificationBracketGroup, "justificationBracketGroup", &m_generalLayout);
+
+    m_justificationBraceGroup.SetInfo("Spacing brace group justification", "Space between staves inside a braced group ijustification");
+    m_justificationBraceGroup.Init(1., 0., 10.);
+    this->Register(&m_justificationBraceGroup, "justificationBraceGroup", &m_generalLayout);
+
     m_staffLineWidth.SetInfo("Staff line width", "The staff line width in unit");
     m_staffLineWidth.Init(0.15, 0.10, 0.30);
     this->Register(&m_staffLineWidth, "staffLineWidth", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -769,6 +769,14 @@ Options::Options()
     m_spacingSystem.Init(3, 0, 12);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
 
+    m_spacingBracketGroup.SetInfo("Spacing bracket group", "Minimum space between staves inside a bracketed group in MEI units");
+    m_spacingBracketGroup.Init(3, 0, 12);
+    this->Register(&m_spacingBracketGroup, "spacingBracketGroup", &m_generalLayout);
+
+    m_spacingBraceGroup.SetInfo("Spacing brace group", "Minimum space between staves inside a braced group in MEI units");
+    m_spacingBraceGroup.Init(3, 0, 12);
+    this->Register(&m_spacingBraceGroup, "spacingBraceGroup", &m_generalLayout);
+
     m_staffLineWidth.SetInfo("Staff line width", "The staff line width in unit");
     m_staffLineWidth.Init(0.15, 0.10, 0.30);
     this->Register(&m_staffLineWidth, "staffLineWidth", &m_generalLayout);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -58,8 +58,7 @@ void Page::Reset()
     m_PPUFactor = 1.0;
 
     m_drawingJustifiableHeight = 0;
-    m_drawingJustifiableSystems = 0;
-    m_drawingJustifiableStaves = 0;
+    m_justificationSum = 0.;
 }
 
 bool Page::IsSupportedChild(Object *child)
@@ -511,9 +510,6 @@ void Page::JustifyVertically()
         return;
     }
 
-    bool systemsOnly = doc->GetOptions()->m_justifySystemsOnly.GetValue();
-    int stepSize = this->CalcJustificationStepSize(systemsOnly);
-
     // Last page and justification of last page is not enabled
     Pages *pages = doc->GetPages();
     assert(pages);
@@ -525,14 +521,9 @@ void Page::JustifyVertically()
         if (idx > 0) {
             Page *penultimatePage = dynamic_cast<Page *>(pages->GetPrevious(this));
             assert(penultimatePage);
-            if (!penultimatePage->m_layoutDone) {
-                doc->SetDrawingPage(idx - 1);
-                penultimatePage->LayOut();
-                doc->SetDrawingPage(idx);
-            }
-            int previousStepSize = penultimatePage->CalcJustificationStepSize(systemsOnly);
-            if (previousStepSize < stepSize) {
-                stepSize = previousStepSize;
+
+            if (penultimatePage->m_drawingJustifiableHeight < this->m_drawingJustifiableHeight) {
+                this->m_drawingJustifiableHeight = penultimatePage->m_drawingJustifiableHeight;
             }
         }
     }
@@ -540,7 +531,8 @@ void Page::JustifyVertically()
     // Justify Y position
     Functor justifyY(&Object::JustifyY);
     JustifyYParams justifyYParams(&justifyY, doc);
-    justifyYParams.m_stepSize = stepSize;
+    justifyYParams.m_justificationSum = this->m_justificationSum;
+    justifyYParams.m_spaceToDistribute = this->m_drawingJustifiableHeight;
     this->Process(&justifyY, &justifyYParams);
 }
 
@@ -608,28 +600,6 @@ int Page::GetContentWidth() const
     doc = NULL;
 
     return maxWidth;
-}
-
-int Page::CalcJustificationStepSize(bool systemsOnly) const
-{
-    if (this->m_drawingJustifiableHeight < 0) {
-        return 0;
-    }
-
-    int stepCount = 0;
-    if (systemsOnly) {
-        stepCount = this->m_drawingJustifiableSystems - 1;
-    }
-    else {
-        stepCount = this->m_drawingJustifiableStaves - 1;
-    }
-
-    // Step should be greater than one...
-    if (stepCount == 0) {
-        return 0;
-    }
-
-    return this->m_drawingJustifiableHeight / stepCount;
 }
 
 void Page::AdjustSylSpacingByVerse(PrepareProcessingListsParams &listsParams, Doc *doc)
@@ -734,8 +704,7 @@ int Page::AlignSystems(FunctorParams *functorParams)
     AlignSystemsParams *params = dynamic_cast<AlignSystemsParams *>(functorParams);
     assert(params);
 
-    params->m_justifiableSystems = 0;
-    params->m_justifiableStaves = 0;
+    params->m_justificationSum = 0;
 
     RunningElement *header = this->GetHeader();
     if (header) {
@@ -760,8 +729,7 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
     assert(params);
 
     this->m_drawingJustifiableHeight = params->m_shift;
-    this->m_drawingJustifiableSystems = params->m_justifiableSystems;
-    this->m_drawingJustifiableStaves = params->m_justifiableStaves;
+    this->m_justificationSum = params->m_justificationSum;
 
     RunningElement *footer = this->GetFooter();
     if (footer) {

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -709,8 +709,7 @@ int Page::AlignVerticallyEnd(FunctorParams *functorParams)
     AlignVerticallyParams *params = dynamic_cast<AlignVerticallyParams *>(functorParams);
     assert(params);
 
-    params->m_cumulatedShift
-        = params->m_doc->GetOptions()->m_spacingStaff.GetValue() * params->m_doc->GetDrawingUnit(100);
+    params->m_cumulatedShift = 0;
 
     // Also align the header and footer
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -362,11 +362,7 @@ int System::AlignVerticallyEnd(FunctorParams *functorParams)
     AlignVerticallyParams *params = dynamic_cast<AlignVerticallyParams *>(functorParams);
     assert(params);
 
-    if (this->GetIdx() > 0) {
-        params->m_cumulatedShift
-            = params->m_doc->GetOptions()->m_spacingStaff.GetValue() * params->m_doc->GetDrawingUnit(100);
-    }
-
+    params->m_cumulatedShift = 0;
     params->m_staffIdx = 0;
 
     m_systemAligner.Process(params->m_functor, params);
@@ -567,29 +563,21 @@ int System::AlignSystems(FunctorParams *functorParams)
 {
     AlignSystemsParams *params = dynamic_cast<AlignSystemsParams *>(functorParams);
     assert(params);
+    assert(m_systemAligner.GetBottomAlignment());
+
+    int systemMargin = this->GetIdx() ? params->m_systemMargin : 0;
+    if (systemMargin) {
+        const int margin = systemMargin - (params->m_prevBottomOverflow + m_systemAligner.GetOverflowAbove());
+        params->m_shift -= margin > 0 ? margin : 0;
+    }
 
     SetDrawingYRel(params->m_shift);
 
-    assert(m_systemAligner.GetBottomAlignment());
-
-    int systemMargin = params->m_systemMargin;
-    if (params->m_doc->GetOptions()->m_justifyVertically.GetValue()) {
-        assert(GetParent());
-        // Check if we are on the last system: last system should stick to the footer.
-        // No margin required.
-        if (this->GetIdx() == GetParent()->GetChildCount() - 1) {
-            systemMargin = 0;
-        }
-    }
-
-    int bottom = m_systemAligner.GetBottomAlignment()->GetYRel();
-    int contentBottom = GetContentY1();
-    int diff = std::max(contentBottom - bottom, systemMargin);
-    params->m_shift += contentBottom - diff;
-
+    params->m_shift += m_systemAligner.GetBottomAlignment()->GetYRel();
     params->m_justifiableSystems++;
     // -1 because of the bottom aligner
     params->m_justifiableStaves += m_systemAligner.GetChildCount() - 1;
+    params->m_prevBottomOverflow = m_systemAligner.GetOverflowBelow();
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -581,7 +581,11 @@ int System::AlignSystems(FunctorParams *functorParams)
         }
     }
 
-    params->m_shift += m_systemAligner.GetBottomAlignment()->GetYRel() - systemMargin;
+    int bottom = m_systemAligner.GetBottomAlignment()->GetYRel();
+    int contentBottom = GetContentY1();
+    int diff = std::max(bottom - contentBottom, systemMargin);
+    params->m_shift += contentBottom - diff;
+
     params->m_justifiableSystems++;
     // -1 because of the bottom aligner
     params->m_justifiableStaves += m_systemAligner.GetChildCount() - 1;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -630,13 +630,17 @@ int System::JustifyY(FunctorParams *functorParams)
     const double systemJustificationFactor = params->m_doc->GetOptions()->m_justificationSystem.GetValue();
     const double shift = systemJustificationFactor / params->m_justificationSum * params->m_spaceToDistribute;
 
-    if (this->GetIdx())
+    if (this->GetIdx()) {
         params->m_cumulatedShift += shift;
+    }
 
-    this->SetDrawingYRel(this->GetDrawingY() - params->m_cumulatedShift);
+    const int currentSystemShift = params->m_cumulatedShift;
+    this->SetDrawingYRel(this->GetDrawingY() - currentSystemShift);
 
     params->m_cumulatedShift = 0;
     m_systemAligner.Process(params->m_functor, params);
+
+    params->m_cumulatedShift += currentSystemShift;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -369,6 +369,7 @@ int System::AlignVerticallyEnd(FunctorParams *functorParams)
 
     params->m_staffIdx = 0;
 
+    m_systemAligner.Process(params->m_functor, params);
     m_systemAligner.Process(params->m_functorEnd, params);
 
     return FUNCTOR_SIBLINGS;
@@ -583,7 +584,7 @@ int System::AlignSystems(FunctorParams *functorParams)
 
     int bottom = m_systemAligner.GetBottomAlignment()->GetYRel();
     int contentBottom = GetContentY1();
-    int diff = std::max(bottom - contentBottom, systemMargin);
+    int diff = std::max(contentBottom - bottom, systemMargin);
     params->m_shift += contentBottom - diff;
 
     params->m_justifiableSystems++;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -631,8 +631,11 @@ int System::JustifyY(FunctorParams *functorParams)
     const double shift = systemJustificationFactor / params->m_justificationSum * params->m_spaceToDistribute;
 
     if (this->GetIdx())
-        this->SetDrawingYRel(this->GetDrawingY() - shift);
+        params->m_cumulatedShift += shift;
 
+    this->SetDrawingYRel(this->GetDrawingY() - params->m_cumulatedShift);
+
+    params->m_cumulatedShift = 0;
     m_systemAligner.Process(params->m_functor, params);
 
     return FUNCTOR_CONTINUE;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -603,6 +603,34 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
+int StaffAlignment::AlignVertically(FunctorParams *functorParams)
+{
+    AlignVerticallyParams *params = dynamic_cast<AlignVerticallyParams *>(functorParams);
+    assert(params);
+
+    if (m_staff) {
+        switch (m_spacingType) {
+            case SpacingType::System:
+                params->m_justificationSum += params->m_doc->GetOptions()->m_justificationSystem.GetValue();
+                break;
+            case SpacingType::Staff:
+                params->m_justificationSum += params->m_doc->GetOptions()->m_justificationStaff.GetValue();
+                break;
+            case SpacingType::Brace:
+                params->m_justificationSum += params->m_doc->GetOptions()->m_justificationBraceGroup.GetValue();
+                break;
+            case SpacingType::Bracket:
+                params->m_justificationSum += params->m_doc->GetOptions()->m_justificationBracketGroup.GetValue();
+                break;
+            case SpacingType::None:
+            default:
+                assert(false);
+        }
+    }
+
+    return FUNCTOR_SIBLINGS;
+}
+
 int StaffAlignment::AlignVerticallyEnd(FunctorParams *functorParams)
 {
     AlignVerticallyParams *params = dynamic_cast<AlignVerticallyParams *>(functorParams);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -164,12 +164,11 @@ void StaffAlignment::SetStaff(Staff *staff, Doc *doc)
             m_spacingType = firstInGroup ? SpacingType::System : SpacingType::Staff;
             if (staffGrp->GetParent()->Is(STAFFGRP)) {
                 // Nested staffGrp
-                if (staffGrp->HasSymbol() && staffGrp->GetSymbol() == staffGroupingSym_SYMBOL_brace && !firstInGroup) {
-                    // this staff is inside braced group (not first)
-                    m_spacingType = SpacingType::Brace;
+                if (staffGrp->HasSymbol() && staffGrp->GetSymbol() == staffGroupingSym_SYMBOL_brace) {
+                    m_spacingType = firstInGroup ? SpacingType::Bracket : SpacingType::Brace;
                 }
                 else {
-                    m_spacingType = SpacingType::Bracket;
+                    m_spacingType = firstInGroup ? SpacingType::Bracket : SpacingType::Staff;
                 }
             }
         } else {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -789,9 +789,9 @@ int StaffAlignment::JustifyY(FunctorParams *functorParams)
     }
 
     const double staffJustificationFactor = GetJustificationFactor(params->m_doc);
-    const double shift = staffJustificationFactor / params->m_justificationSum * params->m_spaceToDistribute;
+    params->m_cumulatedShift += staffJustificationFactor / params->m_justificationSum * params->m_spaceToDistribute;
 
-    this->SetYRel(this->GetYRel() - shift);
+    this->SetYRel(this->GetYRel() - params->m_cumulatedShift);
 
     return FUNCTOR_CONTINUE;
 }


### PR DESCRIPTION
The PR introduces are option --spacing-bracket-group and --spacing-brace-group to explicitly set spacing inside of bracket and brace groups. Improve spacing calculation in between staves and systems.

To improve user control over vertical justification introduced options:
--justification-staff
--justification-system
--justification-brace-group
--justification-bracket-group

The option --justify-systems-only is removed as obsolete. When --justification-* options set to 0 except for --justification-system same effect would be achieved.

Addressing issues described in #1526