### PR TITLE
Add support for newly added piano glyphs to MusicXML import

### DIFF
--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -61,6 +61,11 @@ public:
     void EndsWithBounce(bool endsWithBounce) { m_endsWithBounce = endsWithBounce; }
     ///@}
 
+    /**
+     * Get the SMuFL glyph for the pedal based on function or glyph.num
+     */
+    wchar_t GetPedalGlyph() const;
+                  
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -52,7 +52,7 @@ public:
     ///@}
 
     /**
-     * Get the SMuFL glyph for the trun based on form or glyph.num
+     * Get the SMuFL glyph for the turn based on form or glyph.num
      */
     wchar_t GetTurnGlyph() const;
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2022,7 +2022,17 @@ void MusicXmlInput::ReadMusicXmlDirection(
             if (!placeStr.empty()) pedal->SetPlace(pedal->AttPlacement::StrToStaffrel(placeStr.c_str()));
             pedal->SetDir(ConvertPedalTypeToDir(pedalType));
             if (pedalLine) pedal->SetForm(pedalVis_FORM_line);
-            if (pedalType == "sostenuto") pedal->SetFunc("sostenuto");
+            if (xmlPedal.node().attribute("abbreviated")) {
+                pedal->SetExternalsymbols(pedal, "glyph.auth", "smufl");
+                pedal->SetExternalsymbols(pedal, "glyph.num", "U+E651");
+            }
+            if (pedalType == "sostenuto") {
+                pedal->SetFunc("sostenuto");
+                if (xmlPedal.node().attribute("abbreviated")) {
+                    pedal->SetExternalsymbols(pedal, "glyph.auth", "smufl");
+                    pedal->SetExternalsymbols(pedal, "glyph.num", "U+E65A");
+                }
+            }
             pugi::xpath_node staffNode = node.select_node("staff");
             if (staffNode) {
                 pedal->SetStaff(pedal->AttStaffIdent::StrToXsdPositiveIntegerList(

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2917,8 +2917,8 @@ void MusicXmlInput::ReadMusicXmlNote(
         // place
         mordent->SetPlace(
             mordent->AttPlacement::StrToStaffrel(xmlExtOrnament.node().attribute("placement").as_string()));
-        bool isHaydn = std::string(xmlExtOrnament.node().name()) == "haydn";
-        mordent->SetExternalsymbols(mordent, "glyph.num", isHaydn ? "U+E56F" : "U+E5B0");
+        const bool isHaydn = std::string(xmlExtOrnament.node().name()) == "haydn";
+        mordent->SetExternalsymbols(mordent, "glyph.num", isHaydn ? "U+E56F" : "U+E587");
         mordent->SetExternalsymbols(mordent, "glyph.auth", "smufl");
     }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2043,7 +2043,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
             }
             pedal->SetTstamp(timeStamp);
-            if (pedalLine && (pedalType == "stop")) pedal->SetTstamp(timeStamp - 0.1);
+            if (pedalType == "stop") pedal->SetTstamp(timeStamp - 0.1);
             int defaultY = xmlPedal.node().attribute("default-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -16,6 +16,7 @@
 #include "functorparams.h"
 #include "horizontalaligner.h"
 #include "layerelement.h"
+#include "smufl.h"
 #include "vrv.h"
 
 //----------------------------------------------------------------------------
@@ -63,6 +64,17 @@ void Pedal::Reset()
     ResetVerticalGroup();
 
     m_endsWithBounce = false;
+}
+
+wchar_t Pedal::GetPedalGlyph() const
+{
+    // If there is glyph.num, prioritize it, otherwise check other attributes
+    if (HasGlyphNum()) {
+        wchar_t code = GetGlyphNum();
+        if (NULL != Resources::GetGlyph(code)) return code;
+    }
+
+    return (GetFunc() == "sostenuto") ? SMUFL_E659_keyboardPedalSost : SMUFL_E650_keyboardPedalPed;
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1990,20 +1990,11 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
         if (bounceStar && (pedal->GetDir() == pedalLog_DIR_bounce)) {
             str.push_back(code);
             // Get the staff size of the first staff
-            int staffSize = (staffList.begin() != staffList.end()) ? (*staffList.begin())->m_drawingStaffSize : 100;
-            TextExtend bounceOffset;
-            dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, false));
-            dc->GetSmuflTextExtent(str, &bounceOffset);
-            dc->ResetFont();
-            x -= bounceOffset.m_width;
+            const int staffSize = (staffList.begin() != staffList.end()) ? (*staffList.begin())->m_drawingStaffSize : 100;
+            x -= m_doc->GetGlyphWidth(SMUFL_E655_keyboardPedalUp, staffSize, false);
         }
         if (pedal->GetDir() != pedalLog_DIR_up) {
-            if (pedal->GetFunc() == "sostenuto") {
-                code = SMUFL_E659_keyboardPedalSost;
-            }
-            else {
-                code = SMUFL_E650_keyboardPedalPed;
-            }
+            code = pedal->GetPedalGlyph();
         }
         str.push_back(code);
 
@@ -2012,7 +2003,7 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
                 continue;
             }
             // Basic method that use bounding box
-            int y = pedal->GetDrawingY();
+            const int y = pedal->GetDrawingY();
 
             dc->SetFont(m_doc->GetDrawingSmuflFont((*staffIter)->m_drawingStaffSize, false));
             DrawSmuflString(dc, x, y, str, alignment, (*staffIter)->m_drawingStaffSize);


### PR DESCRIPTION
This PR adds: 
* support for drawing glyph.num with pedal
* import of "abbreviated" piano pedal glyphs from MusicXML
* minor fixes and refinements

![pedalps](https://user-images.githubusercontent.com/7693447/93199272-7a532300-f74e-11ea-8211-77a2739ae6f2.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Single glyph piano pedal glyphs</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">eNote GmbH</corpName>
            </respStmt>
            <date isodate="2020">2020</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>To use single character glyphs for piano pedals Verovio supports the @glyph.num attribute.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <pb />
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                        </layer>
                     </staff>
                     <pedal staff="1" tstamp="1" glyph.auth="smufl" glyph.num="U+E651" dir="down" place="below" />
                     <pedal staff="1" tstamp="4" dir="up" place="below" />
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                        </layer>
                     </staff>
                     <pedal staff="1" tstamp="1" glyph.auth="smufl" glyph.num="U+E65A" dir="down" func="sostenuto" place="below" />
                     <pedal staff="1" tstamp="4" dir="up" place="below" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

I'll add this test file to Verovio website.