### PR TITLE
Add support for additional fermatas in MusicXML import

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -317,8 +317,9 @@ private:
      * @name Helper method for styling fermatas
      */
     ///@{
-    ///@}
+    void SetFermataExternalSymbols(Fermata *fermata, const std::string &shape);
     void ShapeFermata(Fermata *fermata, pugi::xml_node node);
+    ///@}
 
     /*
      * @name Helper method for getting glyph numbers for ornaments based on approach/depart attributes

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3631,7 +3631,9 @@ fermataVis_SHAPE MusicXmlInput::ConvertFermataShape(const std::string &value)
     static const std::map<std::string, fermataVis_SHAPE> FermataShape2Id{
         { "normal", fermataVis_SHAPE_curved }, //
         { "angled", fermataVis_SHAPE_angular }, //
-        { "square", fermataVis_SHAPE_square } //
+        { "square", fermataVis_SHAPE_square }, //
+        { "double-angled", fermataVis_SHAPE_angular }, //
+        { "double-square", fermataVis_SHAPE_square } //
     };
 
     const auto result = FermataShape2Id.find(value);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3799,6 +3799,25 @@ bool MusicXmlInput::NotInEndingStack(const std::string &measureN)
     return true;
 }
 
+void MusicXmlInput::SetFermataExternalSymbols(Fermata *fermata, const std::string &shape)
+{
+    // When MEI adds support for all of these shapes, this can be merged with ConvertFermataShape()
+    static const std::map<std::string, std::string> fermataExtSymbolsAbove = { { "double-angled", "U+E4C2" },
+        { "double-square", "U+E4C8" }, { "double-dot", "U+E4CA" }, { "half-curve", "U+E4CC" }, { "curlew", "U+E4D6" } };
+    static const std::map<std::string, std::string> fermataExtSymbolsBelow = { { "double-angled", "U+E4C3" },
+        { "double-square", "U+E4C9" }, { "double-dot", "U+E4CB" }, { "half-curve", "U+E4CD" }, { "curlew", "U+E4D6" } };
+
+    if (const auto result = fermataExtSymbolsBelow.find(shape);
+             (fermata->GetForm() == fermataVis_FORM_inv) && (result != fermataExtSymbolsBelow.end())) {
+        fermata->SetExternalsymbols(fermata, "glyph.num", result->second);
+        fermata->SetExternalsymbols(fermata, "glyph.auth", "smufl");
+    }
+    else if (const auto result = fermataExtSymbolsAbove.find(shape); result != fermataExtSymbolsAbove.end()) {
+        fermata->SetExternalsymbols(fermata, "glyph.num", result->second);
+        fermata->SetExternalsymbols(fermata, "glyph.auth", "smufl");
+    }
+}
+
 void MusicXmlInput::ShapeFermata(Fermata *fermata, pugi::xml_node node)
 {
     assert(fermata);
@@ -3816,6 +3835,7 @@ void MusicXmlInput::ShapeFermata(Fermata *fermata, pugi::xml_node node)
         fermata->SetForm(fermataVis_FORM_norm);
         fermata->SetPlace(STAFFREL_above);
     }
+    SetFermataExternalSymbols(fermata, node.text().as_string());
 }
 
 bool MusicXmlInput::IsMultirestMeasure(int index) const


### PR DESCRIPTION
This PR adds support for the extended fermata range introduced with MusicXML 3.1 using `@glyph.num`.