### PR TITLE
Use score default for position of bar numbers

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -974,7 +974,7 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure)
         // HARDCODED
         // we set mNum to a fixed height above the system and make it a bit smaller than other text
         params.m_x = staff->GetDrawingX();
-        params.m_y = staff->GetDrawingY() + 1.5 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        params.m_y = staff->GetDrawingY() + m_doc->GetDrawingLyricFont(60)->GetPointSize();
         if (mnum->HasFontsize()) {
             data_FONTSIZE *fs = mnum->GetFontsizeAlternate();
             if (fs->GetType() == FONTSIZE_fontSizeNumeric) {


### PR DESCRIPTION
This is a small follow-up to #1770 adjusting the mNum distance from the system to depend on general font size instead of top most staff size. 