### PR TITLE
* MusicXML Parsing: Don't create empty pgHead or pgFoot if there was …

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -582,10 +582,8 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     // generate page head
     pugi::xpath_node_set credits = root.select_nodes("/score-partwise/credit[@page='1']/credit-words");
     if (!credits.empty()) {
-        bool hasHead = false;
-        bool hasFoot = false;
-        PgHead *head = new PgHead();
-        PgFoot *foot = new PgFoot();
+        PgHead *head = NULL;
+        PgFoot *foot = NULL;
         for (pugi::xpath_node_set::const_iterator it = credits.begin(); it != credits.end(); ++it) {
             pugi::xpath_node words = *it;
             Rend *rend = new Rend();
@@ -603,18 +601,22 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                 rend->AttTypography::StrToFontweight(words.node().attribute("font-weight").as_string()));
             rend->AddChild(text);
             if (words.node().attribute("default-y").as_float() < 2 * bottom) {
+                if (!foot) {
+                    foot = new PgFoot();
+                }
                 foot->AddChild(rend);
-                hasFoot = true;
             }
             else {
+                if (!head) {
+                    head = new PgHead();
+                }
                 head->AddChild(rend);
-                hasHead = true;
             }
         }
-        if (hasHead) {
+        if (head) {
             m_doc->m_mdivScoreDef.AddChild(head);
         }
-        if (hasFoot) {
+        if (foot) {
             m_doc->m_mdivScoreDef.AddChild(foot);
         }
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -582,6 +582,8 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     // generate page head
     pugi::xpath_node_set credits = root.select_nodes("/score-partwise/credit[@page='1']/credit-words");
     if (!credits.empty()) {
+        bool hasHead = false;
+        bool hasFoot = false;
         PgHead *head = new PgHead();
         PgFoot *foot = new PgFoot();
         for (pugi::xpath_node_set::const_iterator it = credits.begin(); it != credits.end(); ++it) {
@@ -602,13 +604,19 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             rend->AddChild(text);
             if (words.node().attribute("default-y").as_float() < 2 * bottom) {
                 foot->AddChild(rend);
+                hasFoot = true;
             }
             else {
                 head->AddChild(rend);
+                hasHead = true;
             }
         }
-        m_doc->m_mdivScoreDef.AddChild(head);
-        m_doc->m_mdivScoreDef.AddChild(foot);
+        if (hasHead) {
+            m_doc->m_mdivScoreDef.AddChild(head);
+        }
+        if (hasFoot) {
+            m_doc->m_mdivScoreDef.AddChild(foot);
+        }
     }
 
     std::vector<StaffGrp *> m_staffGrpStack;


### PR DESCRIPTION
…nothing added there.

When verovio is run with `--header auto` or `--footer auto`, it will automatically create a header or footer *if and only if* there is no existing pgFoot or pgHead.

This PR makes it so that musicXML won't create an empty pgHead if there was only a pgFoot credit (and vice versa).

Thus, you can add explicit footer text (via MusicXML) while keeping the automatically generated header.

Related to #1352