### PR TITLE
Develop brackets

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -533,6 +533,7 @@ public:
      */
     OptionGrp m_generalLayout;
 
+    OptionDbl m_barlineSeparation;
     OptionDbl m_barLineWidth;
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
@@ -558,6 +559,7 @@ public:
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
     OptionIntMap m_measureNumber;
+    OptionDbl m_repeatEndingLineThickness;
     OptionInt m_slurControlPoints;
     OptionInt m_slurCurveFactor;
     OptionInt m_slurHeightFactor;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -288,10 +288,10 @@ void BeamSegment::CalcBeamInit(
         const bool graceGroop = firstNote->GetFirstAncestor(GRACEGRP);
         const bool firstGrace = graceGroop || firstNote->HasGrace();
         const bool lastGrace = graceGroop || lastNote->HasGrace();
-        beamInterface->m_stemXAbove[0] =
-            doc->GetGlyphWidth(firstSmuflCode, staff->m_drawingStaffSize, firstGrace) - drawingStemWidth;
-        beamInterface->m_stemXAbove[1] =
-            doc->GetGlyphWidth(lastSmuflCode, staff->m_drawingStaffSize, lastGrace) - drawingStemWidth;
+        beamInterface->m_stemXAbove[0]
+            = doc->GetGlyphWidth(firstSmuflCode, staff->m_drawingStaffSize, firstGrace) - drawingStemWidth;
+        beamInterface->m_stemXAbove[1]
+            = doc->GetGlyphWidth(lastSmuflCode, staff->m_drawingStaffSize, lastGrace) - drawingStemWidth;
         beamInterface->m_stemXBelow[0] = beamInterface->m_stemXBelow[1] = drawingStemWidth;
     }
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -42,7 +42,7 @@ BeamSegment::BeamSegment()
     Reset();
 }
 
-BeamSegment::~BeamSegment(){ }
+BeamSegment::~BeamSegment() {}
 
 void BeamSegment::Reset()
 {
@@ -127,8 +127,8 @@ void BeamSegment::CalcBeam(
 
         for (BeamElementCoord *coord : m_beamElementCoordRefs) {
             if (coord->m_stem) {
-                if ((beamInterface->m_drawingPlace == BEAMPLACE_above && maxLength < coord->m_yBeam)||
-                    (beamInterface->m_drawingPlace == BEAMPLACE_below && maxLength > coord->m_yBeam)) {
+                if ((beamInterface->m_drawingPlace == BEAMPLACE_above && maxLength < coord->m_yBeam)
+                    || (beamInterface->m_drawingPlace == BEAMPLACE_below && maxLength > coord->m_yBeam)) {
                     maxLength = coord->m_yBeam;
                 }
             }
@@ -145,7 +145,7 @@ void BeamSegment::CalcBeam(
     for (BeamElementCoord *coord : m_beamElementCoordRefs) {
         // All notes and chords get their stem value stored
         LayerElement *el = coord->m_element;
-        if (el->Is({NOTE, CHORD})) {
+        if (el->Is({ NOTE, CHORD })) {
             StemmedDrawingInterface *stemmedInterface = el->GetStemmedDrawingInterface();
             assert(beamInterface);
 
@@ -210,7 +210,8 @@ void BeamSegment::CalcBeamInit(
         if (coord->m_element->Is({ CHORD, NOTE })) {
             if (m_firstNoteOrChord) {
                 m_lastNoteOrChord = coord;
-            } else{
+            }
+            else {
                 m_firstNoteOrChord = coord;
             }
             m_nbNotesOrChords++;
@@ -268,12 +269,14 @@ void BeamSegment::CalcBeamInit(
     Note *firstNote = NULL, *lastNote = NULL;
     if (m_firstNoteOrChord->m_element->Is(NOTE)) {
         firstNote = vrv_cast<Note *>(m_firstNoteOrChord->m_element);
-    } else if (m_firstNoteOrChord->m_element->Is(CHORD)){
+    }
+    else if (m_firstNoteOrChord->m_element->Is(CHORD)) {
         firstNote = vrv_cast<Chord *>(m_firstNoteOrChord->m_element)->GetBottomNote();
     }
     if (m_lastNoteOrChord->m_element->Is(NOTE)) {
         lastNote = vrv_cast<Note *>(m_lastNoteOrChord->m_element);
-    } else if (m_lastNoteOrChord->m_element->Is(CHORD)){
+    }
+    else if (m_lastNoteOrChord->m_element->Is(CHORD)) {
         lastNote = vrv_cast<Chord *>(m_lastNoteOrChord->m_element)->GetBottomNote();
     }
 
@@ -938,8 +941,8 @@ data_STEMDIRECTION BeamElementCoord::GetStemDir()
     return stemInterface->GetStemDir();
 }
 
-void BeamElementCoord::SetDrawingStemDir(
-    data_STEMDIRECTION stemDir, Staff *staff, Doc *doc, BeamSegment *segment, BeamDrawingInterface *interface, bool isLast)
+void BeamElementCoord::SetDrawingStemDir(data_STEMDIRECTION stemDir, Staff *staff, Doc *doc, BeamSegment *segment,
+    BeamDrawingInterface *interface, bool isLast)
 {
     assert(staff);
     assert(doc);

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -61,7 +61,6 @@ void Fermata::ConvertFromAnalyticalMarkup(
     params->m_controlEvents.push_back(this);
 }
 
-
 wchar_t Fermata::GetFermataGlyph() const
 {
     // If there is glyph.num, prioritize it, otherwise check other attributes

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4068,7 +4068,7 @@ bool MEIInput::ReadFermata(Object *parent, pugi::xml_node fermata)
     vrvFermata->ReadColor(fermata);
     vrvFermata->ReadExtSym(fermata);
     vrvFermata->ReadFermataVis(fermata);
-    vrvFermata->ReadPlacement(fermata); 
+    vrvFermata->ReadPlacement(fermata);
 
     parent->AddChild(vrvFermata);
     ReadUnsupportedAttr(fermata, vrvFermata);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2887,8 +2887,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     : DEP_Below;
             }
             const std::string smuflCode = GetOrnamentGlyphNumber(mordentFlags);
-            if (!smuflCode.empty())
-            {
+            if (!smuflCode.empty()) {
                 mordent->SetExternalsymbols(mordent, "glyph.num", smuflCode);
                 mordent->SetExternalsymbols(mordent, "glyph.auth", "smufl");
             }
@@ -3727,10 +3726,10 @@ void MusicXmlInput::ShapeFermata(Fermata *fermata, pugi::xml_node node)
 
 std::string MusicXmlInput::GetOrnamentGlyphNumber(int attributes) const
 {
-    static std::map<int, std::string> precomposedNames = { { APPR_Above | FORM_Inverted, "U+E5C6" },
-        { APPR_Below | FORM_Inverted, "U+E5B5" }, { APPR_Above | FORM_Normal, "U+E5C7" },
-        { APPR_Below | FORM_Normal, "U+E5B8" }, { FORM_Inverted | DEP_Above, "U+E5BB" },
-        { FORM_Inverted | DEP_Below, "U+E5C8" }
+    static std::map<int, std::string> precomposedNames = {
+        { APPR_Above | FORM_Inverted, "U+E5C6" }, { APPR_Below | FORM_Inverted, "U+E5B5" },
+        { APPR_Above | FORM_Normal, "U+E5C7" }, { APPR_Below | FORM_Normal, "U+E5B8" },
+        { FORM_Inverted | DEP_Above, "U+E5BB" }, { FORM_Inverted | DEP_Below, "U+E5C8" }
         // these values need to be matched with proper SMuFL codes first
         /*, { FORM_Normal | DEP_Above, "U+????" },
         { FORM_Normal | DEP_Below, "U+????" }, { APPR_Above | FORM_Normal | DEP_Above, "U+????" },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1222,14 +1222,21 @@ void Options::Sync()
 {
     if (!m_engravingDefaults.isSet()) return;
     // override default or passed engravingDefaults with explicitly set values
-    std::list<std::pair<std::string, OptionDbl *> > engravingDefaults = { { "staffLineThickness", &m_staffLineWidth },
-        { "stemThickness", &m_stemWidth }, { "legerLineThickness", &m_ledgerLineThickness },
-        { "legerLineExtension", &m_ledgerLineExtension }, { "slurMidpointThickness", &m_slurThickness },
-        { "tieMidpointThickness", &m_tieThickness }, { "thinBarlineThickness", &m_barLineWidth },
-        { "thickBarlineThickness", &m_thickBarlineThickness }, { "bracketThickness", &m_bracketThickness },
-        { "subBracketThickness", &m_subBracketThickness }, { "hairpinThickness", &m_hairpinThickness },
-        { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, { "lyricLineThickness", &m_lyricLineThickness },
-        { "tupletBracketThickness", &m_tupletBracketThickness } };
+    std::list<std::pair<std::string, OptionDbl *> > engravingDefaults
+        = { { "staffLineThickness", &m_staffLineWidth }, //
+              { "stemThickness", &m_stemWidth }, //
+              { "legerLineThickness", &m_ledgerLineThickness }, //
+              { "legerLineExtension", &m_ledgerLineExtension }, //
+              { "slurMidpointThickness", &m_slurThickness }, //
+              { "tieMidpointThickness", &m_tieThickness }, //
+              { "thinBarlineThickness", &m_barLineWidth }, //
+              { "thickBarlineThickness", &m_thickBarlineThickness }, //
+              { "bracketThickness", &m_bracketThickness }, //
+              { "subBracketThickness", &m_subBracketThickness }, //
+              { "hairpinThickness", &m_hairpinThickness }, //
+              { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, //
+              { "lyricLineThickness", &m_lyricLineThickness }, //
+              { "tupletBracketThickness", &m_tupletBracketThickness } };
 
     for (auto &pair : engravingDefaults) {
         if (pair.second->isSet()) continue;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -39,7 +39,7 @@ std::map<int, std::string> Option::s_systemDivider
 constexpr const char *engravingDefaults = "{'engravingDefaults':{'thinBarlineThickness':0.15,'lyricLineThickness':0.125,"
     "'slurMidpointThickness':0.3,'staffLineThickness':0.075,'stemThickness':0.1,'tieMidpointThickness':0.25,"
     "'hairpinThickness':0.1,'thickBarlineThickness':0.5,'tupletBracketThickness':0.1,'subBracketThickness':0.5,"
-    "'bracketThickness':0.5}}";
+    "'bracketThickness':0.5,'repeatEndingLineThickness':0.15}}";
 
 //----------------------------------------------------------------------------
 // Option
@@ -877,6 +877,11 @@ Options::Options()
     m_measureNumber.Init(MEASURENUMBER_system, &Option::s_measureNumber);
     this->Register(&m_measureNumber, "measureNumber", &m_generalLayout);
 
+    m_repeatEndingLineThickness.SetInfo(
+        "Repeat ending line thickness", "Repeat and ending line thickness");
+    m_repeatEndingLineThickness.Init(0.15, 0.1, 2.0);
+    this->Register(&m_repeatEndingLineThickness, "repeatEndingLineThickness", &m_generalLayout);
+
     m_slurControlPoints.SetInfo(
         "Slur control points", "Slur control points - higher value means more curved at the end");
     m_slurControlPoints.Init(5, 1, 10);
@@ -1227,7 +1232,6 @@ void Options::Sync()
             { "tieMidpointThickness", &m_tieThickness },
             { "thinBarlineThickness", &m_barLineWidth },
             { "thickBarlineThickness", &m_thickBarlineThickness },
-            { "barlineSeparation", &m_barlineSeparation },
             { "bracketThickness", &m_bracketThickness },
             { "subBracketThickness", &m_subBracketThickness },
             { "hairpinThickness", &m_hairpinThickness },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1219,19 +1219,21 @@ void Options::Sync()
     if (!m_engravingDefaults.isSet()) return;
     // override default or passed engravingDefaults with explicitly set values
     std::list<std::pair<std::string, OptionDbl *>> engravingDefaults
-        = { { "thinBarlineThickness", &m_barLineWidth },
-            { "lyricLineThickness", &m_lyricLineThickness },
-            { "slurMidpointThickness", &m_slurThickness },
-            { "staffLineThickness", &m_staffLineWidth },
+        = { { "staffLineThickness", &m_staffLineWidth },
             { "stemThickness", &m_stemWidth },
-            { "tieMidpointThickness", &m_tieThickness },
-            { "hairpinThickness", &m_hairpinThickness },
-            { "thickBarlineThickness", &m_thickBarlineThickness },
-            { "tupletBracketThickness", &m_tupletBracketThickness },
-            { "subBracketThickness", &m_subBracketThickness },
-            { "bracketThickness", &m_bracketThickness },
             { "legerLineThickness", &m_ledgerLineThickness },
-            { "legerLineExtension", &m_ledgerLineExtension }
+            { "legerLineExtension", &m_ledgerLineExtension },
+            { "slurMidpointThickness", &m_slurThickness },
+            { "tieMidpointThickness", &m_tieThickness },
+            { "thinBarlineThickness", &m_barLineWidth },
+            { "thickBarlineThickness", &m_thickBarlineThickness },
+            { "barlineSeparation", &m_barlineSeparation },
+            { "bracketThickness", &m_bracketThickness },
+            { "subBracketThickness", &m_subBracketThickness },
+            { "hairpinThickness", &m_hairpinThickness },
+            { "repeatEndingLineThickness", &m_repeatEndingLineThickness },
+            { "lyricLineThickness", &m_lyricLineThickness },
+            { "tupletBracketThickness", &m_tupletBracketThickness }
     };
 
     for (auto &pair : engravingDefaults) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,10 +36,11 @@ std::map<int, std::string> Option::s_measureNumber
 std::map<int, std::string> Option::s_systemDivider
     = { { SYSTEMDIVIDER_none, "none" }, { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
 
-constexpr const char *engravingDefaults = "{'engravingDefaults':{'thinBarlineThickness':0.15,'lyricLineThickness':0.125,"
-    "'slurMidpointThickness':0.3,'staffLineThickness':0.075,'stemThickness':0.1,'tieMidpointThickness':0.25,"
-    "'hairpinThickness':0.1,'thickBarlineThickness':0.5,'tupletBracketThickness':0.1,'subBracketThickness':0.5,"
-    "'bracketThickness':0.5,'repeatEndingLineThickness':0.15}}";
+constexpr const char *engravingDefaults
+    = "{'engravingDefaults':{'thinBarlineThickness':0.15,'lyricLineThickness':0.125,"
+      "'slurMidpointThickness':0.3,'staffLineThickness':0.075,'stemThickness':0.1,'tieMidpointThickness':0.25,"
+      "'hairpinThickness':0.1,'thickBarlineThickness':0.5,'tupletBracketThickness':0.1,'subBracketThickness':0.5,"
+      "'bracketThickness':0.5,'repeatEndingLineThickness':0.15}}";
 
 //----------------------------------------------------------------------------
 // Option
@@ -196,7 +197,7 @@ bool OptionDbl::SetValue(double value)
         return false;
     }
     m_value = value;
-    m_isSet =  true;
+    m_isSet = true;
     return true;
 }
 
@@ -318,7 +319,7 @@ bool OptionArray::SetValue(const std::string &value)
     // Passing a single value to an array option adds it to the values and to not replace them
     if (!value.empty()) {
         m_values.push_back(value);
-        m_isSet =  true;
+        m_isSet = true;
     }
     return true;
 }
@@ -537,15 +538,14 @@ int OptionJson::GetIntValue(const std::vector<std::string> &jsonNodePath, bool g
 
 double OptionJson::GetDoubleValue(const std::vector<std::string> &jsonNodePath, bool getDefault) const
 {
-    JsonPath path = getDefault ? StringPath2NodePath(m_defaultValues, jsonNodePath)
-                               : StringPath2NodePath(m_values, jsonNodePath);
+    JsonPath path
+        = getDefault ? StringPath2NodePath(m_defaultValues, jsonNodePath) : StringPath2NodePath(m_values, jsonNodePath);
 
     if (path.size() != jsonNodePath.size() && !getDefault) {
         path = StringPath2NodePath(m_defaultValues, jsonNodePath);
     }
 
-    if (path.size() != jsonNodePath.size() || !path.back().get().is<jsonxx::Number>())
-        return 0;
+    if (path.size() != jsonNodePath.size() || !path.back().get().is<jsonxx::Number>()) return 0;
 
     return path.back().get().get<jsonxx::Number>();
 }
@@ -586,8 +586,7 @@ OptionJson::JsonPath OptionJson::StringPath2NodePath(
         else if (val.is<jsonxx::Array>()) {
             try {
                 const int index = std::stoi(*iter);
-                if (!val.get<jsonxx::Array>().has<jsonxx::Value>(index))
-                    break;
+                if (!val.get<jsonxx::Array>().has<jsonxx::Value>(index)) break;
 
                 path.push_back(val.get<jsonxx::Array>().get<jsonxx::Value>(index));
             }
@@ -841,7 +840,8 @@ Options::Options()
     m_ledgerLineThickness.Init(0.15, 0.10, 0.30);
     this->Register(&m_ledgerLineThickness, "ledgerLineThickness", &m_generalLayout);
 
-    m_ledgerLineExtension.SetInfo("Ledger line extension", "The amount by which a ledger line should extend either side of a notehead");
+    m_ledgerLineExtension.SetInfo(
+        "Ledger line extension", "The amount by which a ledger line should extend either side of a notehead");
     m_ledgerLineExtension.Init(0.20, 0.10, 0.50);
     this->Register(&m_ledgerLineExtension, "ledgerLineExtension", &m_generalLayout);
 
@@ -877,8 +877,7 @@ Options::Options()
     m_measureNumber.Init(MEASURENUMBER_system, &Option::s_measureNumber);
     this->Register(&m_measureNumber, "measureNumber", &m_generalLayout);
 
-    m_repeatEndingLineThickness.SetInfo(
-        "Repeat ending line thickness", "Repeat and ending line thickness");
+    m_repeatEndingLineThickness.SetInfo("Repeat ending line thickness", "Repeat and ending line thickness");
     m_repeatEndingLineThickness.Init(0.15, 0.1, 2.0);
     this->Register(&m_repeatEndingLineThickness, "repeatEndingLineThickness", &m_generalLayout);
 
@@ -1223,22 +1222,14 @@ void Options::Sync()
 {
     if (!m_engravingDefaults.isSet()) return;
     // override default or passed engravingDefaults with explicitly set values
-    std::list<std::pair<std::string, OptionDbl *>> engravingDefaults
-        = { { "staffLineThickness", &m_staffLineWidth },
-            { "stemThickness", &m_stemWidth },
-            { "legerLineThickness", &m_ledgerLineThickness },
-            { "legerLineExtension", &m_ledgerLineExtension },
-            { "slurMidpointThickness", &m_slurThickness },
-            { "tieMidpointThickness", &m_tieThickness },
-            { "thinBarlineThickness", &m_barLineWidth },
-            { "thickBarlineThickness", &m_thickBarlineThickness },
-            { "bracketThickness", &m_bracketThickness },
-            { "subBracketThickness", &m_subBracketThickness },
-            { "hairpinThickness", &m_hairpinThickness },
-            { "repeatEndingLineThickness", &m_repeatEndingLineThickness },
-            { "lyricLineThickness", &m_lyricLineThickness },
-            { "tupletBracketThickness", &m_tupletBracketThickness }
-    };
+    std::list<std::pair<std::string, OptionDbl *> > engravingDefaults = { { "staffLineThickness", &m_staffLineWidth },
+        { "stemThickness", &m_stemWidth }, { "legerLineThickness", &m_ledgerLineThickness },
+        { "legerLineExtension", &m_ledgerLineExtension }, { "slurMidpointThickness", &m_slurThickness },
+        { "tieMidpointThickness", &m_tieThickness }, { "thinBarlineThickness", &m_barLineWidth },
+        { "thickBarlineThickness", &m_thickBarlineThickness }, { "bracketThickness", &m_bracketThickness },
+        { "subBracketThickness", &m_subBracketThickness }, { "hairpinThickness", &m_hairpinThickness },
+        { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, { "lyricLineThickness", &m_lyricLineThickness },
+        { "tupletBracketThickness", &m_tupletBracketThickness } };
 
     for (auto &pair : engravingDefaults) {
         if (pair.second->isSet()) continue;

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -41,7 +41,7 @@ Trill::Trill()
     RegisterAttClass(ATT_NNUMBERLIKE);
     RegisterAttClass(ATT_ORNAMENTACCID);
     RegisterAttClass(ATT_PLACEMENT);
-    
+
     Reset();
 }
 
@@ -58,7 +58,6 @@ void Trill::Reset()
     ResetNNumberLike();
     ResetOrnamentAccid();
     ResetPlacement();
-    
 }
 
 wchar_t Trill::GetTrillGlyph() const

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -62,7 +62,7 @@ wchar_t Turn::GetTurnGlyph() const
         if (NULL != Resources::GetGlyph(code)) return code;
     }
 
-    return (GetForm() == turnLog_FORM_lower)? SMUFL_E568_ornamentTurnInverted : SMUFL_E567_ornamentTurn;
+    return (GetForm() == turnLog_FORM_lower) ? SMUFL_E568_ornamentTurnInverted : SMUFL_E567_ornamentTurn;
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -207,7 +207,7 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 }
 
 void View::DrawBeamSegment(DeviceContext *dc, BeamSegment *beamSegment, BeamDrawingInterface *beamInterface,
-                           Layer *layer, Staff *staff, Measure *measure)
+    Layer *layer, Staff *staff, Measure *measure)
 {
     assert(dc);
     assert(beamSegment);
@@ -300,7 +300,7 @@ void View::DrawBeamSegment(DeviceContext *dc, BeamSegment *beamSegment, BeamDraw
                 int nextIdx = noteIndexes.at(i + 1);
 
                 bool breakSec = (beamElementCoords.at(idx)->m_breaksec
-                                 && (testDur - DUR_8 >= beamElementCoords.at(idx)->m_breaksec));
+                    && (testDur - DUR_8 >= beamElementCoords.at(idx)->m_breaksec));
                 beamElementCoords.at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_NONE;
                 // partial is needed
                 if (beamElementCoords.at(idx)->m_dur >= (char)testDur) {
@@ -322,7 +322,7 @@ void View::DrawBeamSegment(DeviceContext *dc, BeamSegment *beamSegment, BeamDraw
                             }
                             // if the previous level underneath was a partial through, put it left
                             else if (beamElementCoords.at(noteIndexes.at(i - 1))->m_partialFlags[testDur - 1 - DUR_8]
-                                     == PARTIAL_THROUGH) {
+                                == PARTIAL_THROUGH) {
                                 beamElementCoords.at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_LEFT;
                             }
                             // if the level underneath was not left (right or through), put it right
@@ -350,8 +350,7 @@ void View::DrawBeamSegment(DeviceContext *dc, BeamSegment *beamSegment, BeamDraw
             // partial is needed
             if ((beamElementCoords.at(idx)->m_dur >= (char)testDur)) {
                 // and the previous one had no partial - put it left
-                if ((noteCount == 1) || (beamElementCoords.at(noteIndexes.at(i - 1))->m_dur < (char)testDur)
-                    || start) {
+                if ((noteCount == 1) || (beamElementCoords.at(noteIndexes.at(i - 1))->m_dur < (char)testDur) || start) {
                     beamElementCoords.at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_LEFT;
                 }
             }
@@ -367,7 +366,7 @@ void View::DrawBeamSegment(DeviceContext *dc, BeamSegment *beamSegment, BeamDraw
                     y2 = beamElementCoords.at(noteIndexes.at(i + 1))->m_yBeam + barY;
                     polygonHeight = beamInterface->m_beamWidthBlack * shiftY;
                     DrawObliquePolygon(dc, beamElementCoords.at(idx)->m_x, y1,
-                                       beamElementCoords.at(noteIndexes.at(i + 1))->m_x, y2, polygonHeight);
+                        beamElementCoords.at(noteIndexes.at(i + 1))->m_x, y2, polygonHeight);
                 }
                 else if (beamElementCoords.at(idx)->m_partialFlags[testDur - DUR_8] == PARTIAL_RIGHT) {
                     y1 = beamElementCoords.at(idx)->m_yBeam + barY;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2432,7 +2432,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
             continue;
         }
 
-        int y1 = ending->GetDrawingY();
+        const int y1 = ending->GetDrawingY();
 
         FontInfo currentFont = *m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize);
         // currentFont.SetWeight(FONTWEIGHT_bold);
@@ -2470,15 +2470,16 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
 
         dc->ResetFont();
 
-        int y2 = y1 + extend.m_height + m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize) * 2 / 3;
+        const int y2 = y1 + extend.m_height + m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize) * 2 / 3;
+        const int lineWidth = m_options->m_repeatEndingLineThickness.GetValue() * m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize);
 
-        DrawFilledRectangle(dc, x1, y2, x2, y2 + m_doc->GetDrawingBarLineWidth((*staffIter)->m_drawingStaffSize));
+        DrawFilledRectangle(dc, x1, y2, x2, y2 + lineWidth);
         if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
-            DrawFilledRectangle(dc, x1, y1, x1 + m_doc->GetDrawingBarLineWidth((*staffIter)->m_drawingStaffSize), y2);
+            DrawFilledRectangle(dc, x1, y1, x1 + lineWidth, y2);
         }
         if (((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END))
             && (ending->GetLendsym() != LINESTARTENDSYMBOL_none)) {
-            DrawFilledRectangle(dc, x2 - m_doc->GetDrawingBarLineWidth((*staffIter)->m_drawingStaffSize), y1, x2, y2);
+            DrawFilledRectangle(dc, x2 - lineWidth, y1, x2, y2);
         }
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2471,7 +2471,8 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         dc->ResetFont();
 
         const int y2 = y1 + extend.m_height + m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize) * 2 / 3;
-        const int lineWidth = m_options->m_repeatEndingLineThickness.GetValue() * m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize);
+        const int lineWidth = m_options->m_repeatEndingLineThickness.GetValue()
+            * m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize);
 
         DrawFilledRectangle(dc, x1, y2, x2, y2 + lineWidth);
         if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -490,20 +490,20 @@ void View::DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize)
 {
     assert(dc);
 
-    int x1, x2, offset;
+    const int offset = m_doc->GetDrawingStaffLineWidth(staffSize) / 2;
+    const int beamWidth = m_doc->GetDrawingBeamWidth(staffSize, false);
 
     const int bracketThickness = m_doc->GetDrawingUnit(staffSize) * m_options->m_bracketThickness.GetValue();
 
-    x2 = x - bracketThickness;
-    x1 = x2 - bracketThickness;
-    offset = m_doc->GetDrawingStaffLineWidth(staffSize) / 2;
+    const int x2 = x - bracketThickness;
+    const int x1 = x2 - bracketThickness;
 
     dc->StartCustomGraphic("grpSym");
 
-    DrawSmuflCode(dc, x1, y1 + offset, SMUFL_E003_bracketTop, staffSize, false);
-    DrawSmuflCode(dc, x1, y2 - offset, SMUFL_E004_bracketBottom, staffSize, false);
+    DrawSmuflCode(dc, x1, y1 + offset + bracketThickness/2, SMUFL_E003_bracketTop, staffSize, false);
+    DrawSmuflCode(dc, x1, y2 - offset - bracketThickness/2, SMUFL_E004_bracketBottom, staffSize, false);
 
-    DrawFilledRectangle(dc, x1, y1 + 2 * offset, x2, y2 - 2 * offset);
+    DrawFilledRectangle(dc, x1, y1 + 2 * offset + beamWidth / 2, x2, y2 - 2 * offset - beamWidth / 2);
 
     dc->EndCustomGraphic();
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -337,7 +337,7 @@ void View::DrawStaffGrp(
         && ((((firstDef != lastDef) || staffGrp->HasSymbol())
                 && (m_doc->m_mdivScoreDef.GetSystemLeftline() != BOOLEAN_false))
             || (m_doc->m_mdivScoreDef.GetSystemLeftline() == BOOLEAN_true))) {
-        //int barLineWidth = m_doc->GetDrawingElementDefaultSize("bracketThickness", staffSize);
+        // int barLineWidth = m_doc->GetDrawingElementDefaultSize("bracketThickness", staffSize);
         int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
         x += barLineWidth / 2;
         DrawVerticalLine(dc, yTop, yBottom, x, barLineWidth);
@@ -500,8 +500,8 @@ void View::DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize)
 
     dc->StartCustomGraphic("grpSym");
 
-    DrawSmuflCode(dc, x1, y1 + offset + bracketThickness/2, SMUFL_E003_bracketTop, staffSize, false);
-    DrawSmuflCode(dc, x1, y2 - offset - bracketThickness/2, SMUFL_E004_bracketBottom, staffSize, false);
+    DrawSmuflCode(dc, x1, y1 + offset + bracketThickness / 2, SMUFL_E003_bracketTop, staffSize, false);
+    DrawSmuflCode(dc, x1, y2 - offset - bracketThickness / 2, SMUFL_E004_bracketBottom, staffSize, false);
 
     DrawFilledRectangle(dc, x1, y1 + 2 * offset + beamWidth / 2, x2, y2 - 2 * offset - beamWidth / 2);
 


### PR DESCRIPTION
This PR 
* improves drawing of staffGrp brackets, so that the glyphs won't touch the staff
* adds support for repeatEndingLineThickness from engravingDefaults
* sorts engraving defaults in Sync(), following the list in https://w3c.github.io/smufl/gitbook/specification/engravingdefaults.html
