### PR TITLE
Improve vertical justification of last page

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -456,7 +456,6 @@ public:
     OptionBool m_condenseTempoPages;
     OptionBool m_evenNoteSpacing;
     OptionBool m_humType;
-    OptionBool m_justifyIncludeLastPage;
     OptionBool m_justifyVertically;
     OptionBool m_landscape;
     OptionBool m_mensuralToMeasure;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -527,10 +527,6 @@ Options::Options()
     m_humType.Init(false);
     this->Register(&m_humType, "humType", &m_general);
 
-    m_justifyIncludeLastPage.SetInfo("Justify including the last page", "Justify including the last page");
-    m_justifyIncludeLastPage.Init(false);
-    this->Register(&m_justifyIncludeLastPage, "justifyIncludeLastPage", &m_general);
-
     m_justifyVertically.SetInfo("Justify vertically", "Justify spacing vertically to fill the page");
     m_justifyVertically.Init(false);
     this->Register(&m_justifyVertically, "justifyVertically", &m_general);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -521,6 +521,7 @@ void Page::JustifyVertically()
     assert(pages);
     if (pages->GetLast() == this) {
         int idx = this->GetIdx();
+        const int childSystems = GetChildCount(SYSTEM);
         if (idx > 0) {
             Page *penultimatePage = dynamic_cast<Page *>(pages->GetPrevious(this));
             assert(penultimatePage);
@@ -529,11 +530,14 @@ void Page::JustifyVertically()
                 this->m_drawingJustifiableHeight = penultimatePage->m_drawingJustifiableHeight;
             }
 
-            const int childSystems = GetChildCount(SYSTEM);
             const int maxSystemsPerPage = doc->GetOptions()->m_systemMaxPerPage.GetValue();
             if ((childSystems <= 2) || (childSystems < maxSystemsPerPage)) {
                 m_justificationSum = penultimatePage->m_justificationSum;
             }
+        }
+        else {
+            const int stavesPerSystem = m_drawingScoreDef.GetChildCount(STAFFDEF, UNLIMITED_DEPTH);
+            if (childSystems * stavesPerSystem < 8) return;
         }
     }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -520,9 +520,6 @@ void Page::JustifyVertically()
     Pages *pages = doc->GetPages();
     assert(pages);
     if (pages->GetLast() == this) {
-        if (!doc->GetOptions()->m_justifyIncludeLastPage.GetValue()) {
-            return;
-        }
         int idx = this->GetIdx();
         if (idx > 0) {
             Page *penultimatePage = dynamic_cast<Page *>(pages->GetPrevious(this));
@@ -530,6 +527,12 @@ void Page::JustifyVertically()
 
             if (penultimatePage->m_drawingJustifiableHeight < this->m_drawingJustifiableHeight) {
                 this->m_drawingJustifiableHeight = penultimatePage->m_drawingJustifiableHeight;
+            }
+
+            const int childSystems = GetChildCount(SYSTEM);
+            const int maxSystemsPerPage = doc->GetOptions()->m_systemMaxPerPage.GetValue();
+            if ((childSystems <= 2) || (maxSystemsPerPage && childSystems < maxSystemsPerPage)) {
+                m_justificationSum = penultimatePage->m_justificationSum;
             }
         }
     }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -531,7 +531,7 @@ void Page::JustifyVertically()
 
             const int childSystems = GetChildCount(SYSTEM);
             const int maxSystemsPerPage = doc->GetOptions()->m_systemMaxPerPage.GetValue();
-            if ((childSystems <= 2) || (maxSystemsPerPage && childSystems < maxSystemsPerPage)) {
+            if ((childSystems <= 2) || (childSystems < maxSystemsPerPage)) {
                 m_justificationSum = penultimatePage->m_justificationSum;
             }
         }


### PR DESCRIPTION
Changed logic so that last page would be justified regardless of the additional options, if `--justify-vertically` option has been provided.
Justification for last page is based on the spacing/proportions of the previous one if there are not enough of systems in it.