### PR TITLE
Improving barline rendition

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -558,6 +558,7 @@ public:
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
     OptionIntMap m_measureNumber;
+    OptionDbl m_repeatBarlineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionInt m_slurControlPoints;
     OptionInt m_slurCurveFactor;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -532,7 +532,7 @@ public:
      */
     OptionGrp m_generalLayout;
 
-    OptionDbl m_barlineSeparation;
+    OptionDbl m_barLineSeparation;
     OptionDbl m_barLineWidth;
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
@@ -558,7 +558,7 @@ public:
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
     OptionIntMap m_measureNumber;
-    OptionDbl m_repeatBarlineDotSeparation;
+    OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionInt m_slurControlPoints;
     OptionInt m_slurCurveFactor;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -201,7 +201,7 @@ protected:
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
     void DrawBarLine(DeviceContext *dc, int y_top, int y_bottom, BarLine *barLine, bool eraseIntersections = false);
-    void DrawBarLineDots(DeviceContext *dc, StaffDef *staffDef, Staff *staff, BarLine *barLine);
+    void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, ArrayOfLedgerLines *lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);
     void DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -769,6 +769,10 @@ Options::Options()
     m_generalLayout.SetLabel("General layout options", "2-generalLayout");
     m_grps.push_back(&m_generalLayout);
 
+    m_barlineSeparation.SetInfo("Bar line separation", "The default distance between multiple barlines when locked together");
+    m_barlineSeparation.Init(1.0, 0.5, 2.0);
+    this->Register(&m_barlineSeparation, "barlineSeparation", &m_generalLayout);
+
     m_barLineWidth.SetInfo("Bar line width", "The barLine width");
     m_barLineWidth.Init(0.30, 0.10, 0.80);
     this->Register(&m_barLineWidth, "barLineWidth", &m_generalLayout);
@@ -1227,6 +1231,7 @@ void Options::Sync()
               { "tieMidpointThickness", &m_tieThickness }, //
               { "thinBarlineThickness", &m_barLineWidth }, //
               { "thickBarlineThickness", &m_thickBarlineThickness }, //
+              { "barlineSeparation", &m_barlineSeparation }, //
               { "bracketThickness", &m_bracketThickness }, //
               { "subBracketThickness", &m_subBracketThickness }, //
               { "hairpinThickness", &m_hairpinThickness }, //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -769,9 +769,9 @@ Options::Options()
     m_generalLayout.SetLabel("General layout options", "2-generalLayout");
     m_grps.push_back(&m_generalLayout);
 
-    m_barlineSeparation.SetInfo("Barline separation", "The default distance between multiple barlines when locked together");
-    m_barlineSeparation.Init(0.8, 0.5, 2.0);
-    this->Register(&m_barlineSeparation, "barlineSeparation", &m_generalLayout);
+    m_barLineSeparation.SetInfo("Barline separation", "The default distance between multiple barlines when locked together");
+    m_barLineSeparation.Init(0.8, 0.5, 2.0);
+    this->Register(&m_barLineSeparation, "barLineSeparation", &m_generalLayout);
 
     m_barLineWidth.SetInfo("Barline width", "The barLine width");
     m_barLineWidth.Init(0.30, 0.10, 0.80);
@@ -877,9 +877,9 @@ Options::Options()
     m_measureNumber.Init(MEASURENUMBER_system, &Option::s_measureNumber);
     this->Register(&m_measureNumber, "measureNumber", &m_generalLayout);
     
-    m_repeatBarlineDotSeparation.SetInfo("Repeat barline dot separation", "The default horizontal distance between the dots and the inner barline of a repeat barline");
-    m_repeatBarlineDotSeparation.Init(0.30, 0.10, 1.00);
-    this->Register(&m_repeatBarlineDotSeparation, "repeatBarlineDotSeparation", &m_generalLayout);
+    m_repeatBarLineDotSeparation.SetInfo("Repeat barline dot separation", "The default horizontal distance between the dots and the inner barline of a repeat barline");
+    m_repeatBarLineDotSeparation.Init(0.30, 0.10, 1.00);
+    this->Register(&m_repeatBarLineDotSeparation, "repeatBarLineDotSeparation", &m_generalLayout);
 
     m_repeatEndingLineThickness.SetInfo("Repeat ending line thickness", "Repeat and ending line thickness");
     m_repeatEndingLineThickness.Init(0.15, 0.1, 2.0);
@@ -1235,8 +1235,8 @@ void Options::Sync()
               { "tieMidpointThickness", &m_tieThickness }, //
               { "thinBarlineThickness", &m_barLineWidth }, //
               { "thickBarlineThickness", &m_thickBarlineThickness }, //
-              { "barlineSeparation", &m_barlineSeparation }, //
-              { "repeatBarlineDotSeparation", &m_repeatBarlineDotSeparation }, //
+              { "barlineSeparation", &m_barLineSeparation }, //
+              { "repeatBarlineDotSeparation", &m_repeatBarLineDotSeparation }, //
               { "bracketThickness", &m_bracketThickness }, //
               { "subBracketThickness", &m_subBracketThickness }, //
               { "hairpinThickness", &m_hairpinThickness }, //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -769,11 +769,11 @@ Options::Options()
     m_generalLayout.SetLabel("General layout options", "2-generalLayout");
     m_grps.push_back(&m_generalLayout);
 
-    m_barlineSeparation.SetInfo("Bar line separation", "The default distance between multiple barlines when locked together");
-    m_barlineSeparation.Init(1.0, 0.5, 2.0);
+    m_barlineSeparation.SetInfo("Barline separation", "The default distance between multiple barlines when locked together");
+    m_barlineSeparation.Init(0.8, 0.5, 2.0);
     this->Register(&m_barlineSeparation, "barlineSeparation", &m_generalLayout);
 
-    m_barLineWidth.SetInfo("Bar line width", "The barLine width");
+    m_barLineWidth.SetInfo("Barline width", "The barLine width");
     m_barLineWidth.Init(0.30, 0.10, 0.80);
     this->Register(&m_barLineWidth, "barLineWidth", &m_generalLayout);
 
@@ -876,6 +876,10 @@ Options::Options()
     m_measureNumber.SetInfo("Measure number", "The measure numbering rule (unused)");
     m_measureNumber.Init(MEASURENUMBER_system, &Option::s_measureNumber);
     this->Register(&m_measureNumber, "measureNumber", &m_generalLayout);
+    
+    m_repeatBarlineDotSeparation.SetInfo("Repeat barline dot separation", "The default horizontal distance between the dots and the inner barline of a repeat barline");
+    m_repeatBarlineDotSeparation.Init(0.30, 0.10, 1.00);
+    this->Register(&m_repeatBarlineDotSeparation, "repeatBarlineDotSeparation", &m_generalLayout);
 
     m_repeatEndingLineThickness.SetInfo("Repeat ending line thickness", "Repeat and ending line thickness");
     m_repeatEndingLineThickness.Init(0.15, 0.1, 2.0);
@@ -1232,6 +1236,7 @@ void Options::Sync()
               { "thinBarlineThickness", &m_barLineWidth }, //
               { "thickBarlineThickness", &m_thickBarlineThickness }, //
               { "barlineSeparation", &m_barlineSeparation }, //
+              { "repeatBarlineDotSeparation", &m_repeatBarlineDotSeparation }, //
               { "bracketThickness", &m_bracketThickness }, //
               { "subBracketThickness", &m_subBracketThickness }, //
               { "hairpinThickness", &m_hairpinThickness }, //

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -395,9 +395,16 @@ void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    int y = staff->GetDrawingY();
+    int yTop = staff->GetDrawingY();
+    int yBottom = yTop - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+
+    int offset = (yTop == yBottom)? m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) : 0;
+        
     DrawBarLine(
-        dc, y, y - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize), barLine);
+        dc, yTop + offset, yBottom - offset, barLine);
+    if (barLine->HasRepetitionDots()) {
+        DrawBarLineDots(dc, staff, barLine);
+    }
 
     dc->EndGraphic(element, this);
 }

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -188,7 +188,7 @@ void View::DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width,
 
 void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize)
 {
-    int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staffSize) / 5), 2);
+    const int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staffSize) / 5), 2);
 
     dc->SetPen(m_currentColour, 0, AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -685,7 +685,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                 }
                 DrawBarLine(dc, yTop, yBottom, barLine);
                 if (barLine->HasRepetitionDots()) {
-                    DrawBarLineDots(dc, childStaffDef, staff, barLine);
+                    DrawBarLineDots(dc, staff, barLine);
                 }
             }
         }
@@ -762,7 +762,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                             "Could not get staff (%d) while drawing staffGrp - DrawBarLines", childStaffDef->GetN());
                         continue;
                     }
-                    DrawBarLineDots(dc, childStaffDef, staff, barLine);
+                    DrawBarLineDots(dc, staff, barLine);
                 }
             }
         }
@@ -863,10 +863,9 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     }
 }
 
-void View::DrawBarLineDots(DeviceContext *dc, StaffDef *staffDef, Staff *staff, BarLine *barLine)
+void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
 {
     assert(dc);
-    assert(staffDef);
     assert(staff);
     assert(barLine);
 
@@ -878,7 +877,7 @@ void View::DrawBarLineDots(DeviceContext *dc, StaffDef *staffDef, Staff *staff, 
     const int x1 = x - xShift;
     const int x2 = x + xShift;
 
-    const int yBottom = staff->GetDrawingY() - staffDef->GetLines() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int yBottom = staff->GetDrawingY() - staff->m_drawingLines * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
     if ((barLine->GetForm() == BARRENDITION_rptstart) || (barLine->GetForm() == BARRENDITION_rptboth)) {

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -780,8 +780,9 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     int x = barLine->GetDrawingX();
     const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
     const int barLineThickWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_thickBarlineThickness.GetValue();
-    int x1 = x - barLineThickWidth - barLineWidth;
-    int x2 = x + barLineThickWidth + barLineWidth;
+    const int barlineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barlineSeparation.GetValue();
+    int x1 = x - barlineSeparation - barLineWidth;
+    int x2 = x + barlineSeparation + barLineWidth;
 
     // optimized for five line staves
     int dashLength = m_doc->GetDrawingUnit(staffSize) * 16 / 13;
@@ -827,17 +828,17 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dotLength);
     }
     else if (barLine->GetForm() == BARRENDITION_rptend) {
-        DrawVerticalSegmentedLine(dc, x1, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x1 - (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptboth) {
-        DrawVerticalSegmentedLine(dc, x1, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x1 - (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
-        DrawVerticalSegmentedLine(dc, x2, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptstart) {
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
-        DrawVerticalSegmentedLine(dc, x2, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_invis) {
         barLine->SetEmptyBB();
@@ -848,12 +849,10 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     }
     else if (barLine->GetForm() == BARRENDITION_dbl) {
         // Narrow the bars a little bit - should be centered?
-        x2 -= barLineWidth;
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
         DrawVerticalSegmentedLine(dc, x2, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_dbldashed) {
-        x2 -= barLineWidth;
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength);
         DrawVerticalSegmentedLine(dc, x2, line, barLineWidth, dashLength);
     }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -780,9 +780,9 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     const int x = barLine->GetDrawingX();
     const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
     const int barLineThickWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_thickBarlineThickness.GetValue();
-    const int barlineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barlineSeparation.GetValue();
-    int x1 = x - barlineSeparation - barLineWidth;
-    int x2 = x + barlineSeparation + barLineWidth;
+    const int barLineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barLineSeparation.GetValue();
+    int x1 = x - barLineSeparation - barLineWidth;
+    int x2 = x + barLineSeparation + barLineWidth;
 
     // optimized for five line staves
     int dashLength = m_doc->GetDrawingUnit(staffSize) * 16 / 13;
@@ -872,8 +872,8 @@ void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
     const int x = barLine->GetDrawingX();
     // HARDCODED - should be half the width of the proper glyph
     const int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 5), 2);
-    const int dotSeparation = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_repeatBarlineDotSeparation.GetValue();
-    const int xShift = m_doc->GetDrawingUnit(100) * m_options->m_thickBarlineThickness.GetValue() / 2 + m_doc->GetDrawingUnit(100) * m_options->m_barlineSeparation.GetValue() + m_doc->GetDrawingUnit(100) * m_options->m_barLineWidth.GetValue() + dotSeparation + r;
+    const int dotSeparation = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_repeatBarLineDotSeparation.GetValue();
+    const int xShift = m_doc->GetDrawingUnit(100) * m_options->m_thickBarlineThickness.GetValue() / 2 + m_doc->GetDrawingUnit(100) * m_options->m_barLineSeparation.GetValue() + m_doc->GetDrawingUnit(100) * m_options->m_barLineWidth.GetValue() + dotSeparation + r;
     const int x1 = x - xShift;
     const int x2 = x + xShift;
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -775,9 +775,9 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     assert(barLine);
 
     Staff *staff = dynamic_cast<Staff *>(barLine->GetFirstAncestor(STAFF));
-    int staffSize = (staff) ? staff->m_drawingStaffSize : 100;
+    const int staffSize = (staff) ? staff->m_drawingStaffSize : 100;
 
-    int x = barLine->GetDrawingX();
+    const int x = barLine->GetDrawingX();
     const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
     const int barLineThickWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_thickBarlineThickness.GetValue();
     const int barlineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barlineSeparation.GetValue();
@@ -844,7 +844,7 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
         barLine->SetEmptyBB();
     }
     else if (barLine->GetForm() == BARRENDITION_end) {
-        DrawVerticalSegmentedLine(dc, x1, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x1 - (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_dbl) {
@@ -870,14 +870,16 @@ void View::DrawBarLineDots(DeviceContext *dc, StaffDef *staffDef, Staff *staff, 
     assert(staff);
     assert(barLine);
 
-    int x = barLine->GetDrawingX();
-    int x1 = x - 2 * m_doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, false)
-        - m_doc->GetDrawingBarLineWidth(staff->m_drawingStaffSize);
-    int x2 = x + 2 * m_doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, false)
-        + m_doc->GetDrawingBarLineWidth(staff->m_drawingStaffSize);
+    const int x = barLine->GetDrawingX();
+    // HARDCODED - should be half the width of the proper glyph
+    const int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 5), 2);
+    const int dotSeparation = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_repeatBarlineDotSeparation.GetValue();
+    const int xShift = m_doc->GetDrawingUnit(100) * m_options->m_thickBarlineThickness.GetValue() / 2 + m_doc->GetDrawingUnit(100) * m_options->m_barlineSeparation.GetValue() + m_doc->GetDrawingUnit(100) * m_options->m_barLineWidth.GetValue() + dotSeparation + r;
+    const int x1 = x - xShift;
+    const int x2 = x + xShift;
 
-    int yBottom = staff->GetDrawingY() - staffDef->GetLines() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    int yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int yBottom = staff->GetDrawingY() - staffDef->GetLines() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
     if ((barLine->GetForm() == BARRENDITION_rptstart) || (barLine->GetForm() == BARRENDITION_rptboth)) {
         DrawDot(dc, x2, yBottom, staff->m_drawingStaffSize);


### PR DESCRIPTION
Adds full support for SMuFLs `barlineSeparation` and `repeatBarlineDotSeparation`
closes #1321
closes #1333

Issue #1333
![barline](https://user-images.githubusercontent.com/7693447/95188538-d862ab80-07cc-11eb-88a1-748d9598d6ef.png)

Issue #1321 
![barline](https://user-images.githubusercontent.com/7693447/95203355-ede2d000-07e2-11eb-834a-9665d4ccee04.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Repeated barLine elements</title>
      </titleStmt>
      <pubStmt>
        <respStmt>
          <persName role="encoder">Klaus Rettinghaus</persName>
          <corpName role="funder">eNote GmbH</corpName>
        </respStmt>
        <date isodate="2020">2020</date>
      </pubStmt>
      <seriesStmt>
        <title>Verovio test suite</title>
      </seriesStmt>
      <notesStmt>
        <annot>Verovio renders all barLine elements even on single line staves.</annot>
      </notesStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application version="3.0.0" label="1">
          <name>Verovio</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef>
            <staffGrp>
              <staffDef n="1" lines="1" clef.shape="perc" meter.count="3" meter.unit="4" />
            </staffGrp>
          </scoreDef>
          <section>
            <measure>
              <staff n="1">
                <layer n="1">
                  <rest dur="4" />
                  <barLine form="rptstart" />
                  <tuplet num="3" numbase="2">
                    <note loc="0" stem.dir="up" dur="4" />
                    <note loc="0" stem.dir="up" dur="4" />
                    <note loc="0" stem.dir="up" dur="4" />
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure>
              <staff n="1">
                <layer n="1">
                  <tuplet num="3" numbase="2">
                    <note loc="0" stem.dir="up" dur="4" />
                    <note loc="0" stem.dir="up" dur="4" />
                    <note loc="0" stem.dir="up" dur="4" />
                  </tuplet>
                  <barLine form="rptboth" />
                  <rest dur="4" />
                </layer>
              </staff>
            </measure>
            <measure>
              <staff n="1">
                <layer n="1">
                  <tuplet num="3" numbase="2">
                    <note loc="0" stem.dir="up" dur="4" />
                    <note loc="0" stem.dir="up" dur="4" />
                    <note loc="0" stem.dir="up" dur="4" />
                  </tuplet>
                  <barLine form="rptend" />
                  <rest dur="4" />
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```

I'll add test files to the test suite.