### PR TITLE
upgrade dur.ges from MEI3

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -684,6 +684,7 @@ private:
     ///@{
     // to MEI 4.0.0
     void UpgradeBeatRptTo_4_0_0(pugi::xml_node beatRpt, BeatRpt *vrvBeatRpt);
+    void UpgradeDurGesTo_4_0_0(pugi::xml_node element, DurationInterface *interface);
     void UpgradeFTremTo_4_0_0(pugi::xml_node fTrem, FTrem *vrvFTrem);
     void UpgradeMensurTo_5_0_0(pugi::xml_node mensur, Mensur *vrvMensur);
     void UpgradeMordentTo_4_0_0(pugi::xml_node mordent, Mordent *vrvMordent);


### PR DESCRIPTION
This PR adds an upgrade method for `@dur.ges` from MEI3 (mainly for valid MEI4 output). 