### PR TITLE
fix(gh-actions): fix repo for deploy step

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -19,6 +19,7 @@ env:
   EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
 
   # gh-pages
+  GH_PAGES_REPO: rism-ch/verovio.org
   GH_PAGES_BRANCH: gh-pages
   GH_PAGES_FOLDER: gh-pages
 
@@ -309,9 +310,10 @@ jobs:
     needs: [build_cli, build_js]
 
     steps:
-      - name: Checkout GH_PAGES_BRANCH into GH_PAGES_FOLDER
+      - name: Checkout GH_PAGES_REPO into GH_PAGES_FOLDER
         uses: actions/checkout@v2
         with:
+          repository: ${{ env.GH_PAGES_REPO }}
           ref: ${{ env.GH_PAGES_BRANCH }}
           path: ${{ env.GH_PAGES_FOLDER }}
 


### PR DESCRIPTION
Another step for #1726 .

Build script now seems to run successfully. Deploy step still tries to checkout wrong repo, so this PR uses the check out action to point to the correct repo: rism-ch/verovio.org