### PR TITLE
fix octave lines across systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Improved barline rendition (@rettinghaus)
 
 ## [3.0.0] - 2020-10-05
 * Support for buzz roll tremolos (@rettinghaus)
@@ -12,6 +13,7 @@
 * Support for pedal lines (@rettinghaus)
 * Options for controlling output tabs (--output-indent and --output-indent-tab)
 * Option to remove ids in the MEI output (--remove-ids) to be passed to GetMEI with the JS toolkit
+* Fix tremolo tuplets (@rettinghaus)
 
 ## [2.7.2] - 2020-07-23
 * Fix bug with memory in beams (@valeriyvan)

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -684,7 +684,7 @@ void View::DrawOctave(
         dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
         TextExtend extend;
         dc->GetSmuflTextExtent(str, &extend);
-        int yCode = (disPlace == STAFFREL_basic_above) ? y1 - extend.m_height : y1;
+        const int yCode = (disPlace == STAFFREL_basic_above) ? y1 - extend.m_height : y1;
         DrawSmuflCode(dc, x1 - extend.m_width, yCode, code, staff->m_drawingStaffSize, false);
         dc->ResetFont();
 
@@ -704,9 +704,10 @@ void View::DrawOctave(
 
         dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
         // draw the ending vertical line if not the end of the system
-        if (spanningType != SPANNING_START)
+        if (spanningType == SPANNING_END) {
             dc->DrawLine(ToDeviceContextX(x2), ToDeviceContextY(y1 + lineWidth / 2), ToDeviceContextX(x2),
                 ToDeviceContextY(y2 + lineWidth / 2));
+        }
 
         dc->ResetPen();
         dc->ResetBrush();


### PR DESCRIPTION
This fixes a small bug ending octave lines on system endings: 

current:
![octavebug](https://user-images.githubusercontent.com/7693447/95575368-def05d80-0a2e-11eb-8e50-c456fec053d8.png)

proposed:
![octavefix](https://user-images.githubusercontent.com/7693447/95575369-e0218a80-0a2e-11eb-8c87-9b54a375b7bf.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Octave shift over system breaks</title>
         </titleStmt>
         <pubStmt>
            <date>2020</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <pb />
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note xml:id="n1" dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                     <octave startid="#n1" endid="#n2" dis="8" dis.place="above" />
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note xml:id="n2" dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
