### PR TITLE
Add support for accidental marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Support for `accidental-mark` in MusicXML import (@rettinghaus)
 * Improved barline rendition (@rettinghaus)
 
 ## [3.0.0] - 2020-10-05

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2952,6 +2952,14 @@ void MusicXmlInput::ReadMusicXmlNote(
         mordent->SetPlace(mordent->AttPlacement::StrToStaffrel(xmlMordent.node().attribute("placement").as_string()));
         // form
         mordent->SetForm(mordentLog_FORM_lower);
+        for (pugi::xml_node xmlAccidMark : notations.node().children("accidental-mark")) {
+            if (HasAttributeWithValue(xmlAccidMark, "placement", "above")) {
+                mordent->SetAccidupper(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+            else if (HasAttributeWithValue(xmlAccidMark, "placement", "below")) {
+                mordent->SetAccidlower(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+        }
         if (!std::strncmp(xmlMordent.node().name(), "inverted", 7)) {
             mordent->SetForm(mordentLog_FORM_upper);
         }
@@ -3017,6 +3025,14 @@ void MusicXmlInput::ReadMusicXmlNote(
             musicxml::OpenSpanner openTrill(1, m_measureCounts.at(measure));
             m_trillStack.push_back(std::make_pair(trill, openTrill));
         }
+        for (pugi::xml_node xmlAccidMark : notations.node().children("accidental-mark")) {
+            if (HasAttributeWithValue(xmlAccidMark, "placement", "above")) {
+                trill->SetAccidupper(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+            else if (HasAttributeWithValue(xmlAccidMark, "placement", "below")) {
+                trill->SetAccidlower(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+        }
     }
     if (!m_trillStack.empty() && notations.node().select_node("ornaments/wavy-line[@type='stop']")) {
         int extNumber
@@ -3043,12 +3059,17 @@ void MusicXmlInput::ReadMusicXmlNote(
         m_controlElements.push_back(std::make_pair(measureNum, turn));
         turn->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
         turn->SetStartid(m_ID);
-        // color
         turn->SetColor(xmlTurn.node().attribute("color").as_string());
-        // form
-        // place
         turn->SetPlace(turn->AttPlacement::StrToStaffrel(xmlTurn.node().attribute("placement").as_string()));
         turn->SetForm(turnLog_FORM_upper);
+        for (pugi::xml_node xmlAccidMark : notations.node().children("accidental-mark")) {
+            if (HasAttributeWithValue(xmlAccidMark, "placement", "above")) {
+                turn->SetAccidupper(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+            else if (HasAttributeWithValue(xmlAccidMark, "placement", "below")) {
+                turn->SetAccidlower(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+        }
         if (!std::strncmp(xmlTurn.node().name(), "inverted", 8)) {
             turn->SetForm(turnLog_FORM_lower);
             if (std::string(xmlTurn.node().name()).find("vertical") != std::string::npos) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3026,11 +3026,11 @@ void MusicXmlInput::ReadMusicXmlNote(
             m_trillStack.push_back(std::make_pair(trill, openTrill));
         }
         for (pugi::xml_node xmlAccidMark : notations.node().children("accidental-mark")) {
-            if (HasAttributeWithValue(xmlAccidMark, "placement", "above")) {
-                trill->SetAccidupper(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
-            }
-            else if (HasAttributeWithValue(xmlAccidMark, "placement", "below")) {
+            if (HasAttributeWithValue(xmlAccidMark, "placement", "below")) {
                 trill->SetAccidlower(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
+            }
+            else {
+                trill->SetAccidupper(ConvertAccidentalToAccid(xmlAccidMark.text().as_string()));
             }
         }
     }


### PR DESCRIPTION
This PR add support for the MusicXML `accidental-mark` element on trills, turns and mordents.