### PR TITLE
ci(gh-actions): Fix build compiler

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -87,21 +87,6 @@ jobs:
             compiler: clang
             version: "10"
 
-          #          - os: windows-latest
-          #            compiler: cl
-          #            version: "default"
-          #
-          #          - os: windows-latest
-          #            compiler: clang-cl
-          #            version: "latest"
-          #
-          #          - os: windows-latest
-          #            compiler: clang
-          #            version: "latest"
-          #
-          #          - os: windows-latest
-          #            compiler: gcc
-          #            version: "latest"
 
           - os: macos-latest
             compiler: xcode
@@ -149,24 +134,6 @@ jobs:
             echo CXX=clang++ >> $GITHUB_ENV
           fi
 
-      # Installation step for Windows
-      - name: Install Windows (${{ matrix.config.compiler }}-${{ matrix.config.version }})
-        if: runner.os == 'windows'
-        run: |
-          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-          scoop install ninja llvm --global
-          if ("${{ matrix.config.compiler }}" -eq "gcc") {
-            echo "::set-env name=CC::gcc"
-            echo "::set-env name=CXX::g++"
-          } elseif ("${{ matrix.config.compiler }}" -eq "clang") {
-            echo "::set-env name=CC::clang"
-            echo "::set-env name=CXX::clang++"
-          } else {
-            echo "::set-env name=CC::${{ matrix.config.compiler }}"
-            echo "::set-env name=CXX::${{ matrix.config.compiler }}"
-          }
-          # Make all PATH additions made by scoop and ourselves global.
-          echo "::set-env name=PATH::$env:PATH"
 
       - name: Run make
         working-directory: ${{ github.workspace }}/tools

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -58,15 +58,15 @@ jobs:
   # Adapted from https://github.com/DaanDeMeyer/reproc/blob/master/.github/workflows/main.yml . #
   ###############################################################################################
   build_cpp:
-    name: Build ${{ matrix.config.os }}-${{ matrix.config.compiler }}-${{ matrix.config.version }}
+    name: Build ${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.version }}
     # This job runs on all the os specified in strategy.matrix.os
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.os }}
 
     # set matrix with config options
     # (runs the following steps for every target in parallel)
     strategy:
       matrix:
-        config:
+        include:
           - os: ubuntu-20.04
             compiler: gcc
             version: "9"
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v2
 
       # Installation step for Ubuntu
-      - name: Install Ubuntu (${{ matrix.config.compiler }}-${{ matrix.config.version }})
+      - name: Configure Ubuntu with ${{ matrix.compiler }}-${{ matrix.version }}
         if: runner.os == 'Linux'
         run: |
           # TODO: Remove once https://github.com/actions/virtual-environments/issues/1536 is resolved.
@@ -121,7 +121,7 @@ jobs:
           fi
 
       # Installation step for MacOS
-      - name: Install macOS (${{ matrix.config.compiler }}-${{ matrix.config.version }})
+      - name: Configure macOS with ${{ matrix.compiler }}-${{ matrix.version }}
         if: runner.os == 'macOS'
         run: |
           brew install ninja llvm

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -87,14 +87,17 @@ jobs:
             compiler: clang
             version: "10"
 
-
-          - os: macos-latest
+          - os: macos-10.15
             compiler: xcode
-            version: "default"
+            version: "11.7"
 
-          - os: macos-latest
-            compiler: gcc
-            version: "latest"
+          - os: macos-10.15
+            compiler: xcode
+            version: "12.1"
+
+          - os: macos-10.15
+            compiler: g++
+            version: "9"
 
     steps:
       - name: Checkout main repo
@@ -126,14 +129,27 @@ jobs:
       - name: Configure macOS with ${{ matrix.compiler }}-${{ matrix.version }}
         if: runner.os == 'macOS'
         run: |
-          brew install ninja llvm
-          sudo ln -s /usr/local/opt/llvm/bin/clang-tidy /usr/local/bin/clang-tidy
-          if [ "${{ matrix.config.compiler }}" = "gcc" ]; then
-            echo CC=gcc >> $GITHUB_ENV
-            echo CXX=g++ >> $GITHUB_ENV
+          if [ "${{ matrix.compiler }}" == "g++" ]; then
+            # set environment variables (use alias gcc-9)
+            echo CC=gcc-${{ matrix.version }} >> $GITHUB_ENV
+            echo CXX=g++-${{ matrix.version }} >> $GITHUB_ENV
+
           else
-            echo CC=clang >> $GITHUB_ENV
-            echo CXX=clang++ >> $GITHUB_ENV
+            TARGET_XCODE="/Applications/Xcode_${{ matrix.version }}.app/Contents/Developer"
+
+            # check XCode version
+            if [ $(xcode-select --print-path | grep Xcode) == $TARGET_XCODE ] ; then
+              echo "XCode ${{ matrix.version }} already set..."
+            else
+              # switch XCode version
+              # cf. https://github.com/actions/virtual-environments/issues/257#issuecomment-573562956
+              echo "Found active $(xcodebuild -version | grep Xcode). Switching to XCode ${{ matrix.version }}..."
+              sudo xcode-select -s $TARGET_XCODE
+            fi
+
+            # set environment variables from XCode
+            echo CC=$(xcrun --find clang) >> $GITHUB_ENV
+            echo CXX=$(xcrun --find clang++) >> $GITHUB_ENV
           fi
 
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -65,6 +65,7 @@ jobs:
     # set matrix with config options
     # (runs the following steps for every target in parallel)
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-20.04
@@ -152,6 +153,14 @@ jobs:
             echo CXX=$(xcrun --find clang++) >> $GITHUB_ENV
           fi
 
+      - name: Check settings and dry-run make
+        working-directory: ${{ github.workspace }}/tools
+        run: |
+          echo "CC: ${CC}"
+          echo "CXX: ${CXX}"
+
+          cmake --version
+          cmake -S ../cmake -B debug -DCMAKE_BUILD_TYPE=Debug
 
       - name: Run make
         working-directory: ${{ github.workspace }}/tools

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -68,11 +68,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            compiler: gcc
+            compiler: g++
             version: "9"
 
           - os: ubuntu-20.04
-            compiler: gcc
+            compiler: g++
             version: "10"
 
           - os: ubuntu-20.04
@@ -104,20 +104,22 @@ jobs:
       - name: Configure Ubuntu with ${{ matrix.compiler }}-${{ matrix.version }}
         if: runner.os == 'Linux'
         run: |
-          # TODO: Remove once https://github.com/actions/virtual-environments/issues/1536 is resolved.
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal llvm-toolchain-focal-10 main' -y
-          sudo apt-get update -q
-          sudo apt-get install -y --no-install-recommends ninja-build clang-tidy-10
-          sudo ln -s /usr/bin/clang-tidy-10 /usr/local/bin/clang-tidy
-          if [ "${{ matrix.config.compiler }}" = "gcc" ]; then
-            sudo apt-get install -y --no-install-recommends g++-${{ matrix.config.version }}
-            echo CC=gcc-${{ matrix.config.version }} >> $GITHUB_ENV
-            echo CXX=g++-${{ matrix.config.version }} >> $GITHUB_ENV
+          # check if compiler is available from runner by default
+          if dpkg -l | grep ${{ matrix.compiler }}-${{ matrix.version }}; then
+            echo "${{ matrix.compiler }}-${{ matrix.version }} available from runner..."
           else
-            sudo apt-get install -y --no-install-recommends clang-${{ matrix.config.version }}
-            echo CC=clang-${{ matrix.config.version }} >> $GITHUB_ENV
-            echo CXX=clang++-${{ matrix.config.version }} >> $GITHUB_ENV
+            # if not, install compiler
+            sudo apt-get update -q
+            sudo apt-get install -y -q --no-install-recommends ${{ matrix.compiler }}-${{ matrix.version }}
+          fi
+
+          # set environment variables
+          if [ "${{ matrix.compiler }}" == "g++" ]; then
+            echo CC=gcc-${{ matrix.version }} >> $GITHUB_ENV
+            echo CXX=g++-${{ matrix.version }} >> $GITHUB_ENV
+          else
+            echo CC=clang-${{ matrix.version }} >> $GITHUB_ENV
+            echo CXX=clang++-${{ matrix.version }} >> $GITHUB_ENV
           fi
 
       # Installation step for MacOS


### PR DESCRIPTION
This PR fixes the incorrect compiler setup in the GH Actions build workflow.

On Ubuntu, it removes unused steps from setup and checks if requested compiler is available from runner by default, otherwise installs the compiler.
On macOs, it removes unused steps from setup and checks if the requested XCode version is running by default, or needs to be switched.
On Win, it removes unused steps, i.e. the complete Windows build section, because Win build is not set up properly in the workflow at the moment.

Builds are now checked against Ubuntu-20.04 (g++9 and 10, clang 6, 9, 10; with cmake 3.17.0) and macOs-10.15 (XCode 11.7 = AppleClang 11; XCode 12.1 = AppleClang 12, g++9; with cmake 3.18.4)

Fixes #1772 (closed already).

Ready to be merged.