### PR TITLE
Import MusicXML dynamics to MEI note@vel and dynam@val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Support for `note@vel` and `dynamics@val` in MusicXML import (@earboxer)
 * Support for `multiRest@loc` (@rettinghaus)
 * Support for `mNum@fontsize` (@rettinghaus)
 * Support for `accidental-mark` in MusicXML import (@rettinghaus)

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_DYNAM_H__
 #define __VRV_DYNAM_H__
 
+#include "atts_midi.h"
 #include "controlelement.h"
 #include "textdirinterface.h"
 #include "timeinterface.h"
@@ -26,6 +27,8 @@ class Dynam : public ControlElement,
               public TimeSpanningInterface,
               public AttExtender,
               public AttLineRendBase,
+              public AttMidiValue,
+              public AttMidiValue2,
               public AttVerticalGroup {
 public:
     /**

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -329,7 +329,7 @@ private:
     std::string GetOrnamentGlyphNumber(int attributes) const;
 
     /*
-     * @name Methods for converting MusicXML string values to MEI attributes.
+     * @name Methods for converting MusicXML values to MEI attributes.
      */
     ///@{
     static data_ACCIDENTAL_WRITTEN ConvertAccidentalToAccid(const std::string &value);
@@ -340,6 +340,7 @@ private:
     static data_DURATION ConvertTypeToDur(const std::string &value);
     static data_HEADSHAPE ConvertNotehead(const std::string &value);
     static data_LINESTARTENDSYMBOL ConvertLineEndSymbol(const std::string &value);
+    static data_MIDIVALUE ConvertDynamicsToMidiVal(const float dynamics);
     static data_PITCHNAME ConvertStepToPitchName(const std::string &value);
     static data_TEXTRENDITION ConvertEnclosure(const std::string &value);
     static curvature_CURVEDIR InferCurvedir(const pugi::xml_node slurOrTie);

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -39,12 +39,16 @@ Dynam::Dynam()
     , TimeSpanningInterface()
     , AttExtender()
     , AttLineRendBase()
+    , AttMidiValue()
+    , AttMidiValue2()
     , AttVerticalGroup()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_EXTENDER);
     RegisterAttClass(ATT_LINERENDBASE);
+    RegisterAttClass(ATT_MIDIVALUE);
+    RegisterAttClass(ATT_MIDIVALUE2);
     RegisterAttClass(ATT_VERTICALGROUP);
 
     Reset();

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1214,6 +1214,8 @@ void MEIOutput::WriteDynam(pugi::xml_node currentNode, Dynam *dynam)
     WriteTimeSpanningInterface(currentNode, dynam);
     dynam->WriteExtender(currentNode);
     dynam->WriteLineRendBase(currentNode);
+    dynam->WriteMidiValue(currentNode);
+    dynam->WriteMidiValue2(currentNode);
     dynam->WriteVerticalGroup(currentNode);
 }
 
@@ -4089,6 +4091,8 @@ bool MEIInput::ReadDynam(Object *parent, pugi::xml_node dynam)
     ReadTimeSpanningInterface(dynam, vrvDynam);
     vrvDynam->ReadExtender(dynam);
     vrvDynam->ReadLineRendBase(dynam);
+    vrvDynam->ReadMidiValue(dynam);
+    vrvDynam->ReadMidiValue2(dynam);
     vrvDynam->ReadVerticalGroup(dynam);
 
     parent->AddChild(vrvDynam);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1958,7 +1958,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         if (node.select_node("sound")) {
             const float dynamics = node.select_node("sound").node().attribute("dynamics").as_float(-1.0);
             if (dynamics >= 0.0) {
-                dynam->SetVal(std::min(int((dynamics * 90) / 100), 127));
+                dynam->SetVal(ConvertDynamicsToMidiVal(dynamics));
             }
         }
 
@@ -2622,7 +2622,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         // dynamics (MIDI velocity)
         const float dynamics = node.attribute("dynamics").as_float(-1.0);
         if (dynamics >= 0.0) {
-            note->SetVel(std::min(int((dynamics * 90) / 100), 127));
+            note->SetVel(ConvertDynamicsToMidiVal(dynamics));
         }
 
         // notehead
@@ -3646,6 +3646,15 @@ data_LINESTARTENDSYMBOL MusicXmlInput::ConvertLineEndSymbol(const std::string &v
     }
 
     return LINESTARTENDSYMBOL_NONE;
+}
+
+data_MIDIVALUE MusicXmlInput::ConvertDynamicsToMidiVal(const float dynamics)
+{
+    if (dynamics > 0.0) {
+        int mididynam = int(dynamics * 90.0 / 100.0 + 0.5);
+        return std::max(1, std::min(127, mididynam));
+    }
+    return 0;
 }
 
 data_PITCHNAME MusicXmlInput::ConvertStepToPitchName(const std::string &value)

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1955,6 +1955,13 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 std::to_string(dynamic_cast<Staff *>(m_prevLayer->GetParent())->GetN())));
         }
 
+        if (node.select_node("sound")) {
+            const float dynamics = node.select_node("sound").node().attribute("dynamics").as_float(-1.0);
+            if (dynamics >= 0.0) {
+                dynam->SetVal(std::min(int((dynamics * 90) / 100), 127));
+            }
+        }
+
         TextRendition(dynamics, dynam);
         if (defaultY == 0) defaultY = dynamics.first().node().attribute("default-y").as_int();
         // parse the default_y attribute and transform to vgrp value, to vertically align dynamics and directives

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2612,6 +2612,12 @@ void MusicXmlInput::ReadMusicXmlNote(
             }
         }
 
+        // dynamics (MIDI velocity)
+        const float dynamics = node.attribute("dynamics").as_float(-1.0);
+        if (dynamics >= 0.0) {
+            note->SetVel(std::min(int((dynamics * 90) / 100), 127));
+        }
+
         // notehead
         pugi::xpath_node notehead = node.select_node("notehead");
         if (notehead) {


### PR DESCRIPTION
Thanks @rettinghaus for [pointing out](https://github.com/rism-ch/verovio/issues/1793#issuecomment-719716709) that `dynam@val` is what we want to convert `direction/sound@dynamics` into.

The equation `std::min(int((dynamics * 90) / 100), 127)` is based on the MusicXML spec

> Dynamics (or MIDI velocity) are expressed as a percentage of the default forte value (90 for MIDI 1.0).

Note that values between [0, 1.111] will all become 0. Users should take care, as many MIDI programs do not treat velocity 0 the same as velocities 1-127. As 0 is a valid value for [data.MIDIVALUE](https://music-encoding.org/guidelines/v4/data-types/data.midivalue.html), I don't think this should be changed.