### PR TITLE
Beam slope improvement

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -91,7 +91,6 @@ public:
     int m_ledgerLinesAbove;
     int m_ledgerLinesBelow;
     int m_uniformStemLength;
-    int m_shortestNoteDuration;
 
     BeamElementCoord *m_firstNoteOrChord;
     BeamElementCoord *m_lastNoteOrChord;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -91,6 +91,7 @@ public:
     int m_ledgerLinesAbove;
     int m_ledgerLinesBelow;
     int m_uniformStemLength;
+    int m_shortestNoteDuration;
 
     BeamElementCoord *m_firstNoteOrChord;
     BeamElementCoord *m_lastNoteOrChord;

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -99,6 +99,11 @@ public:
     bool IsRepeatedPattern();
 
     /**
+     * Checks whether difference between highest and lowest notes of the beam is just one step
+     */
+    bool HasOneStepHeight();
+
+    /**
      * Clear the m_beamElementCoords vector and delete all the objects.
      */
     void ClearCoords();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -135,23 +135,6 @@ void BeamSegment::CalcBeam(
     // ArrayOfBeamElementCoords stemUps;
     // ArrayOfBeamElementCoords stemDowns;
 
-    // For 32th and shorter notes, we want to treat beams that have really small diatonic difference (i.e. just one step)
-    // as horizontal, so that we don't end up with really gentle slopes
-    if (beamInterface->m_shortestDur >= DUR_32) {
-        int top = -128;
-        int bottom = 128;
-        for (auto coord : m_beamElementCoordRefs) {
-            if (coord->m_element) {
-                Note *note = vrv_cast<Note *>(coord->m_element);
-                assert(note);
-                int loc = note->GetDrawingLoc();
-                if (loc > top) top = loc;
-                if (loc < bottom) bottom = loc;
-            }
-        }
-        if (abs(top - bottom) <= 1) horizontal = true;
-    }
-    
     /******************************************************************/
     // Calculate the slope is necessary
 
@@ -770,8 +753,6 @@ void BeamSegment::CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterfac
 void BeamSegment::CalcBeamStemLength(Staff *staff, data_STEMDIRECTION stemDir)
 {
     const int stemDirBias = (stemDir == STEMDIRECTION_up) ? 1 : -1;
-    int bottommostLocation = 128;
-    int topmostLocation = -128;
     for (auto coord : m_beamElementCoordRefs) {
         const int coordStemDir = coord->CalculateStemLength(staff, stemDir);
         if (stemDirBias * coordStemDir > stemDirBias * m_uniformStemLength) {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -759,6 +759,16 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_STEMDIRECTION stemDir)
             m_uniformStemLength = coordStemDir;
         }
     }
+    // make adjustments for the grace notes length
+    for (auto coord : m_beamElementCoordRefs) {
+        if (coord->m_element) {
+            const bool isInGraceGroup = coord->m_element->GetFirstAncestor(GRACEGRP);
+            if (coord->m_element->IsGraceNote() || isInGraceGroup) {
+                m_uniformStemLength *= 0.75;
+                break;
+            }
+        }
+    }
 }
 
 void BeamSegment::CalcSetValues(const int &elementCount)
@@ -1039,12 +1049,10 @@ void BeamElementCoord::SetDrawingStemDir(
 
     if (!m_closestNote) return;
 
-    const bool isInGraceGroup = m_element->GetFirstAncestor(GRACEGRP);
-    
-    if (m_element->IsGraceNote() || isInGraceGroup) segment->m_uniformStemLength *= 0.75;
     this->m_centered = segment->m_uniformStemLength % 2;
     this->m_yBeam += (segment->m_uniformStemLength * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
 
+    const bool isInGraceGroup = m_element->GetFirstAncestor(GRACEGRP);
     if (m_element->IsGraceNote() || isInGraceGroup) return;
 
     // Make sure the stem reaches the center of the staff

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -755,8 +755,7 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_STEMDIRECTION stemDir)
     const int stemDirBias = (stemDir == STEMDIRECTION_up) ? 1 : -1;
     for (auto coord : m_beamElementCoordRefs) {
         const int coordStemDir = coord->CalculateStemLength(staff, stemDir);
-        if ((stemDirBias * coordStemDir > stemDirBias * m_uniformStemLength)
-                && (stemDirBias * m_uniformStemLength + 1 != stemDirBias * coordStemDir)) {
+        if (stemDirBias * coordStemDir > stemDirBias * m_uniformStemLength) {
             m_uniformStemLength = coordStemDir;
         }
     }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -60,6 +60,7 @@ void BeamSegment::Reset()
     m_ledgerLinesAbove = 0;
     m_ledgerLinesBelow = 0;
     m_uniformStemLength = 0;
+    m_shortestNoteDuration = 0;
 
     m_firstNoteOrChord = NULL;
     m_lastNoteOrChord = NULL;
@@ -758,6 +759,9 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_STEMDIRECTION stemDir)
         if (stemDirBias * coordStemDir > stemDirBias * m_uniformStemLength) {
             m_uniformStemLength = coordStemDir;
         }
+        if (coord->m_dur > m_shortestNoteDuration) {
+            m_shortestNoteDuration = coord->m_dur;
+        }
     }
 }
 
@@ -1001,7 +1005,6 @@ void BeamElementCoord::SetDrawingStemDir(
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     this->m_stem->SetDrawingStemDir(stemDir);
-    bool onStaffLine = false;
     int ledgerLines = 0;
     int ledgerLinesOpposite = 0;
     this->m_shortened = false;
@@ -1022,7 +1025,6 @@ void BeamElementCoord::SetDrawingStemDir(
         }
         if (m_closestNote) {
             this->m_yBeam = m_closestNote->GetDrawingY();
-            onStaffLine = (m_closestNote->GetDrawingLoc() % 2);
             m_closestNote->HasLedgerLines(ledgerLinesOpposite, ledgerLines);
         }
     }
@@ -1035,7 +1037,6 @@ void BeamElementCoord::SetDrawingStemDir(
         }
         if (m_closestNote) {
             this->m_yBeam = m_closestNote->GetDrawingY();
-            onStaffLine = (m_closestNote->GetDrawingLoc() % 2);
             m_closestNote->HasLedgerLines(ledgerLines, ledgerLinesOpposite);
         }
     }
@@ -1063,10 +1064,10 @@ void BeamElementCoord::SetDrawingStemDir(
     }
 
     // Make sure there is a at least one staff space before the ledger lines
-    if ((ledgerLines > 2) && (this->m_dur > DUR_32)) {
+    if ((ledgerLines > 2) && (segment->m_shortestNoteDuration > DUR_32)) {
         this->m_yBeam += (stemDir == STEMDIRECTION_up) ? 4 * unit : -4 * unit;
     }
-    else if ((ledgerLines > 1) && (this->m_dur > DUR_16)) {
+    else if ((ledgerLines > 1) && (segment->m_shortestNoteDuration > DUR_16)) {
         this->m_yBeam += (stemDir == STEMDIRECTION_up) ? 2 * unit : -2 * unit;
     }
 
@@ -1076,6 +1077,7 @@ void BeamElementCoord::SetDrawingStemDir(
 int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemDir)
 {
     if (!m_closestNote) return 0;
+
     const bool onStaffLine = m_closestNote->GetDrawingLoc() % 2;
     bool extend = onStaffLine;
     const int standardStemLen = STANDARD_STEMLENGTH * 2;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -755,7 +755,8 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_STEMDIRECTION stemDir)
     const int stemDirBias = (stemDir == STEMDIRECTION_up) ? 1 : -1;
     for (auto coord : m_beamElementCoordRefs) {
         const int coordStemDir = coord->CalculateStemLength(staff, stemDir);
-        if (stemDirBias * coordStemDir > stemDirBias * m_uniformStemLength) {
+        if ((stemDirBias * coordStemDir > stemDirBias * m_uniformStemLength)
+                && (stemDirBias * m_uniformStemLength + 1 != stemDirBias * coordStemDir)) {
             m_uniformStemLength = coordStemDir;
         }
     }

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -229,6 +229,8 @@ bool BeamDrawingInterface::IsHorizontal()
         return true;
     }
 
+    if (HasOneStepHeight()) return true;
+
     if (m_drawingPlace == BEAMPLACE_mixed) return true;
 
     if (m_drawingPlace == BEAMPLACE_NONE) return true;
@@ -347,6 +349,25 @@ bool BeamDrawingInterface::IsRepeatedPattern()
     }
 
     return false;
+}
+
+bool BeamDrawingInterface::HasOneStepHeight()
+{
+    if (m_shortestDur < DUR_32) return false;
+
+    int top = -128;
+    int bottom = 128;
+    for (auto coord : m_beamElementCoords) {
+        if (coord->m_element) {
+            Note *note = vrv_cast<Note *>(coord->m_element);
+            assert(note);
+            int loc = note->GetDrawingLoc();
+            if (loc > top) top = loc;
+            if (loc < bottom) bottom = loc;
+        }
+    }
+
+    return (abs(top - bottom) <= 1);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
A couple of small improvements for the beam slope:

1. Beams with 32th notes that had one dot were still problematic in terms of slope direction:
![image](https://user-images.githubusercontent.com/1819669/95444970-1b588680-0967-11eb-8da1-693fd07d4698.png)

2. For beams with 32th notes and shorter that have just one diatonic step difference slope was too gentle. Changed them to have horizontal beams instead:
https://github.com/rism-ch/verovio.org/gh-pages/_tests/beam/beam-056.mei
![image](https://user-images.githubusercontent.com/1819669/95445161-5ce93180-0967-11eb-80e8-99277774f621.png)

3. Fixed calculation error for grace group beams stem length.
