### PR TITLE
Improve slur/tie thickness calculation

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -199,7 +199,7 @@ public:
     /**
      * Calculate thickness coeficient to be applient for bezier curve to fit MEI units thickness
      */
-    static double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle);
+    static double GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle);
 
     /**
      * Calculate the point bezier point position for a t between 0.0 and 1.0

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -199,7 +199,7 @@ public:
     /**
      * Calculate thickness coeficient to be applient for bezier curve to fit MEI units thickness
      */
-    static double GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle);
+    static double GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle, int penWidth);
 
     /**
      * Calculate the point bezier point position for a t between 0.0 and 1.0

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -187,6 +187,21 @@ public:
     static int CalcBezierAtPosition(const Point bezier[4], int x);
 
     /**
+     * Calculate linear interpolation between two points at time t
+     */
+    static void CalcLinearInterpolation(Point &dest, const Point &a, const Point &b, double t);
+
+    /**
+     * Calculate point (X,Y) coordinaties on the bezier curve
+     */
+    static Point CalcPointAtBezier(const Point bezier[4], double t);
+
+    /**
+     * Calculate thickness coeficient to be applient for bezier curve to fit MEI units thickness
+     */
+    static double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle);
+
+    /**
      * Calculate the point bezier point position for a t between 0.0 and 1.0
      */
     static Point CalcDeCasteljau(const Point bezier[4], double t);

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -566,7 +566,7 @@ public:
     OptionDbl m_slurMaxHeight;
     OptionInt m_slurMaxSlope;
     OptionDbl m_slurMinHeight;
-    OptionDbl m_slurThickness;
+    OptionDbl m_slurMidpointThickness;
     OptionInt m_spacingBraceGroup;
     OptionInt m_spacingBracketGroup;
     OptionBool m_spacingDurDetection;
@@ -580,7 +580,7 @@ public:
     OptionIntMap m_systemDivider;
     OptionInt m_systemMaxPerPage;
     OptionDbl m_thickBarlineThickness;
-    OptionDbl m_tieThickness;    
+    OptionDbl m_tieMidpointThickness;    
     OptionDbl m_tupletBracketThickness;
 
     /**
@@ -643,6 +643,14 @@ public:
     OptionDbl m_rightMarginRightBarLine;
     //
     OptionDbl m_topMarginHarm;
+
+    /**
+     * Deprecated options
+     */
+    OptionGrp m_deprecated;
+    
+    OptionDbl m_slurThickness;
+    OptionDbl m_tieThickness;
 
 private:
     /** The array of style parameters */

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -566,6 +566,7 @@ public:
     OptionDbl m_slurMaxHeight;
     OptionInt m_slurMaxSlope;
     OptionDbl m_slurMinHeight;
+    OptionDbl m_slurEndpointThickness;
     OptionDbl m_slurMidpointThickness;
     OptionInt m_spacingBraceGroup;
     OptionInt m_spacingBracketGroup;
@@ -580,6 +581,7 @@ public:
     OptionIntMap m_systemDivider;
     OptionInt m_systemMaxPerPage;
     OptionDbl m_thickBarlineThickness;
+    OptionDbl m_tieEndpointThickness;    
     OptionDbl m_tieMidpointThickness;    
     OptionDbl m_tupletBracketThickness;
 

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -496,8 +496,8 @@ protected:
     void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawSmuflCode(
         DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
-    void DrawThickBezierCurve(
-        DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle = 0.0, int penStyle = AxSOLID);
+    void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize,
+        int penWidth, float angle = 0.0, int penStyle = AxSOLID);
     void DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int fillSection);
     void DrawTextString(DeviceContext *dc, std::wstring str, TextDrawingParams &params);
     void DrawDynamString(DeviceContext *dc, std::wstring str, TextDrawingParams &params, Rend *rend);
@@ -598,7 +598,13 @@ protected:
      */
     int m_currentColour;
 
-    double m_bezierCurveThicknessCoeficient;
+    /** 
+     * Values to adjust tie/slur thickness by to have proper MEI values for thickness 
+    */
+    ///@{
+    double m_tieThicknessCoeficient;
+    double m_slurThicknessCoeficient;
+    ///@}
 
     /**
      * The current drawing score def.

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -598,6 +598,8 @@ protected:
      */
     int m_currentColour;
 
+    double m_bezierCurveThicknessCoeficient;
+
     /**
      * The current drawing score def.
      * The is set when starting to draw a page in DrawCurrentPage and then

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -752,8 +752,8 @@ void BoundingBox::CalcThickBezier(
 
     Point c1Rotated = bezier[1];
     Point c2Rotated = bezier[2];
-    c1Rotated.y += thickness / 2;
-    c2Rotated.y += thickness / 2;
+    c1Rotated.y += thickness * 0.575;
+    c2Rotated.y += thickness * 0.575;
     if (angle != 0.0) {
         c1Rotated = BoundingBox::CalcPositionAfterRotation(c1Rotated, angle, bezier[1]);
         c2Rotated = BoundingBox::CalcPositionAfterRotation(c2Rotated, angle, bezier[2]);
@@ -769,8 +769,8 @@ void BoundingBox::CalcThickBezier(
 
     c1Rotated = bezier[1];
     c2Rotated = bezier[2];
-    c1Rotated.y -= thickness / 2;
-    c2Rotated.y -= thickness / 2;
+    c1Rotated.y -= thickness * 0.575;
+    c2Rotated.y -= thickness * 0.575;
     if (angle != 0.0) {
         c1Rotated = BoundingBox::CalcPositionAfterRotation(c1Rotated, angle, bezier[1]);
         c2Rotated = BoundingBox::CalcPositionAfterRotation(c2Rotated, angle, bezier[2]);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -752,7 +752,7 @@ Point BoundingBox::CalcPointAtBezier(const Point bezier[4], double t)
     return midPoint;
 }
 
-double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle)
+double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle, int penWidth)
 {
     Point top[4], bottom[4];
     CalcThickBezier(bezier, currentThickness, angle, top, bottom);
@@ -762,7 +762,7 @@ double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int curr
 
     int actualThickness = sqrt((topMidpoint.x - bottomMidpoint.x) * (topMidpoint.x - bottomMidpoint.x)
         + (topMidpoint.y - bottomMidpoint.y) * (topMidpoint.y - bottomMidpoint.y));
-    return (double)currentThickness / (double)actualThickness;
+    return (double)currentThickness / (double)(actualThickness + penWidth);
 }
 
 Point BoundingBox::CalcDeCasteljau(const Point bezier[4], double t)

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -733,6 +733,38 @@ int BoundingBox::CalcBezierAtPosition(const Point bezier[4], int x)
     return p.y;
 }
 
+void BoundingBox::CalcLinearInterpolation(Point &dest, const Point &a, const Point &b, double t)
+{
+    dest.x = a.x + (b.x - a.x) * t;
+    dest.y = a.y + (b.y - a.y) * t;
+}
+
+Point BoundingBox::CalcPointAtBezier(const Point bezier[4], double t)
+{
+    Point p1, p2, p3, p4, p5;
+    CalcLinearInterpolation(p1, bezier[0], bezier[1], t);
+    CalcLinearInterpolation(p2, bezier[1], bezier[2], t);
+    CalcLinearInterpolation(p3, bezier[2], bezier[3], t);
+    CalcLinearInterpolation(p4, p1, p2, t);
+    CalcLinearInterpolation(p5, p2, p3, t);
+    Point midPoint;
+    CalcLinearInterpolation(midPoint, p4, p5, t); // middle point on the bezier-curve 
+    return midPoint;
+}
+
+double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle)
+{
+    Point top[4], bottom[4];
+    CalcThickBezier(bezier, currentThickness, angle, top, bottom);
+
+    Point topMidpoint = CalcPointAtBezier(top, 0.5);
+    Point bottomMidpoint = CalcPointAtBezier(bottom, 0.5);
+
+    int actualThickness = sqrt((topMidpoint.x - bottomMidpoint.x) * (topMidpoint.x - bottomMidpoint.x)
+        + (topMidpoint.y - bottomMidpoint.y) * (topMidpoint.y - bottomMidpoint.y));
+    return (double)currentThickness / (double)actualThickness;
+}
+
 Point BoundingBox::CalcDeCasteljau(const Point bezier[4], double t)
 {
     Point p;
@@ -752,8 +784,8 @@ void BoundingBox::CalcThickBezier(
 
     Point c1Rotated = bezier[1];
     Point c2Rotated = bezier[2];
-    c1Rotated.y += thickness * 0.575;
-    c2Rotated.y += thickness * 0.575;
+    c1Rotated.y += thickness * 0.5;
+    c2Rotated.y += thickness * 0.5;
     if (angle != 0.0) {
         c1Rotated = BoundingBox::CalcPositionAfterRotation(c1Rotated, angle, bezier[1]);
         c2Rotated = BoundingBox::CalcPositionAfterRotation(c2Rotated, angle, bezier[2]);
@@ -769,8 +801,8 @@ void BoundingBox::CalcThickBezier(
 
     c1Rotated = bezier[1];
     c2Rotated = bezier[2];
-    c1Rotated.y -= thickness * 0.575;
-    c2Rotated.y -= thickness * 0.575;
+    c1Rotated.y -= thickness * 0.5;
+    c2Rotated.y -= thickness * 0.5;
     if (angle != 0.0) {
         c1Rotated = BoundingBox::CalcPositionAfterRotation(c1Rotated, angle, bezier[1]);
         c2Rotated = BoundingBox::CalcPositionAfterRotation(c2Rotated, angle, bezier[2]);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -762,7 +762,9 @@ double BoundingBox::GetBezierThicknessCoeficient(const Point bezier[4], int curr
 
     int actualThickness = sqrt((topMidpoint.x - bottomMidpoint.x) * (topMidpoint.x - bottomMidpoint.x)
         + (topMidpoint.y - bottomMidpoint.y) * (topMidpoint.y - bottomMidpoint.y));
-    return (double)currentThickness / (double)(actualThickness + penWidth);
+    double adjustedThickness = currentThickness - penWidth;
+    if (adjustedThickness < 0) adjustedThickness = 0;
+    return adjustedThickness / actualThickness;
 }
 
 Point BoundingBox::CalcDeCasteljau(const Point bezier[4], double t)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -910,9 +910,9 @@ Options::Options()
     m_slurMaxSlope.Init(20, 0, 60);
     this->Register(&m_slurMaxSlope, "slurMaxSlope", &m_generalLayout);
 
-    m_slurThickness.SetInfo("Slur thickness", "The slur thickness in MEI units");
-    m_slurThickness.Init(0.6, 0.2, 1.2);
-    this->Register(&m_slurThickness, "slurThickness", &m_generalLayout);
+    m_slurMidpointThickness.SetInfo("Slur midpoint thickness", "The midpoint slur thickness in MEI units");
+    m_slurMidpointThickness.Init(0.6, 0.2, 1.2);
+    this->Register(&m_slurMidpointThickness, "slurMidpointThickness", &m_generalLayout);
 
     m_spacingBraceGroup.SetInfo(
         "Spacing brace group", "Minimum space between staves inside a braced group in MEI units");
@@ -968,9 +968,9 @@ Options::Options()
     m_thickBarlineThickness.Init(1.0, 0.5, 2.0);
     this->Register(&m_thickBarlineThickness, "thickBarlineThickness", &m_generalLayout);
 
-    m_tieThickness.SetInfo("Tie thickness", "The tie thickness in MEI units");
-    m_tieThickness.Init(0.5, 0.2, 1.0);
-    this->Register(&m_tieThickness, "tieThickness", &m_generalLayout);
+    m_tieMidpointThickness.SetInfo("Tie midpoint thickness", "The midpoint tie thickness in MEI units");
+    m_tieMidpointThickness.Init(0.5, 0.2, 1.0);
+    this->Register(&m_tieMidpointThickness, "tieMidpointThickness", &m_generalLayout);
 
     m_tupletBracketThickness.SetInfo("Tuplet bracket thickness", "The thickness of the tuplet bracket");
     m_tupletBracketThickness.Init(0.2, 0.1, 0.8);
@@ -1183,6 +1183,19 @@ Options::Options()
     m_topMarginHarm.Init(1.0, 0.0, 10.0);
     this->Register(&m_topMarginHarm, "topMarginHarm", &m_elementMargins);
 
+    /********* Deprecated options *********/
+
+    m_deprecated.SetLabel("Deprecated options", "Deprecated");
+    m_grps.push_back(&m_deprecated);
+    
+    m_slurThickness.SetInfo("Slur thickness", "The slur thickness in MEI units");
+    m_slurThickness.Init(0.6, 0.2, 2);
+    this->Register(&m_slurThickness, "slurThickness", &m_deprecated);
+
+    m_tieThickness.SetInfo("Tie  thickness", "The tie thickness in MEI units");
+    m_tieThickness.Init(0.5, 0.2, 1.0);
+    this->Register(&m_tieThickness, "tieThickness", &m_deprecated);
+
     /*
     // Example of a staffRel param
     OptionStaffrel rel;
@@ -1231,8 +1244,8 @@ void Options::Sync()
               { "stemThickness", &m_stemWidth }, //
               { "legerLineThickness", &m_ledgerLineThickness }, //
               { "legerLineExtension", &m_ledgerLineExtension }, //
-              { "slurMidpointThickness", &m_slurThickness }, //
-              { "tieMidpointThickness", &m_tieThickness }, //
+              { "slurMidpointThickness", &m_slurMidpointThickness }, //
+              { "tieMidpointThickness", &m_tieMidpointThickness }, //
               { "thinBarlineThickness", &m_barLineWidth }, //
               { "thickBarlineThickness", &m_thickBarlineThickness }, //
               { "barlineSeparation", &m_barLineSeparation }, //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -910,6 +910,10 @@ Options::Options()
     m_slurMaxSlope.Init(20, 0, 60);
     this->Register(&m_slurMaxSlope, "slurMaxSlope", &m_generalLayout);
 
+    m_slurEndpointThickness.SetInfo("Slur Endpoint thickness", "The Endpoint slur thickness in MEI units");
+    m_slurEndpointThickness.Init(0.1, 0.05, 0.25);
+    this->Register(&m_slurEndpointThickness, "slurEndpointThickness", &m_generalLayout);
+
     m_slurMidpointThickness.SetInfo("Slur midpoint thickness", "The midpoint slur thickness in MEI units");
     m_slurMidpointThickness.Init(0.6, 0.2, 1.2);
     this->Register(&m_slurMidpointThickness, "slurMidpointThickness", &m_generalLayout);
@@ -967,6 +971,10 @@ Options::Options()
     m_thickBarlineThickness.SetInfo("Thick barline thickness", "The thickness of the thick barline");
     m_thickBarlineThickness.Init(1.0, 0.5, 2.0);
     this->Register(&m_thickBarlineThickness, "thickBarlineThickness", &m_generalLayout);
+
+    m_tieEndpointThickness.SetInfo("Tie Endpoint thickness", "The Endpoint tie thickness in MEI units");
+    m_tieEndpointThickness.Init(0.1, 0.05, 0.25);
+    this->Register(&m_tieEndpointThickness, "tieEndpointThickness", &m_generalLayout);
 
     m_tieMidpointThickness.SetInfo("Tie midpoint thickness", "The midpoint tie thickness in MEI units");
     m_tieMidpointThickness.Init(0.5, 0.2, 1.0);
@@ -1244,7 +1252,9 @@ void Options::Sync()
               { "stemThickness", &m_stemWidth }, //
               { "legerLineThickness", &m_ledgerLineThickness }, //
               { "legerLineExtension", &m_ledgerLineExtension }, //
+              { "slurEndpointThickness", &m_slurEndpointThickness }, //
               { "slurMidpointThickness", &m_slurMidpointThickness }, //
+              { "tieEndpointThickness", &m_tieEndpointThickness }, //
               { "tieMidpointThickness", &m_tieMidpointThickness }, //
               { "thinBarlineThickness", &m_barLineWidth }, //
               { "thickBarlineThickness", &m_thickBarlineThickness }, //

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1012,6 +1012,26 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
                     }
                 }
             }
+            else if (iter->first == "slurThickness") {
+                LogWarning("Option slurThickness is deprecated; use slurMidpointThickness instead");
+                Option *opt = NULL;
+                if (json.has<jsonxx::Number>("slurThickness")) {
+                    double thickness = json.get<jsonxx::Number>("slurThickness");
+                    opt = m_options->GetItems()->at("slurMidpointThickness");
+                    assert(opt);
+                    opt->SetValueDbl(thickness);
+                }
+            }
+            else if (iter->first == "tieThickness") {
+                vrv::LogWarning("Option tieThickness is deprecated; use tieMidpointThickness instead");
+                Option *opt = NULL;
+                if (json.has<jsonxx::Number>("tieThickness")) {
+                    double thickness = json.get<jsonxx::Number>("tieThickness");
+                    opt = m_options->GetItems()->at("tieMidpointThickness");
+                    assert(opt);
+                    opt->SetValueDbl(thickness);
+                }
+            }
             else {
                 LogError("Unsupported option '%s'", iter->first.c_str());
             }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -29,6 +29,7 @@ View::View()
     m_doc = NULL;
     m_options = NULL;
     m_pageIdx = 0;
+    m_bezierCurveThicknessCoeficient = 0.0;
 
     m_currentColour = AxNONE;
     m_currentElement = NULL;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -29,7 +29,8 @@ View::View()
     m_doc = NULL;
     m_options = NULL;
     m_pageIdx = 0;
-    m_bezierCurveThicknessCoeficient = 0.0;
+    m_tieThicknessCoeficient = 0.0;
+    m_slurThicknessCoeficient = 0.0;
 
     m_currentColour = AxNONE;
     m_currentElement = NULL;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -891,7 +891,7 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
     if (x2 - x1 > 2 * m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize)) {
         height += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     }
-    int thickness = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tieThickness.GetValue();
+    int thickness = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tieMidpointThickness.GetValue();
 
     // control points
     Point c1, c2;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -935,7 +935,14 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
         dc->ResumeGraphic(graphic, graphic->GetUuid());
     else
         dc->StartGraphic(tie, "", tie->GetUuid(), false);
-    DrawThickBezierCurve(dc, bezier, thickness, staff->m_drawingStaffSize, 0, penStyle);
+    // set pen width and calculate tie thickness coeficient to adjust tie width in according to it
+    const int penWidth
+        = m_doc->GetOptions()->m_tieEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    if (m_tieThicknessCoeficient <= 0) {
+        m_tieThicknessCoeficient = BoundingBox::GetBezierThicknessCoeficient(bezier, thickness, 0, penWidth);
+    }
+    DrawThickBezierCurve(
+        dc, bezier, m_tieThicknessCoeficient * thickness, staff->m_drawingStaffSize, penWidth, 0, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
     else

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -286,17 +286,13 @@ void View::DrawSmuflString(DeviceContext *dc, int x, int y, std::wstring s, data
 }
 
 void View::DrawThickBezierCurve(
-    DeviceContext *dc, Point bezier[4], int thickness, int staffSize, float angle, int penStyle)
+    DeviceContext *dc, Point bezier[4], int thickness, int staffSize, int penWidth, float angle, int penStyle)
 {
     assert(dc);
 
     Point bez1[4], bez2[4]; // filled array with control points and end point
 
-    if (m_bezierCurveThicknessCoeficient <= 0) {
-        m_bezierCurveThicknessCoeficient = BoundingBox::GetBezierThicknessCoeficient(bezier, thickness, angle);
-    }
-
-    BoundingBox::CalcThickBezier(bezier, thickness * m_bezierCurveThicknessCoeficient, angle, bez1, bez2);
+    BoundingBox::CalcThickBezier(bezier, thickness, angle, bez1, bez2);
 
     bez1[0] = ToDeviceContext(bez1[0]);
     bez1[1] = ToDeviceContext(bez1[1]);
@@ -311,12 +307,12 @@ void View::DrawThickBezierCurve(
     // Actually draw it
     if (penStyle == AxSOLID) {
         // Solid Thick Bezier Curves are made of two beziers, filled in.
-        dc->SetPen(m_currentColour, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
+        dc->SetPen(m_currentColour, std::max(1, penWidth), penStyle);
         dc->DrawComplexBezierPath(bez1, bez2);
     }
     else {
         // Dashed or Dotted Thick Bezier Curves have a uniform line width.
-        dc->SetPen(m_currentColour, thickness, penStyle);
+        dc->SetPen(m_currentColour, penWidth, penStyle);
         dc->DrawSimpleBezierPath(bez1);
     }
     dc->ResetPen();

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -292,7 +292,11 @@ void View::DrawThickBezierCurve(
 
     Point bez1[4], bez2[4]; // filled array with control points and end point
 
-    BoundingBox::CalcThickBezier(bezier, thickness, angle, bez1, bez2);
+    if (m_bezierCurveThicknessCoeficient <= 0) {
+        m_bezierCurveThicknessCoeficient = BoundingBox::GetBezierThicknessCoeficient(bezier, thickness, angle);
+    }
+
+    BoundingBox::CalcThickBezier(bezier, thickness * m_bezierCurveThicknessCoeficient, angle, bez1, bez2);
 
     bez1[0] = ToDeviceContext(bez1[0]);
     bez1[1] = ToDeviceContext(bez1[1]);

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -68,7 +68,14 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
         // TODO: Implement wavy slur.
         default: break;
     }
-    DrawThickBezierCurve(dc, points, curve->GetThickness(), staff->m_drawingStaffSize, curve->GetAngle(), penStyle);
+    const int penWidth
+        = m_doc->GetOptions()->m_slurEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    if (m_slurThicknessCoeficient <= 0) {
+        m_slurThicknessCoeficient
+            = BoundingBox::GetBezierThicknessCoeficient(points, curve->GetThickness(), curve->GetAngle(), penWidth);
+    }
+    DrawThickBezierCurve(dc, points, m_slurThicknessCoeficient * curve->GetThickness(), staff->m_drawingStaffSize,
+        penWidth, curve->GetAngle(), penStyle);
 
     /*
     int i;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -419,7 +419,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     points[3] = Point(x2, y2);
 
     float angle = CalcInitialSlur(curve, slur, staff, layer->GetN(), drawingCurveDir, points);
-    int thickness = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_slurThickness.GetValue();
+    int thickness = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_slurMidpointThickness.GetValue();
 
     curve->UpdateCurveParams(points, angle, thickness, drawingCurveDir);
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -278,6 +278,19 @@ int main(int argc, char **argv)
                 key = long_options[option_index].name;
                 opt = params->at(toCamelCase(key));
                 optBool = dynamic_cast<vrv::OptionBool *>(opt);
+                
+                // Handle deprecated options
+                if (key == "slur-thickness") {
+                    vrv::LogWarning("Option --slur-thickness is deprecated; use --slur-midpoint-thickness instead");
+                    options->m_slurMidpointThickness.SetValue(optarg);
+                    break;
+                }
+                else if (key == "tie-thickness") {
+                    vrv::LogWarning("Option --tie-thickness is deprecated; use --tie-midpoint-thickness instead");
+                    options->m_tieMidpointThickness.SetValue(optarg);
+                    break;
+                }
+
                 if (optBool) {
                     optBool->SetValue(true);
                 }


### PR DESCRIPTION
A couple of changes to address slur/tie thickness to follow proper MEI units:
1. Deprecated existing thickness options by moving them to separate category. Not sure if there's another more proper way of deprecating them, since they are not a single letter options (like -b).
2. Added two pair of new options for midpoint and endpoint thickness for slurs and ties correspondingly.
3. Adjusted calculation for curve thickness to take into account penWidth and allow drawing curves that correspond exactly to the MEI unit values.

Example picture with tie having equal mid- and endpoint thickness (values are: slurEndpoint - 0.2, slurMidpoint - 0.75, tieEndpoint - 0.25, tieMidpoint - 0.25)
![image](https://user-images.githubusercontent.com/1819669/96713068-b65e5100-13a8-11eb-8446-f0ade36c6389.png)
