### PR TITLE
Update handling of grace notes within beam

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -859,13 +859,14 @@ void Beam::FilterList(ArrayOfObjects *childList)
             // if we are at the beginning of the beam
             // and the note is cueSize
             // assume all the beam is of grace notes
+            const bool isInGraceGroup = element->GetFirstAncestor(GRACEGRP);
             if (childList->begin() == iter) {
-                if (element->IsGraceNote()) firstNoteGrace = true;
+                if (element->IsGraceNote() || isInGraceGroup) firstNoteGrace = true;
             }
             // if the first note in beam was NOT a grace
             // we have grace notes embedded in a beam
             // drop them
-            if (!firstNoteGrace && element->IsGraceNote()) {
+            if (!firstNoteGrace && (element->IsGraceNote() || isInGraceGroup)) {
                 iter = childList->erase(iter);
                 continue;
             }
@@ -1041,8 +1042,13 @@ void BeamElementCoord::SetDrawingStemDir(
 
     if (!m_closestNote) return;
 
+    const bool isInGraceGroup = m_element->GetFirstAncestor(GRACEGRP);
+    
+    if (m_element->IsGraceNote() || isInGraceGroup) segment->m_uniformStemLength *= 0.75;
     this->m_centered = segment->m_uniformStemLength % 2;
     this->m_yBeam += (segment->m_uniformStemLength * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
+
+    if (m_element->IsGraceNote() || isInGraceGroup) return;
 
     // Make sure the stem reaches the center of the staff
     // Mark the segment as extendedToCenter since we then want a reduced slope


### PR DESCRIPTION
- updated logic of FilterList for beam to take into account notes that are in the grace groups (opposed to notes with @grace attribute)
- updated logic of stem for beamed grace notes - they do not extend to the center of the system and generally should have shorter stems

<details><summary>Example:</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title></title>
         </titleStmt>
         <pubStmt></pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="3" pname="e" />
                           <graceGrp grace="unknown">
                              <beam>
                                 <note dur="32" oct="3" pname="d" stem.dir="up" />
                                 <note dur="32" oct="3" pname="c" stem.dir="up" />
                                 <note accid="n" dur="32" oct="2" pname="b" stem.dir="up" />
                                 <note dur="32" oct="3" pname="c" stem.dir="up" />
                              </beam>
                           </graceGrp>
                           <note dur="8" oct="3" pname="e" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="3" pname="e" />
                           <beam>
                              <graceGrp grace="unknown">
                                 <note dur="32" oct="3" pname="d" stem.dir="up" />
                                 <note dur="32" oct="3" pname="c" stem.dir="up" />
                                 <note accid="n" dur="32" oct="2" pname="b" stem.dir="up" />
                                 <note dur="32" oct="3" pname="c" stem.dir="up" />
                              </graceGrp>
                           </beam>
                           <note dur="8" oct="3" pname="e" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="3" pname="e" />
                              <beam>
                                 <graceGrp grace="unknown">
                                    <note dur="32" oct="3" pname="d" stem.dir="up" />
                                    <note dur="32" oct="3" pname="c" stem.dir="up" />
                                    <note accid="n" dur="32" oct="2" pname="b" stem.dir="up" />
                                    <note dur="32" oct="3" pname="c" stem.dir="up" />
                                 </graceGrp>
                              </beam>
                              <note dur="8" oct="3" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="3" pname="e" />
                              <graceGrp grace="unknown">
                                 <beam>
                                    <note dur="32" oct="3" pname="d" stem.dir="up" />
                                    <note dur="32" oct="3" pname="c" stem.dir="up" />
                                    <note accid="n" dur="32" oct="2" pname="b" stem.dir="up" />
                                    <note dur="32" oct="3" pname="c" stem.dir="up" />
                                 </beam>
                              </graceGrp>
                              <note dur="8" oct="3" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>

**Before**
![image](https://user-images.githubusercontent.com/1819669/95097638-63449700-0736-11eb-95b0-4502f9b51caf.png)

**After**
![image](https://user-images.githubusercontent.com/1819669/95097665-69d30e80-0736-11eb-9a79-9aeee438ad1d.png)
