### PR TITLE
Prevent slurs over breaks looking like ties

### DIFF
--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -371,9 +371,9 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     // Positions not attached to a note
     if (spanningType == SPANNING_START) {
         if (drawingCurveDir == curvature_CURVEDIR_above)
-            y2 = std::max(staff->GetDrawingY(), y1);
+            y2 = staff->GetDrawingY();
         else
-            y2 = std::min(staff->GetDrawingY() - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize), y1);
+            y2 = staff->GetDrawingY() - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
     }
     if (end->Is(TIMESTAMP_ATTR)) {
         if (drawingCurveDir == curvature_CURVEDIR_above)
@@ -383,9 +383,9 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     }
     if (spanningType == SPANNING_END) {
         if (drawingCurveDir == curvature_CURVEDIR_above)
-            y1 = std::max(staff->GetDrawingY(), y2);
+            y1 = staff->GetDrawingY();
         else
-            y1 = std::min(staff->GetDrawingY() - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize), y2);
+            y1 = staff->GetDrawingY() - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
     }
     if (start->Is(TIMESTAMP_ATTR)) {
         if (drawingCurveDir == curvature_CURVEDIR_above)


### PR DESCRIPTION
As Gould states on slurs over system breaks: 
> The whole slur should tilt in the direction of the pitches.

Current behaviour:
![slursold](https://user-images.githubusercontent.com/7693447/94428233-ab8d1380-0190-11eb-82e7-1d817285835b.png)

Proposed:
![slursnew](https://user-images.githubusercontent.com/7693447/94428229-a92ab980-0190-11eb-9b0f-eca8b08d5eb1.png)

