### PR TITLE
Alternate stem direction based on the layer number

### DIFF
--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -546,12 +546,10 @@ int Staff::CalcStem(FunctorParams *)
         layers = nonEmptyLayers;
     }
 
-    data_STEMDIRECTION stemDir = STEMDIRECTION_up;
     for (auto &object : layers) {
+        // Alter stem direction between even and odd numbered layers
         Layer *layer = dynamic_cast<Layer *>(object);
-        layer->SetDrawingStemDir(stemDir);
-        // All remaining layers with stem down
-        stemDir = STEMDIRECTION_down;
+        layer->SetDrawingStemDir(layer->GetN() % 2 ? STEMDIRECTION_up : STEMDIRECTION_down);
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
- changed logic of the stem direction so that it's alternated depending on the layer number (down for even-numbered layers, up - for odd)