### PR TITLE
Add boxed text support

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -579,6 +579,7 @@ public:
     OptionDbl m_subBracketThickness;
     OptionIntMap m_systemDivider;
     OptionInt m_systemMaxPerPage;
+    OptionDbl m_textEnclosureThickness;
     OptionDbl m_thickBarlineThickness;
     OptionDbl m_tieThickness;    
     OptionDbl m_tupletBracketThickness;

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -13,6 +13,8 @@
 
 namespace vrv {
 
+class Rend;
+
 //----------------------------------------------------------------------------
 // TextElement
 //----------------------------------------------------------------------------
@@ -107,6 +109,7 @@ public:
     bool m_verticalShift;
     data_HORIZONTALALIGNMENT m_alignment;
     int m_pointSize;
+    std::vector<TextElement *> m_boxedRend;
 };
 
 } // namespace vrv

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -93,10 +93,11 @@ public:
         m_width = 0;
         m_height = 0;
         m_laidOut = false;
-        m_newLine = false;
+        m_explicitPosition = false;
         m_verticalShift = false;
         m_alignment = HORIZONTALALIGNMENT_left;
         m_pointSize = 0;
+        m_actualWidth = 0;
     }
     virtual ~TextDrawingParams(){};
 
@@ -104,8 +105,11 @@ public:
     int m_y;
     int m_width;
     int m_height;
+    int m_actualWidth;
     bool m_laidOut;
-    bool m_newLine;
+    // used when X and Y has been changed manually or otherwise (e.g. newline <lb/> shift or shift for
+    // boxed enclosure for rend)
+    bool m_explicitPosition;
     bool m_verticalShift;
     data_HORIZONTALALIGNMENT m_alignment;
     int m_pointSize;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -363,7 +363,7 @@ protected:
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
-    void DrawTextBoxes(DeviceContext *dc, const std::vector<TextElement *> &boxedRend);
+    void DrawTextBoxes(DeviceContext *dc, const std::vector<TextElement *> &boxedRend, int staffSize);
 
     /**
      * @name Method for drawing Beam and FTrem.

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -25,7 +25,6 @@ class Beam;
 class BeamSegment;
 class BracketSpan;
 class Breath;
-class ControlElement;
 class Chord;
 class ControlElement;
 class DeviceContext;
@@ -364,6 +363,7 @@ protected:
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
+    void DrawTextBoxes(DeviceContext *dc, const std::vector<TextElement *> &boxedRend);
 
     /**
      * @name Method for drawing Beam and FTrem.
@@ -509,6 +509,7 @@ protected:
     void DrawLyricString(DeviceContext *dc, std::wstring str, int staffSize = 100,
         std::optional<TextDrawingParams> params = std::nullopt);
     void DrawFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2);
+    void DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, int radius);
     void DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int radius);
     void DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2, int height);
     void DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width, bool fill, int linewidth);

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -155,7 +155,14 @@ void DeviceContext::GetTextExtent(const std::wstring &string, TextExtend *extend
             glyph = Resources::GetGlyph(c);
         }
         if (!glyph) {
-            glyph = unkown;
+            // There is no glyph for space, and we would use 'o' to increase extend width. However 'o' is wider than 
+            // space, which led to incorrect rendering. For the time being, set width to that of '.' instead.
+            // This will probably need to be improved to change with font size/style
+            if (c == L' ') {
+                glyph = Resources::GetTextGlyph(L'.');
+            }
+            else
+                glyph = unkown;
         }
         AddGlyphToTextExtend(glyph, extend);
     }

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -161,8 +161,9 @@ void DeviceContext::GetTextExtent(const std::wstring &string, TextExtend *extend
             if (c == L' ') {
                 glyph = Resources::GetTextGlyph(L'.');
             }
-            else
+            else {
                 glyph = unkown;
+            }
         }
         AddGlyphToTextExtend(glyph, extend);
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -424,7 +424,7 @@ void MusicXmlInput::TextRendition(const pugi::xpath_node_set words, ControlEleme
         Object *textParent = element;
         if (textNode.attribute("xml:lang") || textNode.attribute("xml:space") || textNode.attribute("color")
             || textNode.attribute("halign") || textNode.attribute("font-family") || textNode.attribute("font-style")
-            || textNode.attribute("font-weight")) {
+            || textNode.attribute("font-weight") || textNode.attribute("enclosure")) {
             Rend *rend = new Rend();
             rend->SetLang(textNode.attribute("xml:lang").as_string());
             rend->SetColor(textNode.attribute("color").as_string());
@@ -434,6 +434,7 @@ void MusicXmlInput::TextRendition(const pugi::xpath_node_set words, ControlEleme
             rend->SetFontfam(textNode.attribute("font-family").as_string());
             rend->SetFontstyle(rend->AttTypography::StrToFontstyle(textNode.attribute("font-style").as_string()));
             rend->SetFontweight(rend->AttTypography::StrToFontweight(textNode.attribute("font-weight").as_string()));
+            rend->SetRend(ConvertEnclosure(textNode.attribute("enclosure").as_string()));
             element->AddChild(rend);
             textParent = rend;
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3541,7 +3541,7 @@ data_TEXTRENDITION MusicXmlInput::ConvertEnclosure(const std::string &value)
         return result->second;
     }
 
-    return TEXTRENDITION_box;
+    return TEXTRENDITION_none;
 }
 
 std::wstring MusicXmlInput::ConvertTypeToVerovioText(const std::string &value)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -40,7 +40,7 @@ constexpr const char *engravingDefaults
     = "{'engravingDefaults':{'thinBarlineThickness':0.15,'lyricLineThickness':0.125,"
       "'slurMidpointThickness':0.3,'staffLineThickness':0.075,'stemThickness':0.1,'tieMidpointThickness':0.25,"
       "'hairpinThickness':0.1,'thickBarlineThickness':0.5,'tupletBracketThickness':0.1,'subBracketThickness':0.5,"
-      "'bracketThickness':0.5,'repeatEndingLineThickness':0.15}}";
+      "'bracketThickness':0.5,'repeatEndingLineThickness':0.15, 'textEnclosureThickness': 0.2}}";
 
 //----------------------------------------------------------------------------
 // Option
@@ -966,6 +966,10 @@ Options::Options()
     m_systemMaxPerPage.Init(0, 0, 24);
     this->Register(&m_systemMaxPerPage, "systemMaxPerPage", &m_generalLayout);
 
+    m_textEnclosureThickness.SetInfo("Text box line thickness", "The thickness of the line text enclosing box");
+    m_textEnclosureThickness.Init(0.2, 0.10, 0.80);
+    this->Register(&m_textEnclosureThickness, "textEnclosureThickness", &m_generalLayout);
+
     m_thickBarlineThickness.SetInfo("Thick barline thickness", "The thickness of the thick barline");
     m_thickBarlineThickness.Init(1.0, 0.5, 2.0);
     this->Register(&m_thickBarlineThickness, "thickBarlineThickness", &m_generalLayout);
@@ -1244,7 +1248,9 @@ void Options::Sync()
               { "hairpinThickness", &m_hairpinThickness }, //
               { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, //
               { "lyricLineThickness", &m_lyricLineThickness }, //
-              { "tupletBracketThickness", &m_tupletBracketThickness } };
+              { "tupletBracketThickness", &m_tupletBracketThickness }, //
+              { "textEnclosureThickness", &m_textEnclosureThickness }
+    };
 
     for (auto &pair : engravingDefaults) {
         if (pair.second->isSet()) continue;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1249,7 +1249,7 @@ void Options::Sync()
               { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, //
               { "lyricLineThickness", &m_lyricLineThickness }, //
               { "tupletBracketThickness", &m_tupletBracketThickness }, //
-              { "textEnclosureThickness", &m_textEnclosureThickness }
+              { "textEnclosureThickness", &m_textEnclosureThickness } //
     };
 
     for (auto &pair : engravingDefaults) {

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -671,8 +671,7 @@ void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height,
 
     if (m_penStack.size()) {
         Pen currentPen = m_penStack.top();
-        if (currentPen.GetWidth() > 0)
-            rectChild.append_attribute("stroke") = GetColour(currentPen.GetColour()).c_str();
+        if (currentPen.GetWidth() > 0) rectChild.append_attribute("stroke") = GetColour(currentPen.GetColour()).c_str();
         if (currentPen.GetWidth() > 1)
             rectChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
         if (currentPen.GetOpacity() != 1.0)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -667,7 +667,25 @@ void SvgDeviceContext::DrawRectangle(int x, int y, int width, int height)
 
 void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height, int radius)
 {
-    std::string s;
+    pugi::xml_node rectChild = AppendChild("rect");
+
+    if (m_penStack.size()) {
+        Pen currentPen = m_penStack.top();
+        if (currentPen.GetWidth() > 0)
+            rectChild.append_attribute("stroke") = GetColour(currentPen.GetColour()).c_str();
+        if (currentPen.GetWidth() > 1)
+            rectChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
+        if (currentPen.GetOpacity() != 1.0)
+            rectChild.append_attribute("stroke-opacity") = StringFormat("%f", currentPen.GetOpacity()).c_str();
+    }
+
+    if (m_brushStack.size()) {
+        Brush currentBrush = m_brushStack.top();
+        if (currentBrush.GetColour() != AxNONE)
+            rectChild.append_attribute("fill") = GetColour(currentBrush.GetColour()).c_str();
+        if (currentBrush.GetOpacity() != 1.0)
+            rectChild.append_attribute("fill-opacity") = StringFormat("%f", currentBrush.GetOpacity()).c_str();
+    }
 
     // negative heights or widths are not allowed in SVG
     if (height < 0) {
@@ -679,7 +697,6 @@ void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height,
         x -= width;
     }
 
-    pugi::xml_node rectChild = AppendChild("rect");
     rectChild.append_attribute("x") = x;
     rectChild.append_attribute("y") = y;
     rectChild.append_attribute("height") = height;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1488,7 +1488,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params.m_boxedRend);
+        DrawTextBoxes(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(dir, this);
@@ -1570,7 +1570,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             dc->ResetFont();
             dc->ResetBrush();
         }
-        DrawTextBoxes(dc, params.m_boxedRend);
+        DrawTextBoxes(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(dynam, this);
@@ -1699,7 +1699,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params.m_boxedRend);
+        DrawTextBoxes(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(fing, this);
@@ -1865,7 +1865,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
             dc->ResetFont();
             dc->ResetBrush();
 
-            DrawTextBoxes(dc, params.m_boxedRend);
+            DrawTextBoxes(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
         }
     }
 
@@ -2087,7 +2087,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params.m_boxedRend);
+        DrawTextBoxes(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(reh, this);
@@ -2161,7 +2161,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params.m_boxedRend);
+        DrawTextBoxes(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(tempo, this);
@@ -2511,11 +2511,11 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         dc->EndGraphic(ending, this);
 }
 
-void View::DrawTextBoxes(DeviceContext *dc, const std::vector<TextElement *> &boxedRend)
+void View::DrawTextBoxes(DeviceContext *dc, const std::vector<TextElement *> &boxedRend, int staffSize)
 {
     assert(dc);
-    const int lineThickness = m_options->m_textEnclosureThickness.GetValue() * m_doc->GetDrawingUnit(100);
-    const int boxMargin = m_doc->GetDrawingUnit(100) / 2;
+    const int lineThickness = m_options->m_textEnclosureThickness.GetValue() * staffSize;
+    const int boxMargin = staffSize / 2;
 
     for (const auto rend : boxedRend) {
         const int x1 = rend->GetContentLeft() - boxMargin;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -42,6 +42,7 @@
 #include "options.h"
 #include "pedal.h"
 #include "reh.h"
+#include "rend.h"
 #include "slur.h"
 #include "smufl.h"
 #include "staff.h"
@@ -1464,7 +1465,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
         if (!system->SetCurrentFloatingPositioner((*staffIter)->GetN(), dir, dir->GetStart(), *staffIter)) {
             continue;
         }
-
+        params.m_boxedRend.clear();
         params.m_y = dir->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -1486,6 +1487,8 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
 
         dc->ResetFont();
         dc->ResetBrush();
+
+        DrawTextBoxes(dc, params.m_boxedRend);
     }
 
     dc->EndGraphic(dir, this);
@@ -1536,6 +1539,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             continue;
         }
 
+        params.m_boxedRend.clear();
         params.m_y = dynam->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -1566,6 +1570,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             dc->ResetFont();
             dc->ResetBrush();
         }
+        DrawTextBoxes(dc, params.m_boxedRend);
     }
 
     dc->EndGraphic(dynam, this);
@@ -1677,6 +1682,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
             continue;
         }
 
+        params.m_boxedRend.clear();
         params.m_y = fing->GetDrawingY();
 
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
@@ -1692,6 +1698,8 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
 
         dc->ResetFont();
         dc->ResetBrush();
+
+        DrawTextBoxes(dc, params.m_boxedRend);
     }
 
     dc->EndGraphic(fing, this);
@@ -1836,6 +1844,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
             continue;
         }
 
+        params.m_boxedRend.clear();
         params.m_y = harm->GetDrawingY();
 
         if (harm->GetFirst() && harm->GetFirst()->Is(FB)) {
@@ -1855,6 +1864,8 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
 
             dc->ResetFont();
             dc->ResetBrush();
+
+            DrawTextBoxes(dc, params.m_boxedRend);
         }
     }
 
@@ -2060,6 +2071,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
             continue;
         }
 
+        params.m_boxedRend.clear();
         params.m_y = reh->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -2074,6 +2086,8 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
 
         dc->ResetFont();
         dc->ResetBrush();
+
+        DrawTextBoxes(dc, params.m_boxedRend);
     }
 
     dc->EndGraphic(reh, this);
@@ -2124,6 +2138,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
             continue;
         }
 
+        params.m_boxedRend.clear();
         params.m_y = tempo->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -2145,6 +2160,8 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
 
         dc->ResetFont();
         dc->ResetBrush();
+
+        DrawTextBoxes(dc, params.m_boxedRend);
     }
 
     dc->EndGraphic(tempo, this);
@@ -2492,6 +2509,22 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         dc->EndResumedGraphic(ending, this);
     else
         dc->EndGraphic(ending, this);
+}
+
+void View::DrawTextBoxes(DeviceContext *dc, const std::vector<TextElement *> &boxedRend)
+{
+    assert(dc);
+    const int lineThickness = m_options->m_textEnclosureThickness.GetValue() * m_doc->GetDrawingUnit(100);
+    const int boxMargin = m_doc->GetDrawingUnit(100) / 2;
+
+    for (const auto rend : boxedRend) {
+        const int x1 = rend->GetContentLeft() - boxMargin;
+        const int y1 = rend->GetContentBottom() - boxMargin;
+        const int x2 = rend->GetContentRight() + boxMargin;
+        const int y2 = rend->GetContentTop() + 2 * boxMargin;
+
+        DrawNotFilledRectangle(dc, x1, y1, x2, y2, lineThickness, 0);
+    }
 }
 
 } // namespace vrv

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -114,7 +114,8 @@ void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int
     dc->SetPen(m_currentColour, penWidth, AxSOLID);
     dc->SetBrush(m_currentColour, AxTRANSPARENT);
 
-    dc->DrawRoundedRectangle(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
+    dc->DrawRoundedRectangle(
+        ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
 
     dc->ResetPen();
     dc->ResetBrush();

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -104,6 +104,24 @@ void View::DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, in
     return;
 }
 
+void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, int radius = 0)
+{
+    assert(dc); // DC cannot be NULL
+
+    BoundingBox::Swap(y1, y2);
+
+    const int penWidth = lineThinkness;
+    dc->SetPen(m_currentColour, penWidth, AxSOLID);
+    dc->SetBrush(m_currentColour, AxTRANSPARENT);
+
+    dc->DrawRoundedRectangle(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
+
+    dc->ResetPen();
+    dc->ResetBrush();
+
+    return;
+}
+
 /* Draw a filled rectangle with horizontal and vertical sides. */
 void View::DrawFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2)
 {

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -342,11 +342,11 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
         assert(dc->GetFont());
         int MHeight = m_doc->GetTextGlyphHeight('M', dc->GetFont(), false);
         if (rend->GetRend() == TEXTRENDITION_sup) {
-            yShift = m_doc->GetTextGlyphHeight('o', dc->GetFont(), false);
+            yShift += m_doc->GetTextGlyphHeight('o', dc->GetFont(), false);
             yShift += (MHeight * SUPER_SCRIPT_POSITION);
         }
         else {
-            yShift = MHeight * SUB_SCRIPT_POSITION;
+            yShift += MHeight * SUB_SCRIPT_POSITION;
         }
         params.m_y += yShift;
         params.m_verticalShift = true;
@@ -361,6 +361,13 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
         params.m_verticalShift = true;
         dc->GetFont()->SetSupSubScript(false);
         dc->GetFont()->SetPointSize(dc->GetFont()->GetPointSize() / SUPER_SCRIPT_FACTOR);
+    }
+
+    if (rend->GetRend() == TEXTRENDITION_box) {
+        params.m_boxedRend.push_back(rend);
+
+        params.m_x = rend->GetContentRight() + m_doc->GetDrawingUnit(100);
+        params.m_newLine = true;
     }
 
     if (customFont) dc->ResetFont();

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -353,7 +353,7 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
         dc->GetFont()->SetSupSubScript(true);
         dc->GetFont()->SetPointSize(dc->GetFont()->GetPointSize() * SUPER_SCRIPT_FACTOR);
     }
-    
+
     if ((rend->GetRend() == TEXTRENDITION_box) && (params.m_actualWidth != 0)) {
         params.m_x = params.m_actualWidth + m_doc->GetDrawingUnit(100);
         params.m_explicitPosition = true;


### PR DESCRIPTION
Added support for the rend="box" attribute in MEI, as well parsing "rectangle" and "square" attributes from MusicXML
![image](https://user-images.githubusercontent.com/1819669/96133270-8ecc3c00-0f03-11eb-9fa6-553bd8ab1345.png)
![image](https://user-images.githubusercontent.com/1819669/96133719-ab687400-0f03-11eb-8828-3eca94c0dd9f.png)

<details><summary>Example:</summary>
<p>

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><availability />
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2020-10-12T16:47:06" version="3.0.0-dev-[undefined]">
               <name>Verovio</name>
               <p>Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" ppq="1" clef.shape="G" clef.line="2" key.sig="0" meter.count="4" meter.unit="4">
                        <label>Piano</label>
                        <labelAbbr>Pno.</labelAbbr>
                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                           <note dur.ppq="1" dur="4" oct="6" pname="f" stem.dir="down" />
                           <note dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                           <note dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                        </layer>
                     </staff>
                     <dir staff="1" tstamp="1.000000" vgrp="2">
                        <rend rend="box">aa</rend>bb<rend rend="box">cc</rend>
                     </dir>
                     <dir staff="1" tstamp="1.00000" vgrp="1">
                        aa<rend rend="box">bb</rend>cc
                     </dir>
                  </measure>
                  </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</p>
</details>