### PR TITLE
ci(gh-actions): Mute automatic deployment from forks

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,11 +13,11 @@ on:
 # globals
 env:
   # general settings
-  MAIN_REPO_OWNER: musicEnfanthen      # Main repo owner (default: rism-ch; should not be changed)
+  MAIN_REPO_OWNER: rism-ch      # Main repo owner (default: rism-ch; should not be changed)
                                 # If changed, owner needs deploy permission to <owner>/verovio.org and <owner>/verovio-doxygen (cf. Deploy jobs).
                                 # DISABLE_DEPLOY_STEPS & IS_DRY_RUN are programmatically set to false for main repo owner.
 
-  DISABLE_DEPLOY_STEPS: true    # Flag used to disable deploy steps at all (default: true).
+  DISABLE_DEPLOY_STEPS: false    # Flag used to disable deploy steps at all (default: true).
                                 # TRUE (no matter what IS_DRY_RUN): Will skip deploy steps of the workflow.
                                 # FALSE (together with IS_DRY_RUN = true): Will allow to run deploy steps in dry-run mode.
                                 # FALSE (together with IS_DRY_RUN = false): Will allow to deploy/git push from fork.

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -352,7 +352,7 @@ jobs:
       - name: Enable deployment for main repo owner
         if: ${{ github.repository_owner == env.MAIN_REPO_OWNER }}
         run: |
-          echo "Enable deploy steps for main repo owner..."
+          echo "Enabling deploy steps for main repo owner..."
           echo "DISABLE_DEPLOY_STEPS=false" >> $GITHUB_ENV
 
           echo "Disabling dry-run mode for main repo owner..."
@@ -617,6 +617,8 @@ jobs:
   skip_deploy:
     name: Skip deployment if set
     runs-on: ubuntu-20.04
+    # always() is needed here to meet if-condition even if earlier steps failed
+    # cf. https://github.com/actions/runner/issues/491
     if: ${{ always() && needs.check_deploy_settings.outputs._DISABLE_DEPLOY_STEPS == 'true' }}
     needs: [ check_deploy_settings, deploy_toolkit, deploy_docs ]
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -23,7 +23,7 @@ env:
                                 # FALSE (together with IS_DRY_RUN = false): Will allow to deploy/git push from fork.
                                 # Will be programmatically set to 'false' for rism-ch repo.
 
-  IS_DRY_RUN: true              # Flag used for dry-run mode in 'git push' command (default: true).
+  IS_DRY_RUN: false             # Flag used for dry-run mode in 'git push' command (default: true).
                                 # TRUE (needs DISABLE_DEPLOY_STEPS = false): Will allow to run deploy steps in dry-run mode.
                                 # FALSE (needs DISABLE_DEPLOY_STEPS = false): Will allow to deploy/git push from fork.
                                 # Will be programmatically set to 'false' for rism-ch repo.

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -17,7 +17,7 @@ env:
                                 # If changed, owner needs deploy permission to <owner>/verovio.org and <owner>/verovio-doxygen (cf. Deploy jobs).
                                 # DISABLE_DEPLOY_STEPS & IS_DRY_RUN are programmatically set to false for main repo owner.
 
-  DISABLE_DEPLOY_STEPS: true    # Flag used to disable deploy steps at all (default: true).
+  DISABLE_DEPLOY_STEPS: false   # Flag used to disable deploy steps at all (default: true).
                                 # TRUE (no matter what IS_DRY_RUN): Will skip deploy steps of the workflow.
                                 # FALSE (together with IS_DRY_RUN = true): Will allow to run deploy steps in dry-run mode.
                                 # FALSE (together with IS_DRY_RUN = false): Will allow to deploy/git push from fork.
@@ -453,7 +453,7 @@ jobs:
           echo "Build branch ready to go."
 
           echo "Pushing to Github..."
-          git push origin HEAD:$GH_PAGES_BRANCH
+          # git push origin HEAD:$GH_PAGES_BRANCH
 
       - name: Congratulations
         if: ${{ success() && needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}
@@ -594,7 +594,7 @@ jobs:
           echo "Build branch ready to go."
 
           echo "Pushing to Github..."
-          git push origin HEAD:$DOXYGEN_BRANCH
+          # git push origin HEAD:$DOXYGEN_BRANCH
 
       - name: Congratulations
         if: ${{ success() && needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ on:
 # globals
 env:
   # general settings
-  MAIN_REPO_OWNER: rism-ch      # Main repo owner (default: rism-ch; should not be changed)
+  MAIN_REPO_OWNER: musicEnfanthen      # Main repo owner (default: rism-ch; should not be changed)
                                 # If changed, owner needs deploy permission to <owner>/verovio.org and <owner>/verovio-doxygen (cf. Deploy jobs).
                                 # DISABLE_DEPLOY_STEPS & IS_DRY_RUN are programmatically set to false for main repo owner.
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -8,7 +8,7 @@ on:
       # Push events on develop branch
       - develop
       # Push events on ci-test branch (uncomment if needed for testing purposes)
-      - '**'
+      # - ci-test
 
 # globals
 env:
@@ -17,7 +17,7 @@ env:
                                 # If changed, owner needs deploy permission to <owner>/verovio.org and <owner>/verovio-doxygen (cf. Deploy jobs).
                                 # DISABLE_DEPLOY_STEPS & IS_DRY_RUN are programmatically set to false for main repo owner.
 
-  DISABLE_DEPLOY_STEPS: false    # Flag used to disable deploy steps at all (default: true).
+  DISABLE_DEPLOY_STEPS: true    # Flag used to disable deploy steps at all (default: true).
                                 # TRUE (no matter what IS_DRY_RUN): Will skip deploy steps of the workflow.
                                 # FALSE (together with IS_DRY_RUN = true): Will allow to run deploy steps in dry-run mode.
                                 # FALSE (together with IS_DRY_RUN = false): Will allow to deploy/git push from fork.
@@ -453,7 +453,7 @@ jobs:
           echo "Build branch ready to go."
 
           echo "Pushing to Github..."
-          # git push origin HEAD:$GH_PAGES_BRANCH
+          git push origin HEAD:$GH_PAGES_BRANCH
 
       - name: Congratulations
         if: ${{ success() && needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}
@@ -594,7 +594,7 @@ jobs:
           echo "Build branch ready to go."
 
           echo "Pushing to Github..."
-          # git push origin HEAD:$DOXYGEN_BRANCH
+          git push origin HEAD:$DOXYGEN_BRANCH
 
       - name: Congratulations
         if: ${{ success() && needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -17,13 +17,13 @@ env:
                                 # If changed, owner needs deploy permission to <owner>/verovio.org and <owner>/verovio-doxygen (cf. Deploy jobs).
                                 # DISABLE_DEPLOY_STEPS & IS_DRY_RUN are programmatically set to false for main repo owner.
 
-  DISABLE_DEPLOY_STEPS: false   # Flag used to disable deploy steps at all (default: true).
+  DISABLE_DEPLOY_STEPS: true    # Flag used to disable deploy steps at all (default: true).
                                 # TRUE (no matter what IS_DRY_RUN): Will skip deploy steps of the workflow.
                                 # FALSE (together with IS_DRY_RUN = true): Will allow to run deploy steps in dry-run mode.
                                 # FALSE (together with IS_DRY_RUN = false): Will allow to deploy/git push from fork.
                                 # Will be programmatically set to 'false' for rism-ch repo.
 
-  IS_DRY_RUN: false             # Flag used for dry-run mode in 'git push' command (default: true).
+  IS_DRY_RUN: true              # Flag used for dry-run mode in 'git push' command (default: true).
                                 # TRUE (needs DISABLE_DEPLOY_STEPS = false): Will allow to run deploy steps in dry-run mode.
                                 # FALSE (needs DISABLE_DEPLOY_STEPS = false): Will allow to deploy/git push from fork.
                                 # Will be programmatically set to 'false' for rism-ch repo.

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,9 @@ on:
 # globals
 env:
   # general settings
-  RISM_OWNER: rism-ch
+  MAIN_REPO_OWNER: rism-ch      # Main repo owner (default: rism-ch; should not be changed)
+                                # If changed, owner needs deploy permission to <owner>/verovio.org and <owner>/verovio-doxygen (cf. Deploy jobs).
+                                # DISABLE_DEPLOY_STEPS & IS_DRY_RUN are programmatically set to false for main repo owner.
 
   DISABLE_DEPLOY_STEPS: true    # Flag used to disable deploy steps at all (default: true).
                                 # TRUE (no matter what IS_DRY_RUN): Will skip deploy steps of the workflow.
@@ -329,29 +331,42 @@ jobs:
           ls -al
 
 
-  ####################################
-  # Prepare deploy steps for RISM_CH #
-  ####################################
-  prepare_deploy:
-    name: Prepare deployment steps for rism-ch
+  ##################################
+  # Check settings for deployment  #
+  ##################################
+  check_deploy_settings:
+    name: Check settings for deployment
     runs-on: ubuntu-20.04
     # run deployment only after finishing the build jobs
     needs: [ build_cpp, build_cli, build_js ]
 
+    # Github Environment Variables persist only on job level.
+    # To transfer values to later jobs, outputs mechanism has to be used.
+    # Cf. https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs
+    # So global envs are reset here as outputs.
+    outputs:
+      _DISABLE_DEPLOY_STEPS: ${{ steps.settings.outputs.disable }}
+      _IS_DRY_RUN: ${{ steps.settings.outputs.dry-run }}
+
     steps:
-      - name: Prepare deployment for rism-ch
-        if: ${{ github.repository_owner == env.RISM_OWNER }}
+      - name: Enable deployment for main repo owner
+        if: ${{ github.repository_owner == env.MAIN_REPO_OWNER }}
         run: |
-          echo "Enable deploy steps on rism-ch..."
+          echo "Enable deploy steps for main repo owner..."
           echo "DISABLE_DEPLOY_STEPS=false" >> $GITHUB_ENV
 
-          echo "Disabling dry-run mode on rism-ch..."
+          echo "Disabling dry-run mode for main repo owner..."
           echo "IS_DRY_RUN=false" >> $GITHUB_ENV
 
-      - name: Check deployment settings
+      - name: Check deployment settings and set them as outputs
+        id: settings
         run: |
           echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
           echo "IS_DRY_RUN = ${IS_DRY_RUN}"
+
+          echo "::set-output name=disable::${DISABLE_DEPLOY_STEPS}"
+          echo "::set-output name=dry-run::${IS_DRY_RUN}"
+
 
   #########################################
   # Deploy the toolkit builds to gh-pages #
@@ -359,17 +374,22 @@ jobs:
   deploy_toolkit:
     name: Deploy JS toolkit
     runs-on: ubuntu-20.04
-    if: ${{ env.DISABLE_DEPLOY_STEPS == 'false' }}
+    if: ${{ needs.check_deploy_settings.outputs._DISABLE_DEPLOY_STEPS == 'false' }}
     # run deployment only after finishing the build jobs
-    needs: [build_cpp, build_cli, build_js, prepare_deploy]
+    needs: [build_cpp, build_cli, build_js, check_deploy_settings]
 
     steps:
       - name: Checkout GH_PAGES_REPO into GH_PAGES_DIR
         uses: actions/checkout@v2
         with:
+          # repository to check out
           repository: ${{ env.GH_PAGES_REPO }}
+          # Deploy key as secret for accessing <owner>/<GH_PAGES_REPO>;
+          # cf. explanation in https://github.com/rism-ch/verovio/pull/1751
           ssh-key: ${{ secrets.GH_ACTIONS_DEPLOY_KEY }}
+          # ref (branch, tag or SHA) to check out
           ref: ${{ env.GH_PAGES_BRANCH }}
+          # relative path under $GITHUB_WORKSPACE to place the repository
           path: ${{ env.GH_PAGES_DIR }}
 
       - name: Download CLI_BUILD artifacts
@@ -416,7 +436,7 @@ jobs:
       #          git status
 
       - name: Push changes to gh-pages (dry-run)
-        if: ${{ env.IS_DRY_RUN == 'true' }}
+        if: ${{ needs.check_deploy_settings.outputs._IS_DRY_RUN == 'true' }}
         working-directory: ${{ env.GH_PAGES_DIR }}
         run: |
           # Push all changes in one commit to the gh-pages repo
@@ -426,7 +446,7 @@ jobs:
           git push -v --dry-run origin HEAD:$GH_PAGES_BRANCH
 
       - name: Push changes to gh-pages
-        if: {{ env.IS_DRY_RUN == 'false' }}
+        if: ${{ needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}
         working-directory: ${{ env.GH_PAGES_DIR }}
         run: |
           # Push all changes in one commit to the gh-pages repo
@@ -436,9 +456,18 @@ jobs:
           git push origin HEAD:$GH_PAGES_BRANCH
 
       - name: Congratulations
-        if: ${{ success() }}
+        if: ${{ success() && needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}
         run: |
           echo "🎉 New JS toolkit builds deployed 🎊"
+
+      - name: Skipped
+        # skip deployment when deploy steps are disabled or when we are in dry-run mode
+        if: ${{ needs.check_deploy_settings.outputs._IS_DRY_RUN == 'true' }}
+        run: |
+          echo "Deploy job skipped due to deployment settings..."
+
+          echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
+          echo "IS_DRY_RUN = ${IS_DRY_RUN}"
 
 
   ###################################
@@ -493,17 +522,22 @@ jobs:
   deploy_docs:
     name: Deploy documentation
     runs-on: ubuntu-20.04
-    if: ${{ env.DISABLE_DEPLOY_STEPS == 'false' }}
+    if: ${{ needs.check_deploy_settings.outputs._DISABLE_DEPLOY_STEPS == 'false' }}
     # run deployment only after finishing the build job
-    needs: [build_docs, prepare_deploy]
+    needs: [build_docs, check_deploy_settings]
 
     steps:
       - name: Checkout DOXYGEN_REPO into DOXYGEN_DIR
         uses: actions/checkout@v2
         with:
+          # repository to check out
           repository: ${{ env.DOXYGEN_REPO }}
+          # Deploy key as secret for accessing <owner>/<DOXYGEN_REPO>;
+          # cf. explanation in https://github.com/rism-ch/verovio/pull/1751
           ssh-key: ${{ secrets.GH_ACTIONS_DEPLOY_KEY_DOXYGEN }}
+          # ref (branch, tag or SHA) to check out
           ref: ${{ env.DOXYGEN_BRANCH }}
+          # relative path under $GITHUB_WORKSPACE to place the repository
           path: ${{ env.DOXYGEN_DIR }}
 
       - name: Download DOC_BUILD artifacts
@@ -543,7 +577,7 @@ jobs:
       #          git status
 
       - name: Push changes to doxygen (dry-run)
-        if: ${{ env.IS_DRY_RUN == 'true' }}
+        if: ${{ needs.check_deploy_settings.outputs._IS_DRY_RUN == 'true' }}
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
           # Push all changes in one commit to the doxygen repo
@@ -552,9 +586,8 @@ jobs:
           echo "Running git in dry-run mode..."
           git push -v --dry-run origin HEAD:$DOXYGEN_BRANCH
 
-
       - name: Push changes to doxygen
-        if: ${{ env.IS_DRY_RUN == 'false' }}
+        if: ${{ needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}
         working-directory: ${{ env.DOXYGEN_DIR }}
         run: |
           # Push all changes in one commit to the doxygen repo
@@ -564,6 +597,34 @@ jobs:
           git push origin HEAD:$DOXYGEN_BRANCH
 
       - name: Congratulations
-        if: ${{ success() }}
+        if: ${{ success() && needs.check_deploy_settings.outputs._IS_DRY_RUN == 'false' }}
         run: |
           echo "🎉 New documentation deployed 🎊"
+
+      - name: Skipped
+        # skip deployment when deploy steps are disabled or when we are in dry-run mode
+        if: ${{ needs.check_deploy_settings.outputs._IS_DRY_RUN == 'true' }}
+        run: |
+          echo "Deploy job skipped due to deployment settings..."
+
+          echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
+          echo "IS_DRY_RUN = ${IS_DRY_RUN}"
+
+
+  ###############################################
+  # Skip deployment steps according to settings #
+  ###############################################
+  skip_deploy:
+    name: Skip deployment if set
+    runs-on: ubuntu-20.04
+    if: ${{ always() && needs.check_deploy_settings.outputs._DISABLE_DEPLOY_STEPS == 'true' }}
+    needs: [ check_deploy_settings, deploy_toolkit, deploy_docs ]
+
+    steps:
+      - name: Skipped
+        # skip deployment when deploy steps are disabled or when we are in dry-run mode
+        run: |
+          echo "Deploy job skipped due to deployment settings..."
+
+          echo "DISABLE_DEPLOY_STEPS (env) = ${DISABLE_DEPLOY_STEPS}"
+          echo "IS_DRY_RUN (env) = ${IS_DRY_RUN}"


### PR DESCRIPTION
This PR addresses the issue raised in #1758 that on forks the gh-actions build workflow will not pass deployment steps in most cases due to missing permissions (secrets needed as described in #1751) or even missing forks of `.../verovio.org` and `.../verovio-doxygen` repos. These are the targets of the deployment from `rism-ch`, but can not be expected to exist on forks. Hence build workflow is likely to fail regularly on forks.

This PR introduces a check if the build workflow is running on `rism-ch` (set as `<MAIN_REPO_OWNER>`). If so, the deployment steps are automatically activated. For any other owner not matching `<MAIN_REPO_OWNER>` (forks), the deployment steps are skipped per default. They can be activated manually by setting the flag `DISABLE_DEPLOY_STEPS ` to `false`. Another flag, `IS_DRY_RUN` can be used together with `DISABLE_DEPLOY_STEPS: false` to call `git push` in dry-run mode in the deploy steps, so push event is only simulated, but not actually triggered. Different possible scenarios and their settings are reflected in the "test cases" of the single commits to this PR.

Fixes #1758.

Finishes #1757 .

Ready to merge.