### PR TITLE
Fix support for legerLineExtension and legerLineThickness

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -877,14 +877,13 @@ int Note::CalcLedgerLines(FunctorParams *functorParams)
 
     if (!this->HasLedgerLines(linesAbove, linesBelow, staff)) return FUNCTOR_CONTINUE;
 
-    // HARDCODED
     const int ledgerLineExtension
         = params->m_doc->GetOptions()->m_ledgerLineExtension.GetValue() * params->m_doc->GetDrawingUnit(staffSize);
-    int leftExtender = 2.5 * ledgerLineExtension;
-    int rightExtender = 2.5 * ledgerLineExtension;
+    int leftExtender = ledgerLineExtension;
+    int rightExtender = ledgerLineExtension;
     if (drawingCueSize || (this->GetDrawingDur() >= DUR_8)) {
-        leftExtender = 1.75 * ledgerLineExtension;
-        rightExtender = 1.25 * ledgerLineExtension;
+        leftExtender = 0.7 * ledgerLineExtension;
+        rightExtender = 0.5 * ledgerLineExtension;
     }
 
     if (drawingCueSize) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -833,12 +833,12 @@ Options::Options()
     this->Register(&m_justificationBraceGroup, "justificationBraceGroup", &m_generalLayout);
 
     m_ledgerLineThickness.SetInfo("Ledger line thickness", "The thickness of the ledger lines");
-    m_ledgerLineThickness.Init(0.15, 0.10, 0.30);
+    m_ledgerLineThickness.Init(0.25, 0.10, 0.50);
     this->Register(&m_ledgerLineThickness, "ledgerLineThickness", &m_generalLayout);
 
     m_ledgerLineExtension.SetInfo(
         "Ledger line extension", "The amount by which a ledger line should extend either side of a notehead");
-    m_ledgerLineExtension.Init(0.20, 0.10, 0.50);
+    m_ledgerLineExtension.Init(0.54, 0.20, 1.00);
     this->Register(&m_ledgerLineExtension, "ledgerLineExtension", &m_generalLayout);
 
     m_lyricHyphenLength.SetInfo("Lyric hyphen length", "The lyric hyphen and dash length");
@@ -945,7 +945,7 @@ Options::Options()
     this->Register(&m_stemWidth, "stemWidth", &m_generalLayout);
 
     m_subBracketThickness.SetInfo("Sub bracket thickness", "The thickness of system sub-bracket");
-    m_subBracketThickness.Init(1.0, 0.5, 2.0);
+    m_subBracketThickness.Init(1.0, 0.3, 2.0);
     this->Register(&m_subBracketThickness, "subBracketThickness", &m_generalLayout);
 
     m_systemDivider.SetInfo("System divider", "The display of system dividers");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -945,7 +945,7 @@ Options::Options()
     this->Register(&m_stemWidth, "stemWidth", &m_generalLayout);
 
     m_subBracketThickness.SetInfo("Sub bracket thickness", "The thickness of system sub-bracket");
-    m_subBracketThickness.Init(1.0, 0.3, 2.0);
+    m_subBracketThickness.Init(1.0, 0.2, 2.0);
     this->Register(&m_subBracketThickness, "subBracketThickness", &m_generalLayout);
 
     m_systemDivider.SetInfo("System divider", "The display of system dividers");

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1107,7 +1107,7 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, ArrayOfLedgerLines *
 
     int lineWidth
         = m_doc->GetOptions()->m_ledgerLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (cueSize) lineWidth *= 0.75;
+    if (cueSize) lineWidth *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
     dc->SetPen(m_currentColour, ToDeviceContextX(lineWidth), AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1105,10 +1105,9 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, ArrayOfLedgerLines *
 
     dc->StartCustomGraphic("ledgerLines", gClass);
 
-    const int optionLedgerWidth
+    int lineWidth
         = m_doc->GetOptions()->m_ledgerLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    int lineWidth = optionLedgerWidth * 1.75;
-    if (cueSize) lineWidth = optionLedgerWidth * 1.25;
+    if (cueSize) lineWidth *= 0.75;
 
     dc->SetPen(m_currentColour, ToDeviceContextX(lineWidth), AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);


### PR DESCRIPTION
The given values for ledger lines weren't handled correctly. This PR fixes this issue and allows smaller values for `subBracketThickness` to fully support engraving defaults for Bravura. 

NB: Interestingly engravingDefaults for all fonts included in Verovio have "legerLineExtension" set to 0.4 which seems really large. E.g. MuseScore doesn't use this value (correctly?) and shortens the ledger lines, only Dorico works as expected. Verovio's default value was/is 0.27 (or 0.54vu). So I think, that the corresponding value in Leipzig's metadata.json should be adapted to this. 