### PR TITLE
ci(gh-actions): Add dry run mode for gh actions

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -340,7 +340,7 @@ jobs:
 
     steps:
       - name: Prepare deployment for rism-ch
-        if: github.repository_owner == env.RISM_OWNER
+        if: ${{ github.repository_owner == env.RISM_OWNER }}
         run: |
           echo "Enable deploy steps on rism-ch..."
           echo "DISABLE_DEPLOY_STEPS=false" >> $GITHUB_ENV
@@ -349,9 +349,9 @@ jobs:
           echo "IS_DRY_RUN=false" >> $GITHUB_ENV
 
       - name: Check deployment settings
-          run: |
-            echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
-            echo "IS_DRY_RUN = ${IS_DRY_RUN}"
+        run: |
+          echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
+          echo "IS_DRY_RUN = ${IS_DRY_RUN}"
 
   #########################################
   # Deploy the toolkit builds to gh-pages #
@@ -359,7 +359,7 @@ jobs:
   deploy_toolkit:
     name: Deploy JS toolkit
     runs-on: ubuntu-20.04
-    if: env.DISABLE_DEPLOY_STEPS == 'false'
+    if: ${{ env.DISABLE_DEPLOY_STEPS == 'false' }}
     # run deployment only after finishing the build jobs
     needs: [build_cpp, build_cli, build_js, prepare_deploy]
 
@@ -416,7 +416,7 @@ jobs:
       #          git status
 
       - name: Push changes to gh-pages (dry-run)
-        if: env.IS_DRY_RUN == 'true'
+        if: ${{ env.IS_DRY_RUN == 'true' }}
         working-directory: ${{ env.GH_PAGES_DIR }}
         run: |
           # Push all changes in one commit to the gh-pages repo
@@ -426,7 +426,7 @@ jobs:
           git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
 
       - name: Push changes to gh-pages
-        if: env.IS_DRY_RUN == 'false'
+        if: {{ env.IS_DRY_RUN == 'false' }}
         working-directory: ${{ env.GH_PAGES_DIR }}
         run: |
           # Push all changes in one commit to the gh-pages repo
@@ -493,7 +493,7 @@ jobs:
   deploy_docs:
     name: Deploy documentation
     runs-on: ubuntu-20.04
-    if: env.DISABLE_DEPLOY_STEPS == 'false'
+    if: ${{ env.DISABLE_DEPLOY_STEPS == 'false' }}
     # run deployment only after finishing the build job
     needs: [build_docs, prepare_deploy]
 
@@ -543,7 +543,7 @@ jobs:
       #          git status
 
       - name: Push changes to doxygen (dry-run)
-        if: env.IS_DRY_RUN == 'true'
+        if: ${{ env.IS_DRY_RUN == 'true' }}
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
           # Push all changes in one commit to the doxygen repo
@@ -554,14 +554,14 @@ jobs:
 
 
       - name: Push changes to doxygen
-          if: env.IS_DRY_RUN == 'false'
-          working-directory: ${{ env.DOXYGEN_DIR }}
-          run: |
-            # Push all changes in one commit to the doxygen repo
-            echo "Build branch ready to go."
+        if: ${{ env.IS_DRY_RUN == 'false' }}
+        working-directory: ${{ env.DOXYGEN_DIR }}
+        run: |
+          # Push all changes in one commit to the doxygen repo
+          echo "Build branch ready to go."
 
-            echo "Pushing to Github..."
-            git push origin HEAD:$DOXYGEN_BRANCH
+          echo "Pushing to Github..."
+          git push origin HEAD:$DOXYGEN_BRANCH
 
       - name: Congratulations
         if: ${{ success() }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ on:
 # globals
 env:
   # general settings
-  RISM_OWNER: rism-ch
+  RISM_OWNER: musicEnfanthen
   IS_DRY_RUN: true      # Flag used for dry-run mode in 'git push' command (default: true).
                         # Set it manually to 'false' if you need to deploy from fork.
                         # Will be programmatically set to 'false' for rism-ch repo.
@@ -401,7 +401,7 @@ jobs:
             git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
           else
             echo "Pushing to Github..."
-            git push origin HEAD:$GH_PAGES_BRANCH
+            # git push origin HEAD:$GH_PAGES_BRANCH
           fi
 
       - name: Congratulations
@@ -529,7 +529,7 @@ jobs:
             git push -v --dry-run origin HEAD:$DOXYGEN_BRANCH
           else
             echo "Pushing to Github..."
-            git push origin HEAD:$DOXYGEN_BRANCH
+            # git push origin HEAD:$DOXYGEN_BRANCH
           fi
 
       - name: Congratulations

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -7,13 +7,17 @@ on:
     branches:
       # Push events on develop branch
       - develop
-      # Push events on ci-test branch (only needed for testing purposes)
-      - ci-test
-      # Push events on travis-test branch (only needed for testing purposes)
-      - travis-test
+      # Push events on ci-test branch (uncomment if needed for testing purposes)
+      - '**'
 
 # globals
 env:
+  # general settings
+  RISM_OWNER: rism-ch
+  IS_DRY_RUN: true      # Flag used for dry-run mode in 'git push' command (default: true).
+                        # Set it manually to 'false' if you need to deploy from fork.
+                        # Will be programmatically set to 'false' for rism-ch repo.
+
   # build artifacts
   CLI_BUILD: cli-build
   DOC_BUILD: doc-build
@@ -378,13 +382,27 @@ jobs:
       #          git config --get remote.origin.url
       #          git status
 
+      - name: Disable dry-run mode on rism-ch
+        if: github.repository_owner == env.RISM_OWNER
+        # if we are on rism-ch repos
+        run: |
+          echo "Disabling dry-run mode..."
+          echo "IS_DRY_RUN=false" >> $GITHUB_ENV
+
       - name: Push changes to gh-pages
         working-directory: ${{ env.GH_PAGES_DIR }}
         run: |
           # Push all changes in one commit to the gh-pages repo
-          echo "Build branch ready to go. Pushing to Github..."
+          echo "Build branch ready to go."
 
-          git push origin HEAD:$GH_PAGES_BRANCH
+          if [ "$IS_DRY_RUN" = true ]
+          then
+            echo "Running git in dry-run mode..."
+            git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
+          else
+            echo "Pushing to Github..."
+            git push origin HEAD:$GH_PAGES_BRANCH
+          fi
 
       - name: Congratulations
         if: ${{ success() }}
@@ -475,14 +493,14 @@ jobs:
       - name: Configure git
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
-          echo "Configuring git"
+          echo "Configuring git..."
           git config user.name "github-actions"
           git config user.email "github-actions@users.noreply.github.com"
 
       - name: Commit files
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
-          echo "Running git commit"
+          echo "Running git commit..."
           git add .
           git commit -m "Auto-commit of documentation build for ${{ github.repository }}@${{ github.sha }}"
 
@@ -492,13 +510,27 @@ jobs:
       #          git config --get remote.origin.url
       #          git status
 
+      - name: Disable dry-run mode on rism-ch
+        if: github.repository_owner == env.RISM_OWNER
+        # if we are on rism-ch repos
+        run: |
+          echo "Disabling dry-run mode..."
+          echo "IS_DRY_RUN=false" >> $GITHUB_ENV
+
       - name: Push changes to doxygen
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
           # Push all changes in one commit to the doxygen repo
-          echo "Build branch ready to go. Pushing to Github..."
+          echo "Build branch ready to go."
 
-          git push origin HEAD:$DOXYGEN_BRANCH
+          if [ "$IS_DRY_RUN" = true ]
+          then
+            echo "Running git in dry-run mode..."
+            git push -v --dry-run origin HEAD:$DOXYGEN_BRANCH
+          else
+            echo "Pushing to Github..."
+            git push origin HEAD:$DOXYGEN_BRANCH
+          fi
 
       - name: Congratulations
         if: ${{ success() }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,15 +8,23 @@ on:
       # Push events on develop branch
       - develop
       # Push events on ci-test branch (uncomment if needed for testing purposes)
-      # - ci-test
+      - '**'
 
 # globals
 env:
   # general settings
   RISM_OWNER: rism-ch
-  IS_DRY_RUN: true      # Flag used for dry-run mode in 'git push' command (default: true).
-                        # Set it manually to 'false' if you need to deploy from fork.
-                        # Will be programmatically set to 'false' for rism-ch repo.
+
+  DISABLE_DEPLOY_STEPS: true    # Flag used to disable deploy steps at all (default: true).
+                                # TRUE (no matter what IS_DRY_RUN): Will skip deploy steps of the workflow.
+                                # FALSE (together with IS_DRY_RUN = true): Will allow to run deploy steps in dry-run mode.
+                                # FALSE (together with IS_DRY_RUN = false): Will allow to deploy/git push from fork.
+                                # Will be programmatically set to 'false' for rism-ch repo.
+
+  IS_DRY_RUN: true              # Flag used for dry-run mode in 'git push' command (default: true).
+                                # TRUE (needs DISABLE_DEPLOY_STEPS = false): Will allow to run deploy steps in dry-run mode.
+                                # FALSE (needs DISABLE_DEPLOY_STEPS = false): Will allow to deploy/git push from fork.
+                                # Will be programmatically set to 'false' for rism-ch repo.
 
   # build artifacts
   CLI_BUILD: cli-build
@@ -321,14 +329,39 @@ jobs:
           ls -al
 
 
+  ####################################
+  # Prepare deploy steps for RISM_CH #
+  ####################################
+  prepare_deploy:
+    name: Prepare deployment steps for rism-ch
+    runs-on: ubuntu-20.04
+    # run deployment only after finishing the build jobs
+    needs: [ build_cpp, build_cli, build_js ]
+
+    steps:
+      - name: Prepare deployment for rism-ch
+        if: github.repository_owner == env.RISM_OWNER
+        run: |
+          echo "Enable deploy steps on rism-ch..."
+          echo "DISABLE_DEPLOY_STEPS=false" >> $GITHUB_ENV
+
+          echo "Disabling dry-run mode on rism-ch..."
+          echo "IS_DRY_RUN=false" >> $GITHUB_ENV
+
+      - name: Check deployment settings
+          run: |
+            echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
+            echo "IS_DRY_RUN = ${IS_DRY_RUN}"
+
   #########################################
   # Deploy the toolkit builds to gh-pages #
   #########################################
   deploy_toolkit:
     name: Deploy JS toolkit
     runs-on: ubuntu-20.04
+    if: env.DISABLE_DEPLOY_STEPS == 'false'
     # run deployment only after finishing the build jobs
-    needs: [build_cpp, build_cli, build_js]
+    needs: [build_cpp, build_cli, build_js, prepare_deploy]
 
     steps:
       - name: Checkout GH_PAGES_REPO into GH_PAGES_DIR
@@ -382,27 +415,25 @@ jobs:
       #          git config --get remote.origin.url
       #          git status
 
-      - name: Disable dry-run mode on rism-ch
-        if: github.repository_owner == env.RISM_OWNER
-        # if we are on rism-ch repos
-        run: |
-          echo "Disabling dry-run mode..."
-          echo "IS_DRY_RUN=false" >> $GITHUB_ENV
-
-      - name: Push changes to gh-pages
+      - name: Push changes to gh-pages (dry-run)
+        if: env.IS_DRY_RUN == 'true'
         working-directory: ${{ env.GH_PAGES_DIR }}
         run: |
           # Push all changes in one commit to the gh-pages repo
           echo "Build branch ready to go."
 
-          if [ "$IS_DRY_RUN" = true ]
-          then
-            echo "Running git in dry-run mode..."
-            git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
-          else
-            echo "Pushing to Github..."
-            git push origin HEAD:$GH_PAGES_BRANCH
-          fi
+          echo "Running git in dry-run mode..."
+          git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
+
+      - name: Push changes to gh-pages
+        if: env.IS_DRY_RUN == 'false'
+        working-directory: ${{ env.GH_PAGES_DIR }}
+        run: |
+          # Push all changes in one commit to the gh-pages repo
+          echo "Build branch ready to go."
+
+          echo "Pushing to Github..."
+          git push origin HEAD:$GH_PAGES_BRANCH
 
       - name: Congratulations
         if: ${{ success() }}
@@ -462,8 +493,9 @@ jobs:
   deploy_docs:
     name: Deploy documentation
     runs-on: ubuntu-20.04
+    if: env.DISABLE_DEPLOY_STEPS == 'false'
     # run deployment only after finishing the build job
-    needs: [build_docs]
+    needs: [build_docs, prepare_deploy]
 
     steps:
       - name: Checkout DOXYGEN_REPO into DOXYGEN_DIR
@@ -510,27 +542,26 @@ jobs:
       #          git config --get remote.origin.url
       #          git status
 
-      - name: Disable dry-run mode on rism-ch
-        if: github.repository_owner == env.RISM_OWNER
-        # if we are on rism-ch repos
-        run: |
-          echo "Disabling dry-run mode..."
-          echo "IS_DRY_RUN=false" >> $GITHUB_ENV
-
-      - name: Push changes to doxygen
+      - name: Push changes to doxygen (dry-run)
+        if: env.IS_DRY_RUN == 'true'
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
           # Push all changes in one commit to the doxygen repo
           echo "Build branch ready to go."
 
-          if [ "$IS_DRY_RUN" = true ]
-          then
-            echo "Running git in dry-run mode..."
-            git push -v --dry-run origin HEAD:$DOXYGEN_BRANCH
-          else
+          echo "Running git in dry-run mode..."
+          git push -v --dry-run origin HEAD:$DOXYGEN_BRANCH
+
+
+      - name: Push changes to doxygen
+          if: env.IS_DRY_RUN == 'false'
+          working-directory: ${{ env.DOXYGEN_DIR }}
+          run: |
+            # Push all changes in one commit to the doxygen repo
+            echo "Build branch ready to go."
+
             echo "Pushing to Github..."
             git push origin HEAD:$DOXYGEN_BRANCH
-          fi
 
       - name: Congratulations
         if: ${{ success() }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,13 +8,13 @@ on:
       # Push events on develop branch
       - develop
       # Push events on ci-test branch (uncomment if needed for testing purposes)
-      - '**'
+      # - ci-test
 
 # globals
 env:
   # general settings
   RISM_OWNER: rism-ch
-  IS_DRY_RUN: false      # Flag used for dry-run mode in 'git push' command (default: true).
+  IS_DRY_RUN: true      # Flag used for dry-run mode in 'git push' command (default: true).
                         # Set it manually to 'false' if you need to deploy from fork.
                         # Will be programmatically set to 'false' for rism-ch repo.
 
@@ -401,7 +401,7 @@ jobs:
             git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
           else
             echo "Pushing to Github..."
-            # git push origin HEAD:$GH_PAGES_BRANCH
+            git push origin HEAD:$GH_PAGES_BRANCH
           fi
 
       - name: Congratulations
@@ -529,7 +529,7 @@ jobs:
             git push -v --dry-run origin HEAD:$DOXYGEN_BRANCH
           else
             echo "Pushing to Github..."
-            # git push origin HEAD:$DOXYGEN_BRANCH
+            git push origin HEAD:$DOXYGEN_BRANCH
           fi
 
       - name: Congratulations

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -20,7 +20,7 @@ env:
   TOOLKIT_BUILD: toolkit-build
 
   # doxygen
-  DOXYGEN_REPO: ${{ github.repository_owner }}/verovio-doxygen # works also for forks of verovio
+  DOXYGEN_REPO: ${{ github.repository_owner }}/verovio-doxygen # works from rism-ch and from forks
   DOXYGEN_BRANCH: master
 
   # emscripten
@@ -28,7 +28,7 @@ env:
   EMSCRIPTEN_CACHE_FOLDER: emsdk-cache
 
   # gh-pages
-  GH_PAGES_REPO: ${{ github.repository_owner }}/verovio.org  # works also for forks of verovio
+  GH_PAGES_REPO: ${{ github.repository_owner }}/verovio.org  # works from rism-ch and from forks
   GH_PAGES_BRANCH: gh-pages
 
   # temporary directories
@@ -154,10 +154,17 @@ jobs:
           echo "::set-env name=PATH::$env:PATH"
 
       - name: Run make
+        working-directory: ${{ github.workspace }}/tools
         run: |
-          cd $GITHUB_WORKSPACE/tools
           cmake ../cmake
           make -j8
+
+      - name: Check files
+        if: always()
+        working-directory: ${{ github.workspace }}/tools
+        run: |
+          pwd
+          ls -al
 
 
   ###########################
@@ -172,19 +179,19 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create temp dir
+        working-directory: ${{ github.workspace }}
         run: |
-          cd $GITHUB_WORKSPACE
           mkdir -p $TEMP_DIR/
 
       - name: Run make
+        working-directory: ${{ github.workspace }}/tools
         run: |
-          cd $GITHUB_WORKSPACE/tools
           cmake ../cmake
           make -j8
 
       - name: Update cli.txt
+        working-directory: ${{ github.workspace }}/tools
         run: |
-          cd $GITHUB_WORKSPACE/tools
           ./verovio -h > $GITHUB_WORKSPACE/$TEMP_DIR/cli.txt
 
       - name: Upload cli artifact
@@ -195,8 +202,8 @@ jobs:
 
       - name: Check files
         if: always()
+        working-directory: ${{ github.workspace }}/${{ env.TEMP_DIR }}
         run: |
-          cd $GITHUB_WORKSPACE/$TEMP_DIR/
           pwd
           ls -al
 
@@ -279,16 +286,21 @@ jobs:
       - name: Verify emscripten build
         run: emcc -v
 
-      - name: Create temp dir
+      - name: Create TEMP_DIR
+        working-directory: ${{ github.workspace }}
         run: |
-          cd $GITHUB_WORKSPACE
           mkdir -p $TEMP_DIR/
 
-      - name: Build Toolkit (${{ matrix.toolkit.target }}) with options ${{ matrix.toolkit.options }}
+      - name: Build toolkit (${{ matrix.toolkit.target }}) with options ${{ matrix.toolkit.options }}
+        working-directory: ${{ github.workspace }}/emscripten
         run: |
-          cd $GITHUB_WORKSPACE/emscripten
           echo "${{ matrix.toolkit.message }}"
           ./buildToolkit ${{ matrix.toolkit.options }}
+
+      - name: Copy build into TEMP_DIR
+        working-directory: ${{ github.workspace }}/emscripten
+        run: |
+          echo "Copy toolkit build into $TEMP_DIR..."
           cp build/${{ matrix.toolkit.filepath }} $GITHUB_WORKSPACE/$TEMP_DIR/
 
       - name: Upload js build artifact (${{ matrix.toolkit.target }})
@@ -299,8 +311,8 @@ jobs:
 
       - name: Check files
         if: always()
+        working-directory: ${{ github.workspace }}/${{ env.TEMP_DIR }}
         run: |
-          cd $GITHUB_WORKSPACE/$TEMP_DIR/
           pwd
           ls -al
 
@@ -403,11 +415,11 @@ jobs:
           doxygen --help
 
       - name: Upgrade doxygen conf
-        working-directory: ${{ github.WORKSPACE }}/doc
+        working-directory: ${{ github.workspace }}/doc
         run: doxygen -u verovio.conf
 
       - name: Build documentation with (updated) doxygen conf
-        working-directory: ${{ github.WORKSPACE }}/doc
+        working-directory: ${{ github.workspace }}/doc
         if: ${{ success() }}
         run: (cat verovio.conf ; echo "OUTPUT_DIRECTORY = $GITHUB_WORKSPACE/$DOXYGEN_DIR") | doxygen -
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,8 +13,8 @@ on:
 # globals
 env:
   # general settings
-  RISM_OWNER: musicEnfanthen
-  IS_DRY_RUN: true      # Flag used for dry-run mode in 'git push' command (default: true).
+  RISM_OWNER: rism-ch
+  IS_DRY_RUN: false      # Flag used for dry-run mode in 'git push' command (default: true).
                         # Set it manually to 'false' if you need to deploy from fork.
                         # Will be programmatically set to 'false' for rism-ch repo.
 


### PR DESCRIPTION
GH-Actions build workflow, as discussed in #1726 and implemented in #1751, deploys via `git push` to `<repository-owner>/verovio.org` and `<repository-owner>/verovio-doxygen` after finishing all steps. This is expected and desired behaviour on `rism-ch`, but could be undesired for verovio fork repos.

This PR adds a "dry-run mode" for verovio forks by adding a dry-run flag (`IS_DRY_RUN`) that is set to true by default. If so, `git push` commands will be executed as `git push -v --dry-run`, avoiding real push events to fork repos. When running on `rism-ch` repos, the `IS_DRY_RUN` flag is set programmatically to `false`, so push events behave normally. If forks need to actually push/deploy, the `IS_DRY_RUN` flag can be set manually to `false` in the `env` section at the top of the workflow.

Additionally, the PR mutes any other branches than `develop` to be run with the workflow, and uses gh-actions `working-directory: path/to/dir` option throughout the workflow instead of `cd /path/to/dir`.