### PR TITLE
increase thickness of non-solid curves

### DIFF
--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -331,7 +331,7 @@ void View::DrawThickBezierCurve(
     }
     else {
         // Dashed or Dotted Thick Bezier Curves have a uniform line width.
-        dc->SetPen(m_currentColour, penWidth, penStyle);
+        dc->SetPen(m_currentColour, (thickness + penWidth) / 2, penStyle);
         dc->DrawSimpleBezierPath(bez1);
     }
     dc->ResetPen();


### PR DESCRIPTION
Instead of relying on SVG stroke width for non-solid slurs and ties use arithmetic mean of midpoint and endpoint thicknesses.