### PR TITLE
improve tuplet drawing

### DIFF
--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -98,39 +98,43 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
     }
 
     data_STAFFREL_basic position = tuplet->GetDrawingBracketPos();
-    int lineWidth = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();
+    const int lineWidth
+        = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();
 
     dc->ResumeGraphic(tupletBracket, tupletBracket->GetUuid());
 
-    int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
-    int xRight = tuplet->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();
-    int yLeft = tupletBracket->GetDrawingYLeft() - lineWidth / 2;
-    int yRight = tupletBracket->GetDrawingYRight() - lineWidth / 2;
+    const int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
+    const int xRight = tuplet->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();
+    const int yLeft = tupletBracket->GetDrawingYLeft() - lineWidth / 2;
+    const int yRight = tupletBracket->GetDrawingYRight() - lineWidth / 2;
+    int bracketHeight;
 
     // Draw a bracked with a gap
     if (tupletBracket->GetAlignedNum() && tupletBracket->GetAlignedNum()->HasSelfBB()) {
-        int xNumLeft
+        const int xNumLeft
             = tupletBracket->GetAlignedNum()->GetSelfLeft() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-        int xNumRight
+        const int xNumRight
             = tupletBracket->GetAlignedNum()->GetSelfRight() + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-        double slope = (double)(yRight - yLeft) / (double)(xRight - xLeft);
-        int yNumLeft = yLeft + slope * (xNumLeft - xLeft);
+        const double slope = (double)(yRight - yLeft) / (double)(xRight - xLeft);
+        const int yNumLeft = yLeft + slope * (xNumLeft - xLeft);
         DrawObliquePolygon(dc, xLeft, yLeft, xNumLeft, yNumLeft, lineWidth);
-        int yNumRight = yRight - slope * (xRight - xNumRight);
+        const int yNumRight = yRight - slope * (xRight - xNumRight);
         DrawObliquePolygon(dc, xNumRight, yNumRight, xRight, yRight, lineWidth);
+        bracketHeight
+            = abs(tupletBracket->GetAlignedNum()->GetSelfTop() - tupletBracket->GetAlignedNum()->GetSelfBottom()) / 2;
     }
     else {
         DrawObliquePolygon(dc, xLeft, yLeft, xRight, yRight, lineWidth);
+        // HARDCODED
+        bracketHeight = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 6 / 5;
     }
 
-    // HARDCODED
-    int verticalLine = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 6 / 5;
     if (position == STAFFREL_basic_above) {
-        verticalLine *= -1;
+        bracketHeight *= -1;
     }
 
-    DrawFilledRectangle(dc, xLeft, yLeft, xLeft + lineWidth, yLeft + verticalLine);
-    DrawFilledRectangle(dc, xRight, yRight, xRight - lineWidth, yRight + verticalLine);
+    DrawFilledRectangle(dc, xLeft, yLeft, xLeft + lineWidth, yLeft + bracketHeight);
+    DrawFilledRectangle(dc, xRight, yRight, xRight - lineWidth, yRight + bracketHeight);
 
     dc->EndResumedGraphic(tupletBracket, this);
 
@@ -164,22 +168,22 @@ void View::DrawTupletNum(DeviceContext *dc, LayerElement *element, Layer *layer,
     TextExtend extend;
     std::wstring notes;
 
-    bool drawingCueSize = tuplet->GetDrawingCueSize();
+    const bool drawingCueSize = tuplet->GetDrawingCueSize();
     dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, drawingCueSize));
     notes = IntToTupletFigures((short int)tuplet->GetNum());
     if (tuplet->GetNumFormat() == tupletVis_NUMFORMAT_ratio) {
         notes.push_back(SMUFL_E88A_tupletColon);
-        notes = notes + IntToTupletFigures((short int)tuplet->GetNumbase());
+        notes += IntToTupletFigures((short int)tuplet->GetNumbase());
     }
     dc->GetSmuflTextExtent(notes, &extend);
 
     int x = tupletNum->GetDrawingXMid(m_doc);
     // since the number is slanted, move the center left
-    x -= (extend.m_width / 2);
+    x -= extend.m_width / 2;
 
     int y = tupletNum->GetDrawingYMid();
     // adjust the baseline (to be improved with slanted brackets
-    y -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 6 / 5;
+    y -= m_doc->GetGlyphHeight(notes.back(), staff->m_drawingStaffSize, drawingCueSize) / 2;
 
     dc->ResumeGraphic(tupletNum, tupletNum->GetUuid());
 


### PR DESCRIPTION
This PR takes glyph height of tuplet numbers into account, to get a better result with different fonts. 

_Examples from Verovio test suite rendered with Petaluma_
Current:
![tuplet-017](https://user-images.githubusercontent.com/7693447/94143050-9140f600-fe6f-11ea-8247-cdb60c366680.png)
New:
![tuplet-017 new](https://user-images.githubusercontent.com/7693447/94143046-900fc900-fe6f-11ea-88e3-f9fe924b076f.png)

Current:
![tuplet-018](https://user-images.githubusercontent.com/7693447/94143053-91d98c80-fe6f-11ea-9a7b-fe167f1e22cf.png)
New:
![tuplet-018 new](https://user-images.githubusercontent.com/7693447/94143051-9140f600-fe6f-11ea-9863-fb81bff11e00.png)
