### PR TITLE
Improve rendering of the situations when grace notes/groups collide with beams

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -152,6 +152,16 @@ public:
     //----------//
 
     /**
+     * See Object::AdjustBeams
+     */
+    virtual int AdjustBeams(FunctorParams *);
+
+    /**
+     * See Object::AdjustBeamsEnd
+     */
+    virtual int AdjustBeamsEnd(FunctorParams *);
+
+    /**
      * See Object::CalcStem
      */
     virtual int CalcStem(FunctorParams *functorParams);
@@ -196,6 +206,7 @@ public:
         m_element = NULL;
         m_closestNote = NULL;
         m_stem = NULL;
+        m_overlapMargin = 0;
     }
     virtual ~BeamElementCoord();
 
@@ -214,6 +225,7 @@ public:
     int m_yBeam; // y value of stem top position
     int m_dur; // drawing duration
     int m_breaksec;
+    int m_overlapMargin;
     bool m_centered; // beam is centered on the line
     bool m_shortened; // stem is shortened because pointing oustide the staff
     char m_partialFlags[MAX_DURATION_PARTIALS];

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -57,6 +57,15 @@ public:
      */
     static int ClefId(data_CLEFSHAPE shape, char line, data_OCTAVE_DIS octaveDis, data_STAFFREL_basic place);
 
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * See Object::AdjustBeams
+     */
+    virtual int AdjustBeams(FunctorParams *functorParams);
+
 private:
 public:
     //

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -168,6 +168,7 @@ public:
         m_beam = NULL;
         m_y1 = 0;
         m_y2 = 0;
+        m_directionBias = 0;
         m_overlapMargin = 0;
         m_doc = doc;
     }
@@ -175,6 +176,7 @@ public:
     Object *m_beam;
     int m_y1;
     int m_y2;
+    int m_directionBias;
     int m_overlapMargin;
     Doc *m_doc;
 };

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -150,6 +150,36 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// AdjustBeamParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the beam that should be adjusted
+ * member 1: y coordinate of the beam left side
+ * member 2: y coordinate of the beam right side
+ * member 3: overlap margin that beam needs to be displaced by
+ * member 4: the Doc
+ **/
+
+class AdjustBeamParams : public FunctorParams {
+public:
+    AdjustBeamParams(Doc *doc)
+    {
+        m_beam = NULL;
+        m_y1 = 0;
+        m_y2 = 0;
+        m_overlapMargin = 0;
+        m_doc = doc;
+    }
+
+    Object *m_beam;
+    int m_y1;
+    int m_y2;
+    int m_overlapMargin;
+    Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
 // AdjustArticWithSlursParams
 //----------------------------------------------------------------------------
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -211,6 +211,11 @@ public:
     //----------//
 
     /**
+     * See Object::AdjustBeams
+     */
+    virtual int AdjustBeams(FunctorParams *);
+
+    /**
      * See Object::ResetHorizontalAlignment
      */
     virtual int ResetHorizontalAlignment(FunctorParams *functorParams);

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -805,6 +805,16 @@ public:
     virtual int CalcArtic(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
+     * Calculate the vertical position adjustment for the beam if it overlaps with layer elements
+     */
+    virtual int AdjustBeams(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
+     * Apply position adjustment that has been calculated previously
+     */
+    virtual int AdjustBeamsEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Adjust the postion position of slurs.
      */
     virtual int AdjustSlurs(FunctorParams *) { return FUNCTOR_CONTINUE; }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1122,20 +1122,21 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
         params->m_beam = this;
         params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
         params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
+        params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
         return FUNCTOR_CONTINUE;
     }
 
-    const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
+    //const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
 
     const int leftMargin = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam - params->m_y1;
     const int rightMargin = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam - params->m_y2;
 
-    const int overlapMargin = std::max(leftMargin * directionBias, rightMargin * directionBias);
+    const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_overlapMargin) {
         Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
         assert(staff);
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        params->m_overlapMargin = (overlapMargin + staffOffset) * directionBias;
+        params->m_overlapMargin = (overlapMargin + staffOffset) * params->m_directionBias;
     }
     return FUNCTOR_SIBLINGS;
 }

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -14,7 +14,9 @@
 //----------------------------------------------------------------------------
 
 #include "doc.h"
+#include "functorparams.h"
 #include "scoredefinterface.h"
+#include "staff.h"
 
 namespace vrv {
 
@@ -73,6 +75,46 @@ int Clef::GetClefLocOffset() const
 int Clef::ClefId(data_CLEFSHAPE shape, char line, data_OCTAVE_DIS octaveDis, data_STAFFREL_basic place)
 {
     return place << 24 | octaveDis << 16 | line << 8 | shape;
+}
+
+//----------------------------------------------------------------------------
+// Clef functors methods
+//----------------------------------------------------------------------------
+
+int Clef::AdjustBeams(FunctorParams* functorParams)
+{
+    const std::map<data_CLEFSHAPE, std::pair<wchar_t, double> > topToMiddleProportions
+        = { { CLEFSHAPE_G, { SMUFL_E050_gClef, 0.6 } }, 
+            { CLEFSHAPE_C, { SMUFL_E05C_cClef, 0.5 } },
+            { CLEFSHAPE_F, { SMUFL_E062_fClef, 0.35 } }
+    };
+
+    AdjustBeamParams *params = vrv_params_cast<AdjustBeamParams *>(functorParams);
+    assert(params);
+
+    Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
+    assert(staff);
+
+    auto currentShapeIter = topToMiddleProportions.find(GetShape());
+    if (currentShapeIter == topToMiddleProportions.end()) return FUNCTOR_CONTINUE;
+
+    // Y position differes for clef shapes, so we need to take into account only a part of the glyph height
+    // Proportion of the glyph about Y point is defined in the topToMiddleProportions map and used when
+    // left and right margins are calculated
+    const int clefPosition = staff->GetDrawingY()
+        - params->m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - GetLine());
+    const int clefGlyphHeight
+        = params->m_doc->GetGlyphHeight(currentShapeIter->second.first, staff->m_drawingStaffSize, false);
+    const int leftMargin = clefPosition + clefGlyphHeight * currentShapeIter->second.second - params->m_y1;
+    const int rightMargin = clefPosition + clefGlyphHeight * currentShapeIter->second.second - params->m_y2;
+
+    const int overlapMargin = std::max(leftMargin, rightMargin);
+    if (overlapMargin >= params->m_overlapMargin) {
+        const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        params->m_overlapMargin = (overlapMargin/staffOffset + 1) * staffOffset;
+    }
+
+    return FUNCTOR_CONTINUE;
 }
 
 } // namespace vrv

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1137,6 +1137,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     // ignore elements that are not in the beam or are direct children of the beam
     if (!params->m_beam || (Is({ NOTE, CHORD }) && (GetParent() == params->m_beam) && !IsGraceNote()))
         return FUNCTOR_SIBLINGS;
+    if (Is(GRACEGRP)) return FUNCTOR_CONTINUE;
 
     Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
     assert(staff);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1144,6 +1144,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     // check if top/bottom of the element overlaps with beam coordinates
     const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
     int leftMargin = 0, rightMargin = 0;
+
     if (directionBias > 0) {
         leftMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1;
         rightMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2;
@@ -1152,7 +1153,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
         leftMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1;
         rightMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2;
     }
-    
+
     const int overlapMargin = std::max(leftMargin * directionBias, rightMargin * directionBias);
     if (overlapMargin >= directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1158,7 +1158,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        params->m_overlapMargin = (overlapMargin + staffOffset) * params->m_directionBias;
+        params->m_overlapMargin = (((overlapMargin + staffOffset - 1) / staffOffset + 1) * staffOffset) * params->m_directionBias;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1143,10 +1143,10 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     assert(staff);
 
     // check if top/bottom of the element overlaps with beam coordinates
-    const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
+    //const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
     int leftMargin = 0, rightMargin = 0;
 
-    if (directionBias > 0) {
+    if (params->m_directionBias > 0) {
         leftMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1;
         rightMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2;
     }
@@ -1155,10 +1155,10 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
         rightMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2;
     }
 
-    const int overlapMargin = std::max(leftMargin * directionBias, rightMargin * directionBias);
-    if (overlapMargin >= directionBias * params->m_overlapMargin) {
+    const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
+    if (overlapMargin >= params->m_directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        params->m_overlapMargin = (overlapMargin + staffOffset) * directionBias;
+        params->m_overlapMargin = (overlapMargin + staffOffset) * params->m_directionBias;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -404,6 +404,12 @@ void Page::LayOutVertically()
     Functor adjustArticWithSlurs(&Object::AdjustArticWithSlurs);
     this->Process(&adjustArticWithSlurs, &adjustArticWithSlursParams);
 
+    // Adjust the position of the beams in regards of layer elements
+    AdjustBeamParams adjustBeamParams(doc);
+    Functor adjustBeams(&Object::AdjustBeams);
+    Functor adjustBeamsEnd(&Object::AdjustBeamsEnd);
+    this->Process(&adjustBeams, &adjustBeamParams, &adjustBeamsEnd);
+
     // Adjust the position of the tuplets
     FunctorDocParams adjustTupletsYParams(doc);
     Functor adjustTupletsY(&Object::AdjustTupletsY);


### PR DESCRIPTION
Fixes two problems:
1. Beams containing grace notes/groups that end up overlapping with parent beam:
![image](https://user-images.githubusercontent.com/1819669/95100921-49a54e80-073a-11eb-90f1-7d8273682347.png)

Fixes to following:
![image](https://user-images.githubusercontent.com/1819669/95100976-57f36a80-073a-11eb-87ee-9c4644c7e06c.png)

Coupled with #1721 it would look better, since it fixes related problem (grace groups within beams).

2. Clef change happening inside of the beam. Originally it would just overlap, now code tries to adjust beam vertical position to avoid colliding with clef:
![image](https://user-images.githubusercontent.com/1819669/95101255-9db03300-073a-11eb-94d0-9986a470aa26.png)
