### PR TITLE
fix ties over breaks on dotted notes

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -260,7 +260,7 @@ void BeamSegment::CalcBeamInit(
     // Calculate the extreme values
 
     int yMax = 0, yMin = 0;
-    int nbRests = 0;
+    size_t nbRests = 0;
 
     m_avgY = 0;
     m_nbNotesOrChords = 0;
@@ -312,7 +312,7 @@ void BeamSegment::CalcBeamInit(
             }
         }
         else {
-            nbRests++;
+            ++nbRests;
         }
     }
 

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -431,7 +431,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
         flag = vrv_cast<Flag *>(this->FindDescendantByType(FLAG));
         assert(flag);
         flag->m_drawingNbFlags = params->m_dur - DUR_4;
-        slashFactor += (params->m_dur > DUR_8) ? 2 : 1;
+        if (!this->HasStemLen() && this->HasStemMod()) slashFactor += (params->m_dur > DUR_8) ? 2 : 1;
     }
 
     // Adjust basic stem length to number of slashes

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -800,6 +800,12 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
         }
         if (!isShortTie) {
             x1 += r1 + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
+            if (note1 && note1->GetDots() > 0) {
+                x1 += m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * note1->GetDots() * 3 / 2;
+            }
+            else if (parentChord1 && (parentChord1->GetDots() > 0)) {
+                x1 += m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * parentChord1->GetDots();
+            }
         }
     }
     // Now this is the case when the tie is split but we are drawing the end of it

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -807,6 +807,9 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
                 x1 += m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * parentChord1->GetDots();
             }
         }
+        x2 -= (m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
+                  + m_doc->GetDrawingBarLineWidth(staff->m_drawingStaffSize))
+            / 2;
     }
     // Now this is the case when the tie is split but we are drawing the end of it
     else if (spanningType == SPANNING_END) {

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -355,12 +355,13 @@ void View::DrawStaffGrp(
     }
     else if (staffGrp->GetSymbol() == staffGroupingSym_SYMBOL_bracket) {
         DrawBracket(dc, x, yTop, yBottom, staffSize);
-        x -= m_doc->GetDrawingUnit(staffSize) * m_options->m_bracketThickness.GetValue() + m_doc->GetDrawingUnit(staffSize);
-
+        x -= m_doc->GetDrawingUnit(staffSize) * m_options->m_bracketThickness.GetValue()
+            + m_doc->GetDrawingUnit(staffSize);
     }
     else if (staffGrp->GetSymbol() == staffGroupingSym_SYMBOL_bracketsq) {
         DrawBracketsq(dc, x, yTop, yBottom, staffSize);
-        x -= m_doc->GetDrawingUnit(staffSize) * m_options->m_subBracketThickness.GetValue() + m_doc->GetDrawingUnit(staffSize);
+        x -= m_doc->GetDrawingUnit(staffSize) * m_options->m_subBracketThickness.GetValue()
+            + m_doc->GetDrawingUnit(staffSize);
     }
 
     // recursively draw the children


### PR DESCRIPTION
fixes #1718 

example file from issue by @craigsapp 
![ties](https://user-images.githubusercontent.com/7693447/94993732-605d7100-0593-11eb-9c9f-7c3095b71bc4.png)
