### PR TITLE
fix logic on arpeg with arrow

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1363,6 +1363,8 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
         angle = 90;
     }
 
+    if (arpeg->GetArrowShape() == LINESTARTENDSYMBOL_none) endGlyph = 0;
+
     Point orig(x, y);
 
     dc->StartGraphic(arpeg, "", arpeg->GetUuid());

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1353,13 +1353,13 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
     int angle = -90;
 
     wchar_t fillGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
-    wchar_t endGlyph = (arpeg->GetArrow()) ? SMUFL_EAAD_wiggleArpeggiatoUpArrow : 0;
+    wchar_t endGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAD_wiggleArpeggiatoUpArrow : 0;
 
     if (arpeg->GetOrder() == arpegLog_ORDER_down) {
         y = top + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         x -= m_doc->GetGlyphWidth(SMUFL_EAAA_wiggleArpeggiatoDown, staff->m_drawingStaffSize, drawingCueSize) / 2;
         fillGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
-        endGlyph = (arpeg->GetArrow()) ? SMUFL_EAAE_wiggleArpeggiatoDownArrow : 0;
+        endGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAE_wiggleArpeggiatoDownArrow : 0;
         angle = 90;
     }
 

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -224,14 +224,16 @@ void View::DrawSmuflLine(
 {
     assert(dc);
 
-    int startWidth = (start == 0) ? 0 : m_doc->GetGlyphAdvX(start, staffSize, dimin);
-    int fillWidth = m_doc->GetGlyphAdvX(fill, staffSize, dimin);
-    int endWidth = (end == 0) ? 0 : m_doc->GetGlyphAdvX(end, staffSize, dimin);
-
     if (length <= 0) return;
 
+    const int startWidth = (start == 0) ? 0 : m_doc->GetGlyphAdvX(start, staffSize, dimin);
+    const int endWidth = (end == 0) ? 0 : m_doc->GetGlyphAdvX(end, staffSize, dimin);
+    int fillWidth = m_doc->GetGlyphAdvX(fill, staffSize, dimin);
+
+    if (fillWidth == 0) fillWidth = m_doc->GetGlyphWidth(fill, staffSize, dimin);
+
     // We add half a fill length for an average shorter / longer line result
-    int count = (length + fillWidth / 2 - startWidth - endWidth) / fillWidth;
+    const int count = (length + fillWidth / 2 - startWidth - endWidth) / fillWidth;
 
     dc->SetBrush(m_currentColour, AxSOLID);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
@@ -242,8 +244,7 @@ void View::DrawSmuflLine(
         str.push_back(start);
     }
 
-    int i;
-    for (i = 0; i < count; ++i) {
+    for (int i = 0; i < count; ++i) {
         str.push_back(fill);
     }
 


### PR DESCRIPTION
There was a small problem with the `@arrow` attribute on `<arpeg>`.

Before: 
![arpeggios](https://user-images.githubusercontent.com/7693447/93781132-55b4ea80-fc29-11ea-8d38-7da71d015437.png)

After:
![arpeggios new](https://user-images.githubusercontent.com/7693447/93781141-59e10800-fc29-11ea-82f6-3606f417f46f.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei meiversion="4.0.1" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Arpeggios with and without arrows</title>
            </titleStmt>
            <pubStmt />
        </fileDesc>
        <encodingDesc></encodingDesc>
    </meiHead>
    <music xml:id="m-23">
        <body xml:id="m-24">
            <mdiv xml:id="m-25">
                <score xml:id="m-27">
                    <scoreDef xml:id="m-28" meter.count="4" meter.unit="4" page.botmar="12.7mm" page.height="297mm" page.leftmar="12.7mm" page.rightmar="12.7mm" page.topmar="12.7mm" page.width="210mm">
                        <staffGrp xml:id="m-29">
                            <staffDef xml:id="m-30" clef.line="2" clef.shape="G" key.mode="major" lines="5" n="1" />
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="m-33">
                        <pb xml:id="m-22" />
                        <sb xml:id="m-35" />
                        <measure xml:id="m-34" label="1" n="1">
                            <staff xml:id="m-36" n="1">
                                <layer xml:id="m-37" n="1">
                                    <chord xml:id="m-38" dur="2" stem.dir="up">
                                        <note xml:id="m-39" dur="2" oct="4" pname="d" pnum="62" />
                                        <note xml:id="m-40" dur="2" oct="4" pname="f" pnum="65" />
                                        <note xml:id="m-41" dur="2" oct="5" pname="c" pnum="72" />
                                        <note xml:id="m-42" dur="2" oct="5" pname="e" pnum="76" />
                                    </chord>
                                    <chord xml:id="m-44" dur="2" stem.dir="up">
                                        <note xml:id="m-45" dur="2" oct="4" pname="d" pnum="63">
                                            <accid xml:id="m-46" accid="s" />
                                        </note>
                                        <note xml:id="m-47" dur="2" oct="4" pname="f" pnum="66">
                                            <accid xml:id="m-48" accid="s" />
                                        </note>
                                        <note xml:id="m-49" dur="2" oct="5" pname="c" pnum="73">
                                            <accid xml:id="m-50" accid="s" />
                                        </note>
                                        <note xml:id="m-51" dur="2" oct="5" pname="e" pnum="77">
                                            <accid xml:id="m-52" accid="s" />
                                        </note>
                                    </chord>
                                </layer>
                            </staff>
                            <arpeg xml:id="m-43" arrow="false" layer="1" staff="1" plist="#m-44" />
                            <arpeg xml:id="m-53" arrow="false" layer="1" staff="1" plist="#m-39 #m-40 #m-41 #m-42" />
                        </measure>
                        <measure xml:id="m-54" n="2" label="arpeggios with encoding errors">
                            <staff xml:id="m-55" n="1">
                                <layer xml:id="m-56" n="1">
                                    <chord xml:id="m-57" dur="2" stem.dir="up">
                                        <note xml:id="m-58" dur="2" oct="4" pname="d" pnum="62">
                                            <accid xml:id="m-59" accid="n" />
                                        </note>
                                        <note xml:id="m-60" dur="2" oct="4" pname="f" pnum="65">
                                            <accid xml:id="m-61" accid="n" />
                                        </note>
                                        <note xml:id="m-62" dur="2" oct="5" pname="c" pnum="72">
                                            <accid xml:id="m-63" accid="n" />
                                        </note>
                                        <note xml:id="m-64" dur="2" oct="5" pname="e" pnum="76">
                                            <accid xml:id="m-65" accid="n" />
                                        </note>
                                    </chord>
                                    <chord xml:id="m-67" dur="2" stem.dir="up">
                                        <note xml:id="m-68" dur="2" oct="4" pname="d" pnum="63">
                                            <accid xml:id="m-69" accid="s" />
                                        </note>
                                        <note xml:id="m-70" dur="2" oct="4" pname="f" pnum="66">
                                            <accid xml:id="m-71" accid="s" />
                                        </note>
                                        <note xml:id="m-72" dur="2" oct="5" pname="c" pnum="73">
                                            <accid xml:id="m-73" accid="s" />
                                        </note>
                                        <note xml:id="m-74" dur="2" oct="5" pname="e" pnum="77">
                                            <accid xml:id="m-75" accid="s" />
                                        </note>
                                    </chord>
                                </layer>
                            </staff>
                            <arpeg xml:id="m-66" arrow="true" layer="1" order="up" staff="1" startid="#m-58" />
                            <arpeg xml:id="m-76" arrow="true" layer="1" order="down" staff="1" startid="#nowhere" />
                        </measure>
                        <measure xml:id="m-77" n="3" right="end">
                            <staff xml:id="m-78" n="1">
                                <layer xml:id="m-79" n="1">
                                    <chord xml:id="m-80" dur="2" stem.dir="up">
                                        <note xml:id="m-81" dur="2" oct="4" pname="d" pnum="62">
                                            <accid xml:id="m-82" accid="n" />
                                        </note>
                                        <note xml:id="m-83" dur="2" oct="4" pname="f" pnum="65">
                                            <accid xml:id="m-84" accid="n" />
                                        </note>
                                        <note xml:id="m-85" dur="2" oct="5" pname="c" pnum="72">
                                            <accid xml:id="m-86" accid="n" />
                                        </note>
                                        <note xml:id="m-87" dur="2" oct="5" pname="e" pnum="76">
                                            <accid xml:id="m-88" accid="n" />
                                        </note>
                                    </chord>
                                    <chord xml:id="m-90" dur="2" stem.dir="up">
                                        <note xml:id="m-91" dur="2" oct="4" pname="d" pnum="63">
                                            <accid xml:id="m-92" accid="s" />
                                        </note>
                                        <note xml:id="m-93" dur="2" oct="4" pname="f" pnum="66">
                                            <accid xml:id="m-94" accid="s" />
                                        </note>
                                        <note xml:id="m-95" dur="2" oct="5" pname="c" pnum="73">
                                            <accid xml:id="m-96" accid="s" />
                                        </note>
                                        <note xml:id="m-97" dur="2" oct="5" pname="e" pnum="77">
                                            <accid xml:id="m-98" accid="s" />
                                        </note>
                                    </chord>
                                </layer>
                            </staff>
                            <arpeg xml:id="m-89" arrow="false" order="down" layer="1" staff="1" startid="#m-80" />
                            <arpeg xml:id="m-99" arrow="true" order="down" layer="1" staff="1" startid="#m-90" />
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
