### PR TITLE
Separate slurs if they have common point

### DIFF
--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -269,8 +269,8 @@ public:
     /**
      * Moves bounding points vertically by a specified distance downward
     */
-    void MoveFrontDownward(int distance);
-    void MoveBackDownward(int distance);
+    void MoveFrontVertical(int distance);
+    void MoveBackVertical(int distance);
 
     /**
      * Calculate the min or max Y for a set of points

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -267,6 +267,12 @@ public:
     void UpdateCurveParams(const Point points[4], float angle, int thickness, curvature_CURVEDIR curveDir);
 
     /**
+     * Moves bounding points vertically by a specified distance downward
+    */
+    void MoveFrontDownward(int distance);
+    void MoveBackDownward(int distance);
+
+    /**
      * Calculate the min or max Y for a set of points
      */
     int CalcMinMaxY(const Point points[4]);
@@ -281,7 +287,7 @@ public:
      * @name Getters for the current parameters
      */
     ///@{
-    void GetPoints(Point points[4]);
+    void GetPoints(Point points[4]) const;
     float GetAngle() { return m_angle; }
     int GetThickness() { return m_thickness; }
     curvature_CURVEDIR GetDir() { return m_dir; }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -463,16 +463,16 @@ void FloatingCurvePositioner::UpdateCurveParams(
     m_cachedMinMaxY = VRV_UNSET;
 }
 
-void FloatingCurvePositioner::MoveFrontDownward(int distance)
+void FloatingCurvePositioner::MoveFrontVertical(int distance)
 {
-    m_points[0].y -= distance;
-    m_points[1].y -= distance;
+    m_points[0].y += distance;
+    m_points[1].y += distance;
 }
 
-void FloatingCurvePositioner::MoveBackDownward(int distance)
+void FloatingCurvePositioner::MoveBackVertical(int distance)
 {
-    m_points[2].y -= distance;
-    m_points[3].y -= distance;
+    m_points[2].y += distance;
+    m_points[3].y += distance;
 }
 
 int FloatingCurvePositioner::CalcMinMaxY(const Point points[4])

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -463,6 +463,18 @@ void FloatingCurvePositioner::UpdateCurveParams(
     m_cachedMinMaxY = VRV_UNSET;
 }
 
+void FloatingCurvePositioner::MoveFrontDownward(int distance)
+{
+    m_points[0].y -= distance;
+    m_points[1].y -= distance;
+}
+
+void FloatingCurvePositioner::MoveBackDownward(int distance)
+{
+    m_points[2].y -= distance;
+    m_points[3].y -= distance;
+}
+
 int FloatingCurvePositioner::CalcMinMaxY(const Point points[4])
 {
     assert(this->GetObject());
@@ -586,7 +598,7 @@ int FloatingCurvePositioner::CalcAdjustment(BoundingBox *boundingBox, bool &disc
     }
 }
 
-void FloatingCurvePositioner::GetPoints(Point points[4])
+void FloatingCurvePositioner::GetPoints(Point points[4]) const
 {
     points[0] = m_points[0];
     points[1] = m_points[1];

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -792,14 +792,14 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
 
     std::vector<FloatingCurvePositioner *> positioners;
     ArrayOfFloatingPositioners::iterator iter;
-    for (FloatingPositioner* iter:m_floatingPositioners) {
-        assert(iter->GetObject());
-        if (!iter->GetObject()->Is({PHRASE, SLUR})) continue;
-        Slur* slur = vrv_cast<Slur*>(iter->GetObject());
+    for (FloatingPositioner *positioner : m_floatingPositioners) {
+        assert(positioner->GetObject());
+        if (!positioner->GetObject()->Is({PHRASE, SLUR})) continue;
+        Slur* slur = vrv_cast<Slur*>(positioner->GetObject());
         assert(slur);
 
-        assert(iter->Is(FLOATING_CURVE_POSITIONER));
-        FloatingCurvePositioner* curve = vrv_cast<FloatingCurvePositioner*>(iter);
+        assert(positioner->Is(FLOATING_CURVE_POSITIONER));
+        FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner*>(positioner);
         assert(curve);
 
         // Skip if no content bounding box is available
@@ -812,12 +812,12 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
         }
     }
 
-    auto staff = GetStaff();
+    Staff *staff = GetStaff();
     if (staff) {
         const int slurShift = staff->m_drawingStaffSize / 2;
-        for (size_t i = 0; i+1<positioners.size(); i++) {
+        for (size_t i = 0; i + 1 < positioners.size(); i++) {
             Slur* firstSlur = vrv_cast<Slur*>(positioners[i]->GetObject());
-            for (auto j = i+1; j<positioners.size(); j++) {
+            for (auto j = i + 1; j < positioners.size(); j++) {
                 Slur* secondSlur = vrv_cast<Slur*>(positioners[j]->GetObject());
                 Point points1[4], points2[4];
                 positioners[i]->GetPoints(points1);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -791,15 +791,14 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
     assert(params);
 
     std::vector<FloatingCurvePositioner *> positioners;
-    ArrayOfFloatingPositioners::iterator iter;
     for (FloatingPositioner *positioner : m_floatingPositioners) {
         assert(positioner->GetObject());
         if (!positioner->GetObject()->Is({PHRASE, SLUR})) continue;
-        Slur* slur = vrv_cast<Slur*>(positioner->GetObject());
+        Slur *slur = vrv_cast<Slur *>(positioner->GetObject());
         assert(slur);
 
         assert(positioner->Is(FLOATING_CURVE_POSITIONER));
-        FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner*>(positioner);
+        FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(positioner);
         assert(curve);
 
         // Skip if no content bounding box is available
@@ -816,9 +815,9 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
     if (staff) {
         const int slurShift = staff->m_drawingStaffSize / 2;
         for (size_t i = 0; i + 1 < positioners.size(); i++) {
-            Slur* firstSlur = vrv_cast<Slur*>(positioners[i]->GetObject());
+            Slur *firstSlur = vrv_cast<Slur *>(positioners[i]->GetObject());
             for (auto j = i + 1; j < positioners.size(); j++) {
-                Slur* secondSlur = vrv_cast<Slur*>(positioners[j]->GetObject());
+                Slur *secondSlur = vrv_cast<Slur *>(positioners[j]->GetObject());
                 Point points1[4], points2[4];
                 positioners[i]->GetPoints(points1);
                 positioners[j]->GetPoints(points2);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -822,9 +822,11 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
                 positioners[i]->GetPoints(points1);
                 positioners[j]->GetPoints(points2);
                 if (firstSlur->GetStart() == secondSlur->GetStart()) {
-                    positioners[points1[2].x > points2[2].x ? i : j]->MoveFrontDownward(slurShift);
+                    FloatingCurvePositioner *positioner = positioners[points1[2].x > points2[2].x ? i : j];
+                    positioner->MoveFrontVertical(positioner->GetDir() == curvature_CURVEDIR_below ? -slurShift : slurShift);
                 } else if (firstSlur->GetEnd() == secondSlur->GetEnd()) {
-                    positioners[points1[0].x < points2[0].x ? i : j]->MoveBackDownward(slurShift);
+                    FloatingCurvePositioner *positioner = positioners[points1[0].x < points2[0].x ? i : j];
+                    positioner->MoveBackVertical(positioner->GetDir() == curvature_CURVEDIR_below ? -slurShift : slurShift);
                 }
             }
         }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -790,23 +790,44 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
     AdjustSlursParams *params = vrv_params_cast<AdjustSlursParams *>(functorParams);
     assert(params);
 
+    std::vector<FloatingCurvePositioner *> positioners;
     ArrayOfFloatingPositioners::iterator iter;
-    for (iter = m_floatingPositioners.begin(); iter != m_floatingPositioners.end(); ++iter) {
-        assert((*iter)->GetObject());
-        if (!(*iter)->GetObject()->Is({ PHRASE, SLUR })) continue;
-        Slur *slur = vrv_cast<Slur *>((*iter)->GetObject());
+    for (FloatingPositioner* iter:m_floatingPositioners) {
+        assert(iter->GetObject());
+        if (!iter->GetObject()->Is({PHRASE, SLUR})) continue;
+        Slur* slur = vrv_cast<Slur*>(iter->GetObject());
         assert(slur);
 
-        assert((*iter)->Is(FLOATING_CURVE_POSITIONER));
-        FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(*iter);
+        assert(iter->Is(FLOATING_CURVE_POSITIONER));
+        FloatingCurvePositioner* curve = vrv_cast<FloatingCurvePositioner*>(iter);
         assert(curve);
 
         // Skip if no content bounding box is available
         if (!curve->HasContentBB()) continue;
+        positioners.push_back(curve);
 
         bool adjusted = slur->AdjustSlur(params->m_doc, curve, this->GetStaff());
         if (adjusted) {
             params->m_adjusted = true;
+        }
+    }
+
+    auto staff = GetStaff();
+    if (staff) {
+        const int slurShift = staff->m_drawingStaffSize / 2;
+        for (size_t i = 0; i+1<positioners.size(); i++) {
+            Slur* firstSlur = vrv_cast<Slur*>(positioners[i]->GetObject());
+            for (auto j = i+1; j<positioners.size(); j++) {
+                Slur* secondSlur = vrv_cast<Slur*>(positioners[j]->GetObject());
+                Point points1[4], points2[4];
+                positioners[i]->GetPoints(points1);
+                positioners[j]->GetPoints(points2);
+                if (firstSlur->GetStart() == secondSlur->GetStart()) {
+                    positioners[points1[2].x > points2[2].x ? i : j]->MoveFrontDownward(slurShift);
+                } else if (firstSlur->GetEnd() == secondSlur->GetEnd()) {
+                    positioners[points1[0].x < points2[0].x ? i : j]->MoveBackDownward(slurShift);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If two slurs have a common note (firs or last) corresponding curves touch each other. The purpose of this commit recognize this situation and move one of these curves a little bit lower. The situation when more than two slurs have such intersection is not considered.