### PR TITLE
Noteheads and notehead modifiers

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -13,6 +13,7 @@
 //----------------------------------------------------------------------------
 
 #include "accid.h"
+#include "atts_externalsymbols.h"
 #include "atts_mensural.h"
 #include "atts_midi.h"
 #include "atts_shared.h"
@@ -49,6 +50,7 @@ class Note : public LayerElement,
              public AttColor,
              public AttColoration,
              public AttCue,
+             public AttExtSym,
              public AttGraced,
              public AttMidiVelocity,
              public AttNoteAnlMensural,

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -180,7 +180,7 @@ public:
     /**
      * Return a SMuFL code for the notehead
      */
-    wchar_t GetNoteheadGlyph() const;
+    wchar_t GetNoteheadGlyph(int duration) const;
 
     /**
      * Check if a note or its parent chord are visible

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -176,6 +176,11 @@ public:
     wchar_t GetMensuralSmuflNoteHead();
 
     /**
+     * Return a SMuFL code for the notehead
+     */
+    wchar_t GetNoteheadGlyph() const;
+
+    /**
      * Check if a note or its parent chord are visible
      */
     bool IsVisible();

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -180,7 +180,7 @@ public:
     /**
      * Return a SMuFL code for the notehead
      */
-    wchar_t GetNoteheadGlyph(int duration) const;
+    wchar_t GetNoteheadGlyph(const int duration) const;
 
     /**
      * Check if a note or its parent chord are visible

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1784,6 +1784,7 @@ void MEIOutput::WriteNote(pugi::xml_node currentNode, Note *note)
     note->WriteColor(currentNode);
     note->WriteColoration(currentNode);
     note->WriteCue(currentNode);
+    note->WriteExtSym(currentNode);
     note->WriteGraced(currentNode);
     note->WriteMidiVelocity(currentNode);
     note->WriteNoteAnlMensural(currentNode);
@@ -4979,6 +4980,7 @@ bool MEIInput::ReadNote(Object *parent, pugi::xml_node note)
     vrvNote->ReadColor(note);
     vrvNote->ReadColoration(note);
     vrvNote->ReadCue(note);
+    vrvNote->ReadExtSym(note);
     vrvNote->ReadGraced(note);
     vrvNote->ReadMidiVelocity(note);
     vrvNote->ReadNoteAnlMensural(note);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2536,6 +2536,8 @@ void MusicXmlInput::ReadMusicXmlNote(
             note->SetHeadColor(notehead.node().attribute("color").as_string());
             note->SetHeadShape(ConvertNotehead(notehead.node().text().as_string()));
             if (notehead.node().attribute("parentheses").as_bool()) note->SetHeadMod(NOTEHEADMODIFIER_paren);
+            auto noteHeadFill = notehead.node().attribute("filled");
+            if (noteHeadFill) note->SetHeadFill(noteHeadFill.as_bool() ? FILL_solid : FILL_void);
             if (!std::strncmp(notehead.node().text().as_string(), "none", 4)) note->SetHeadVisible(BOOLEAN_false);
         }
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -467,12 +467,18 @@ int LayerElement::GetDrawingRadius(Doc *doc, bool isInLigature)
             return doc->GetGlyphWidth(note->GetMensuralSmuflNoteHead(), 
                 staff->m_drawingStaffSize, this->GetDrawingCueSize()) / 2;
         }
-        code = note->GetNoteheadGlyph();
+        code = note->GetNoteheadGlyph(dur);
     }
     else if (this->Is(CHORD)) {
         Chord *chord = dynamic_cast<Chord *>(this);
         assert(chord);
         dur = chord->GetActualDur();
+        if (dur == DUR_1)
+            code = SMUFL_E0A2_noteheadWhole;
+        else if (dur == DUR_2)
+            code = SMUFL_E0A3_noteheadHalf;
+        else
+            code = SMUFL_E0A4_noteheadBlack;
     }
 
     // Mensural note shorter than DUR_BR
@@ -486,7 +492,6 @@ int LayerElement::GetDrawingRadius(Doc *doc, bool isInLigature)
         }
     }
 
-    if ((dur == DUR_1) || (dur == DUR_2)) code = (dur == DUR_1) ? SMUFL_E0A2_noteheadWhole : SMUFL_E0A3_noteheadHalf;
     return doc->GetGlyphWidth(code, staff->m_drawingStaffSize, this->GetDrawingCueSize()) / 2;
 }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -52,6 +52,7 @@ Note::Note()
     , AttColor()
     , AttColoration()
     , AttCue()
+    , AttExtSym()
     , AttGraced()
     , AttMidiVelocity()
     , AttNoteAnlMensural()
@@ -67,6 +68,7 @@ Note::Note()
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_COLORATION);
     RegisterAttClass(ATT_CUE);
+    RegisterAttClass(ATT_EXTSYM);
     RegisterAttClass(ATT_GRACED);
     RegisterAttClass(ATT_NOTEANLMENSURAL);
     RegisterAttClass(ATT_NOTEHEADS);
@@ -91,6 +93,7 @@ void Note::Reset()
     ResetColor();
     ResetColoration();
     ResetCue();
+    ResetExtSym();
     ResetGraced();
     ResetNoteAnlMensural();
     ResetNoteHeads();
@@ -400,24 +403,38 @@ wchar_t Note::GetMensuralSmuflNoteHead()
 
 wchar_t Note::GetNoteheadGlyph() const 
 {
+    static std::map<std::string, wchar_t> additionalNoteheadSymbols
+        = { { "vocalSprechgesang", SMUFL_E645_vocalSprechgesang },
+            { "noteheadDiamondBlackWide", SMUFL_E0DC_noteheadDiamondBlackWide },
+            { "noteheadDiamondWhiteWide", SMUFL_E0DE_noteheadDiamondWhiteWide },
+            { "noteheadDiamondHalf", SMUFL_E0D9_noteheadDiamondHalf }, 
+            { "noteheadNull", SMUFL_E0A5_noteheadNull } };
+    if (HasGlyphName()) {
+        auto glyph = GetGlyphName();
+        if (end(additionalNoteheadSymbols) == additionalNoteheadSymbols.find(glyph)) {
+            return SMUFL_E0A4_noteheadBlack;
+        }
+        return additionalNoteheadSymbols[glyph];
+    }
+
     switch (GetHeadShape()) {
         case HEADSHAPE_quarter: return SMUFL_E0A4_noteheadBlack;
         case HEADSHAPE_half: return SMUFL_E0A3_noteheadHalf;
         case HEADSHAPE_whole: return SMUFL_E0A2_noteheadWhole;
         //case HEADSHAPE_backslash: return SMUFL_noteheadBackslash;
-        //case HEADSHAPE_circle: return SMUFL_noteheadCircle;
-        //case HEADSHAPE_plus: return SMUFL_noteheadPlus;
-        //case HEADSHAPE_diamond: return GetHeadFill() == FILL_void ? SMUFL_noteheadDiamondEmpty 
-        //                                                          : SMUFL_noteheadDiamondFilled;
-        //case HEADSHAPE_isotriangle: return SMUFL_noteheadIsoTriangle;
+        //case HEADSHAPE_circle: return SMUFL_E0B3_noteheadCircleX;
+        case HEADSHAPE_plus: return SMUFL_E0AF_noteheadPlusBlack;
+        case HEADSHAPE_diamond:
+            return GetHeadFill() == FILL_void ? SMUFL_E0DD_noteheadDiamondWhite : SMUFL_E0DB_noteheadDiamondBlack;
+        //case HEADSHAPE_isotriangle: return SMUFL_E0BC_noteheadTriangleUpHalf;
         //case HEADSHAPE_oval: return SMUFL_noteheadOval;
-        //case HEADSHAPE_piewedge: return SMUFL_noteheadPieWedgel
+        //case HEADSHAPE_piewedge: return SMUFL_noteheadPieWedge;
         //case HEADSHAPE_rectangle: return SMUFL_noteheadRectangle;
         //case HEADSHAPE_rtriangle: return SMUFL_noteheadRTriangle;
         //case HEADSHAPE_semicircle: return SMUFL_noteheadSemicircle;
         case HEADSHAPE_slash: return SMUFL_E101_noteheadSlashHorizontalEnds;
         //case HEADSHAPE_square: return SMUFL_noteheadSquare;
-        //case HEADSHAPE_x: return SMUFL_noteheadX;
+        case HEADSHAPE_x: return SMUFL_E0A9_noteheadXBlack;
         default: return SMUFL_E0A4_noteheadBlack;
     }
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -409,7 +409,7 @@ wchar_t Note::GetNoteheadGlyph(const int duration) const
             { "noteheadNull", SMUFL_E0A5_noteheadNull } };
 
     if (HasGlyphName()) {
-        auto glyph = GetGlyphName();
+        const std::string glyph = GetGlyphName();
         if (additionalNoteheadSymbols.end() == additionalNoteheadSymbols.find(glyph)) {
             return SMUFL_E0A4_noteheadBlack;
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -436,7 +436,8 @@ wchar_t Note::GetNoteheadGlyph(const int duration) const
         case HEADSHAPE_slash: return SMUFL_E101_noteheadSlashHorizontalEnds;
         //case HEADSHAPE_square: return SMUFL_noteheadSquare;
         case HEADSHAPE_x: {
-            if (DUR_1 == duration || DUR_2 == duration) break; // return SMUFL_E0B3_noteheadCircleX;
+            if (DUR_1 == duration) return SMUFL_E0B5_noteheadWholeWithX;
+            if (DUR_2 == duration) return SMUFL_E0B6_noteheadHalfWithX;
             return SMUFL_E0A9_noteheadXBlack;
         } 
         default: break;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -401,7 +401,7 @@ wchar_t Note::GetMensuralSmuflNoteHead()
     return code;
 }
 
-wchar_t Note::GetNoteheadGlyph(int duration) const 
+wchar_t Note::GetNoteheadGlyph(const int duration) const 
 {
     static std::map<std::string, wchar_t> additionalNoteheadSymbols
         = { { "noteheadDiamondBlackWide", SMUFL_E0DC_noteheadDiamondBlackWide },
@@ -410,7 +410,7 @@ wchar_t Note::GetNoteheadGlyph(int duration) const
 
     if (HasGlyphName()) {
         auto glyph = GetGlyphName();
-        if (end(additionalNoteheadSymbols) == additionalNoteheadSymbols.find(glyph)) {
+        if (additionalNoteheadSymbols.end() == additionalNoteheadSymbols.find(glyph)) {
             return SMUFL_E0A4_noteheadBlack;
         }
         return additionalNoteheadSymbols[glyph];

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -257,7 +257,7 @@ Point Note::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
     Point p(defaultXShift, defaultYShift);
 
     // Here we should get the notehead value
-    wchar_t code = GetNoteheadGlyph();
+    wchar_t code = GetNoteheadGlyph(GetDrawingDur());
 
     // This is never called for now because mensural notes do not have stem/flag children
     // For changingg this, change Note::CalcStem and Note::PrepareLayerElementParts
@@ -296,7 +296,7 @@ Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     Point p(defaultXShift, -defaultYShift);
 
     // Here we should get the notehead value
-    wchar_t code = GetNoteheadGlyph();
+    wchar_t code = GetNoteheadGlyph(GetDrawingDur());
 
     // This is never called for now because mensural notes do not have stem/flag children
     // See comment above
@@ -401,14 +401,13 @@ wchar_t Note::GetMensuralSmuflNoteHead()
     return code;
 }
 
-wchar_t Note::GetNoteheadGlyph() const 
+wchar_t Note::GetNoteheadGlyph(int duration) const 
 {
     static std::map<std::string, wchar_t> additionalNoteheadSymbols
-        = { { "vocalSprechgesang", SMUFL_E645_vocalSprechgesang },
-            { "noteheadDiamondBlackWide", SMUFL_E0DC_noteheadDiamondBlackWide },
-            { "noteheadDiamondWhiteWide", SMUFL_E0DE_noteheadDiamondWhiteWide },
-            { "noteheadDiamondHalf", SMUFL_E0D9_noteheadDiamondHalf }, 
+        = { { "noteheadDiamondBlackWide", SMUFL_E0DC_noteheadDiamondBlackWide },
+            { "noteheadDiamondWhiteWide", SMUFL_E0DE_noteheadDiamondWhiteWide },             
             { "noteheadNull", SMUFL_E0A5_noteheadNull } };
+
     if (HasGlyphName()) {
         auto glyph = GetGlyphName();
         if (end(additionalNoteheadSymbols) == additionalNoteheadSymbols.find(glyph)) {
@@ -424,8 +423,10 @@ wchar_t Note::GetNoteheadGlyph() const
         //case HEADSHAPE_backslash: return SMUFL_noteheadBackslash;
         //case HEADSHAPE_circle: return SMUFL_E0B3_noteheadCircleX;
         case HEADSHAPE_plus: return SMUFL_E0AF_noteheadPlusBlack;
-        case HEADSHAPE_diamond:
+        case HEADSHAPE_diamond: {
+            if (DUR_1 == duration) return SMUFL_E0D9_noteheadDiamondHalf;
             return GetHeadFill() == FILL_void ? SMUFL_E0DD_noteheadDiamondWhite : SMUFL_E0DB_noteheadDiamondBlack;
+        }
         //case HEADSHAPE_isotriangle: return SMUFL_E0BC_noteheadTriangleUpHalf;
         //case HEADSHAPE_oval: return SMUFL_noteheadOval;
         //case HEADSHAPE_piewedge: return SMUFL_noteheadPieWedge;
@@ -434,9 +435,16 @@ wchar_t Note::GetNoteheadGlyph() const
         //case HEADSHAPE_semicircle: return SMUFL_noteheadSemicircle;
         case HEADSHAPE_slash: return SMUFL_E101_noteheadSlashHorizontalEnds;
         //case HEADSHAPE_square: return SMUFL_noteheadSquare;
-        case HEADSHAPE_x: return SMUFL_E0A9_noteheadXBlack;
-        default: return SMUFL_E0A4_noteheadBlack;
+        case HEADSHAPE_x: {
+            if (DUR_1 == duration || DUR_2 == duration) break; // return SMUFL_E0B3_noteheadCircleX;
+            return SMUFL_E0A9_noteheadXBlack;
+        } 
+        default: break;
     }
+
+    if (DUR_1 == duration) return SMUFL_E0A2_noteheadWhole;
+    if (DUR_2 == duration) return SMUFL_E0A3_noteheadHalf;
+    return SMUFL_E0A4_noteheadBlack;
 }
 
 bool Note::IsVisible()

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -254,7 +254,7 @@ Point Note::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
     Point p(defaultXShift, defaultYShift);
 
     // Here we should get the notehead value
-    wchar_t code = SMUFL_E0A4_noteheadBlack;
+    wchar_t code = GetNoteheadGlyph();
 
     // This is never called for now because mensural notes do not have stem/flag children
     // For changingg this, change Note::CalcStem and Note::PrepareLayerElementParts
@@ -293,7 +293,7 @@ Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     Point p(defaultXShift, -defaultYShift);
 
     // Here we should get the notehead value
-    wchar_t code = SMUFL_E0A4_noteheadBlack;
+    wchar_t code = GetNoteheadGlyph();
 
     // This is never called for now because mensural notes do not have stem/flag children
     // See comment above
@@ -396,6 +396,29 @@ wchar_t Note::GetMensuralSmuflNoteHead()
         }
     }
     return code;
+}
+
+wchar_t Note::GetNoteheadGlyph() const 
+{
+    switch (GetHeadShape()) {
+        case HEADSHAPE_quarter: return SMUFL_E0A4_noteheadBlack;
+        case HEADSHAPE_half: return SMUFL_E0A3_noteheadHalf;
+        case HEADSHAPE_whole: return SMUFL_E0A2_noteheadWhole;
+        //case HEADSHAPE_backslash: return SMUFL_noteheadBackslash;
+        //case HEADSHAPE_circle: return SMUFL_noteheadCircle;
+        //case HEADSHAPE_plus: return SMUFL_noteheadPlus;
+        //case HEADSHAPE_diamond: return SMUFL_noteheadDiamond;
+        //case HEADSHAPE_isotriangle: return SMUFL_noteheadIsoTriangle;
+        //case HEADSHAPE_oval: return SMUFL_noteheadOval;
+        //case HEADSHAPE_piewedge: return SMUFL_noteheadPieWedgel
+        //case HEADSHAPE_rectangle: return SMUFL_noteheadRectangle;
+        //case HEADSHAPE_rtriangle: return SMUFL_noteheadRTriangle;
+        //case HEADSHAPE_semicircle: return SMUFL_noteheadSemicircle;
+        //case HEADSHAPE_slash: return SMUFL_E101_noteheadSlashHorizontalEnds;
+        //case HEADSHAPE_square: return SMUFL_noteheadSquare;
+        //case HEADSHAPE_x: return SMUFL_noteheadX;
+        default: return SMUFL_E0A4_noteheadBlack;
+    }
 }
 
 bool Note::IsVisible()

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -407,14 +407,15 @@ wchar_t Note::GetNoteheadGlyph() const
         //case HEADSHAPE_backslash: return SMUFL_noteheadBackslash;
         //case HEADSHAPE_circle: return SMUFL_noteheadCircle;
         //case HEADSHAPE_plus: return SMUFL_noteheadPlus;
-        //case HEADSHAPE_diamond: return SMUFL_noteheadDiamond;
+        //case HEADSHAPE_diamond: return GetHeadFill() == FILL_void ? SMUFL_noteheadDiamondEmpty 
+        //                                                          : SMUFL_noteheadDiamondFilled;
         //case HEADSHAPE_isotriangle: return SMUFL_noteheadIsoTriangle;
         //case HEADSHAPE_oval: return SMUFL_noteheadOval;
         //case HEADSHAPE_piewedge: return SMUFL_noteheadPieWedgel
         //case HEADSHAPE_rectangle: return SMUFL_noteheadRectangle;
         //case HEADSHAPE_rtriangle: return SMUFL_noteheadRTriangle;
         //case HEADSHAPE_semicircle: return SMUFL_noteheadSemicircle;
-        //case HEADSHAPE_slash: return SMUFL_E101_noteheadSlashHorizontalEnds;
+        case HEADSHAPE_slash: return SMUFL_E101_noteheadSlashHorizontalEnds;
         //case HEADSHAPE_square: return SMUFL_noteheadSquare;
         //case HEADSHAPE_x: return SMUFL_noteheadX;
         default: return SMUFL_E0A4_noteheadBlack;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1369,7 +1369,33 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
             }
 
             dc->StartCustomGraphic("notehead");
+
             DrawSmuflCode(dc, noteX, noteY, fontNo, staff->m_drawingStaffSize, drawingCueSize, true);
+
+            // handle notehead enclosure
+            if (note->HasHeadMod()) {
+                switch (note->GetHeadMod()) {
+                    case NOTEHEADMODIFIER_paren: {
+                        DrawSmuflCode(dc, noteX - note->GetDrawingRadius(m_doc), noteY, 
+                            SMUFL_E26A_accidentalParensLeft, staff->m_drawingStaffSize, drawingCueSize, true);
+                        DrawSmuflCode(dc, noteX + note->GetDrawingRadius(m_doc) * 2, noteY,
+                            SMUFL_E26B_accidentalParensRight, staff->m_drawingStaffSize, drawingCueSize, true);
+                        break;
+                    }
+                    case NOTEHEADMODIFIER_slash:
+                    case NOTEHEADMODIFIER_backslash:
+                    case NOTEHEADMODIFIER_vline: 
+                    case NOTEHEADMODIFIER_hline: {
+                        // TODO: Handle other headmodifiers whenever they become available
+                        //wchar_t glyphCode = note->GetNoteheadModifierGlyph();
+                        //int offset = (m_doc->GetGlyphWidth - note->GetDrawingRadius(m_doc) * 2) / 2;
+                        //DrawSmuflCode(dc, noteX - offset, noteY, glyphCode, staff->m_drawingStaffSize, drawingCueSize, true);
+                        break;
+                    }
+                    default: break;
+                }
+            }
+
             dc->EndCustomGraphic();
         }
     }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1350,22 +1350,11 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         else {
             // Whole notes
             wchar_t fontNo;
-            if (drawingDur == DUR_1) {
-                if (note->GetColored() == BOOLEAN_true) {
-                    fontNo = SMUFL_E0FA_noteheadWholeFilled;
-                }
-                else {
-                    fontNo = SMUFL_E0A2_noteheadWhole;
-                }
+            if (note->GetColored() == BOOLEAN_true) {
+                fontNo = (drawingDur == DUR_1) ? SMUFL_E0FA_noteheadWholeFilled : SMUFL_E0A3_noteheadHalf;
             }
-            // Other values
             else {
-                if ((note->GetColored() == BOOLEAN_true) || drawingDur == DUR_2) {
-                    fontNo = SMUFL_E0A3_noteheadHalf;
-                }
-                else {
-                    fontNo = note->GetNoteheadGlyph();
-                }
+                fontNo = note->GetNoteheadGlyph(drawingDur);
             }
 
             dc->StartCustomGraphic("notehead");

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1364,7 +1364,7 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
                     fontNo = SMUFL_E0A3_noteheadHalf;
                 }
                 else {
-                    fontNo = SMUFL_E0A4_noteheadBlack;
+                    fontNo = note->GetNoteheadGlyph();
                 }
             }
 


### PR DESCRIPTION
Added handling of the recently generated notehead glyphs. There's also placeholder for the noteheads that don't have generated SMuFLs but have support in MEI format. Also added handling of @head.mod, namely parenthesis (since it appears to be the only one modifier with corresponding symbols present).