### PR TITLE
use SMuFL default for stem x position

### DIFF
--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -376,6 +376,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
     assert(params->m_interface);
 
     int staffSize = params->m_staff->m_drawingStaffSize;
+    int stemShift = params->m_doc->GetDrawingStemWidth(staffSize) / 2;
     bool drawingCueSize = this->GetDrawingCueSize();
 
     /************ Set the position, the length and adjust to the note head ************/
@@ -398,18 +399,22 @@ int Stem::CalcStem(FunctorParams *functorParams)
         if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
             if (this->GetStemPos() == STEMPOSITION_left) {
                 p = params->m_interface->GetStemDownNW(params->m_doc, staffSize, drawingCueSize);
+                p.x += stemShift;
             }
             else {
                 p = params->m_interface->GetStemUpSE(params->m_doc, staffSize, drawingCueSize);
+                p.x -= stemShift;
             }
             this->SetDrawingStemLen(baseStem + params->m_chordStemLength + p.y);
         }
         else {
             if (this->GetStemPos() == STEMPOSITION_right) {
                 p = params->m_interface->GetStemUpSE(params->m_doc, staffSize, drawingCueSize);
+                p.x -= stemShift;
             }
             else {
                 p = params->m_interface->GetStemDownNW(params->m_doc, staffSize, drawingCueSize);
+                p.x += stemShift;
             }
             this->SetDrawingStemLen(-(baseStem + params->m_chordStemLength - p.y));
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -249,8 +249,6 @@ Point Note::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
     if (isCueSize) defaultYShift = doc->GetCueSize(defaultYShift);
     // x default is always set to the right for now
     int defaultXShift = doc->GetGlyphWidth(SMUFL_E0A3_noteheadHalf, staffSize, isCueSize);
-    // adjust the x shift in order to take the stem width into account
-    defaultXShift -= doc->GetDrawingStemWidth(staffSize) / 2;
     Point p(defaultXShift, defaultYShift);
 
     // Here we should get the notehead value
@@ -263,11 +261,6 @@ Point Note::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
         code = this->GetMensuralSmuflNoteHead();
         p.y = doc->GetGlyphHeight(code, staffSize, isCueSize) / 2;
         p.x = doc->GetGlyphWidth(code, staffSize, isCueSize);
-    }
-
-    // Use the default for standard quarter and half note heads
-    if ((code == SMUFL_E0A3_noteheadHalf) || (code == SMUFL_E0A4_noteheadBlack)) {
-        return p;
     }
 
     Glyph *glyph = Resources::GetGlyph(code);
@@ -287,10 +280,7 @@ Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     int defaultYShift = doc->GetDrawingUnit(staffSize) / 4;
     if (isCueSize) defaultYShift = doc->GetCueSize(defaultYShift);
     // x default is always set to the left for now
-    int defaultXShift = 0;
-    // adjust the x shift in order to take the stem width into account
-    defaultXShift += doc->GetDrawingStemWidth(staffSize) / 2;
-    Point p(defaultXShift, -defaultYShift);
+    Point p(0, -defaultYShift);
 
     // Here we should get the notehead value
     wchar_t code = SMUFL_E0A4_noteheadBlack;
@@ -302,11 +292,6 @@ Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
         code = this->GetMensuralSmuflNoteHead();
         p.y = -doc->GetGlyphHeight(code, staffSize, isCueSize) / 2;
         p.x = doc->GetGlyphWidth(code, staffSize, isCueSize);
-    }
-
-    // Use the default for standard quarter and half note heads
-    if ((code == SMUFL_E0A3_noteheadHalf) || (code == SMUFL_E0A4_noteheadBlack)) {
-        return p;
     }
 
     Glyph *glyph = Resources::GetGlyph(code);


### PR DESCRIPTION
This PR moves shifting stems to actual stem calculation, relying on (default) SMuFL anchor points for note heads.