### PR TITLE
Make Object::m_children private

### DIFF
--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -372,7 +372,7 @@ public:
      */
     virtual bool CopyChildren() const { return false; }
 
-    int GetAlignmentCount() const { return (int)m_children.size(); }
+    int GetAlignmentCount() const { return (int)GetChildren()->size(); }
 
     //----------//
     // Functors //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -255,9 +255,15 @@ public:
     Object *GetChild(int idx, const ClassId classId);
 
     /**
-     * Return a cont pointer to the children
+     * Return a const pointer to the children
      */
-    const ArrayOfObjects *GetChildren() { return &m_children; }
+    const ArrayOfObjects *GetChildren() const { return &m_children; }
+
+    /**
+     * Return a pointer to the children that allows modification.
+     * This method should be all only in AddChild overrides methods
+     */
+    ArrayOfObjects *GetChildrenForModification() { return &m_children; }
 
     /**
      * Fill an array of pairs with all attributes and their values.
@@ -1212,13 +1218,14 @@ public:
     ArrayOfStrAttr m_unsupported;
 
 protected:
+    //
+private:
     /**
      * A vector of child objects.
      * Unless SetAsReferenceObject is set or with detached and relinquished, the children are own by it.
      */
     ArrayOfObjects m_children;
 
-private:
     /**
      * A pointer to the parent object;
      */

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -257,7 +257,7 @@ public:
     /**
      * Return a const pointer to the children
      */
-    const ArrayOfObjects *GetChildren() const { return &m_children; }
+    virtual const ArrayOfObjects *GetChildren(bool docChildren = true) const { return &m_children; }
 
     /**
      * Return a pointer to the children that allows modification.

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -52,7 +52,7 @@ public:
     /**
      * Return the number of system (children are System object only)
      */
-    int GetSystemCount() const { return (int)m_children.size(); }
+    int GetSystemCount() const { return (int)GetChildren()->size(); }
 
     /**
      * @name Get and set the pixel per unit factor.

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -54,6 +54,11 @@ public:
     virtual void CloneReset();
 
     virtual FacsimileInterface *GetFacsimileInterface() { return dynamic_cast<FacsimileInterface *>(this); }
+    
+    /**
+     * Return a const pointer to the children
+     */
+    virtual const ArrayOfObjects *GetChildren(bool docChildren = true) const;
 
     /**
      * Delete all the legder line arrays.

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -128,14 +128,16 @@ void Chord::AddChild(Object *child)
         return;
     }
 
+    ArrayOfObjects *children = this->GetChildrenForModification();
+
     child->SetParent(this);
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is({ DOTS, STEM })) {
-        m_children.insert(m_children.begin(), child);
+        children->insert(children->begin(), child);
     }
     else {
-        m_children.push_back(child);
+        children->push_back(child);
     }
     Modify();
 }

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -168,16 +168,17 @@ void Measure::AddChildBack(Object *child)
     }
 
     child->SetParent(this);
-    if (m_children.empty()) {
-        m_children.push_back(child);
+    ArrayOfObjects *children = this->GetChildrenForModification();
+    if (children->empty()) {
+        children->push_back(child);
     }
-    else if (m_children.back()->Is(STAFF)) {
-        m_children.push_back(child);
+    else if (children->back()->Is(STAFF)) {
+        children->push_back(child);
     }
     else {
-        for (auto it = m_children.begin(); it != m_children.end(); ++it) {
+        for (auto it = children->begin(); it != children->end(); ++it) {
             if (!(*it)->Is(STAFF)) {
-                m_children.insert(it, child);
+                children->insert(it, child);
                 break;
             }
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -168,13 +168,15 @@ void Note::AddChild(Object *child)
 
     child->SetParent(this);
 
+    ArrayOfObjects *children = this->GetChildrenForModification();
+
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is({ DOTS, STEM })) {
-        m_children.insert(m_children.begin(), child);
+        children->insert(children->begin(), child);
     }
     else {
-        m_children.push_back(child);
+        children->push_back(child);
     }
     Modify();
 }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -587,7 +587,7 @@ int Page::GetContentHeight() const
         return 0;
     }
 
-    System *last = dynamic_cast<System *>(m_children.back());
+    System *last = dynamic_cast<System *>(GetChildren()->back());
     assert(last);
     int height = doc->m_drawingPageContentHeight - last->GetDrawingYRel() + last->GetHeight();
 
@@ -611,7 +611,7 @@ int Page::GetContentWidth() const
     assert(this == doc->GetDrawingPage());
 
     int maxWidth = 0;
-    for (auto &child : m_children) {
+    for (auto &child : *this->GetChildren()) {
         System *system = dynamic_cast<System *>(child);
         if (system) {
             // we include the left margin and the right margin

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -195,13 +195,15 @@ void Rest::AddChild(Object *child)
 
     child->SetParent(this);
 
+    ArrayOfObjects *children = this->GetChildrenForModification();
+
     // Dots are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is(DOTS)) {
-        m_children.insert(m_children.begin(), child);
+        children->insert(children->begin(), child);
     }
     else {
-        m_children.push_back(child);
+        children->push_back(child);
     }
     Modify();
 }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -96,6 +96,11 @@ void Staff::CloneReset()
     m_drawingStaffDef = NULL;
 }
 
+const ArrayOfObjects *Staff::GetChildren(bool docChildren) const
+{
+    return Object::GetChildren(true);
+}
+
 void Staff::ClearLedgerLines()
 {
     if (m_ledgerLinesAbove) {

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -135,7 +135,7 @@ int StaffGrp::OptimizeScoreDefEnd(FunctorParams *)
 
     this->SetDrawingVisibility(OPTIMIZATION_HIDDEN);
 
-    for (auto &child : m_children) {
+    for (auto &child : *this->GetChildren()) {
         if (child->Is(STAFFDEF)) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(child);
             assert(staffDef);
@@ -155,7 +155,7 @@ int StaffGrp::OptimizeScoreDefEnd(FunctorParams *)
     }
 
     if ((this->GetSymbol() == staffGroupingSym_SYMBOL_brace) && (this->GetDrawingVisibility() != OPTIMIZATION_HIDDEN)) {
-        for (auto &child : m_children) {
+        for (auto &child : *this->GetChildren()) {
             if (child->Is(STAFFDEF)) {
                 StaffDef *staffDef = vrv_cast<StaffDef *>(child);
                 assert(staffDef);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -120,13 +120,15 @@ void Tuplet::AddChild(Object *child)
 
     child->SetParent(this);
 
+    ArrayOfObjects *children = this->GetChildrenForModification();
+
     // Num and bracket are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
-        m_children.insert(m_children.begin(), child);
+        children->insert(children->begin(), child);
     }
     else {
-        m_children.push_back(child);
+        children->push_back(child);
     }
 
     Modify();

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -52,15 +52,17 @@ void SystemAligner::Reset()
 
 StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc)
 {
+    ArrayOfObjects *children = this->GetChildrenForModification();
+
     // The last one is always the bottomAlignment (unless if not created)
     if (m_bottomAlignment) {
         // remove it temporarily
-        this->m_children.pop_back();
+        children->pop_back();
     }
 
     if (idx < GetChildCount()) {
-        this->m_children.push_back(m_bottomAlignment);
-        return dynamic_cast<StaffAlignment *>(m_children.at(idx));
+        children->push_back(m_bottomAlignment);
+        return dynamic_cast<StaffAlignment *>(GetChildren()->at(idx));
     }
     // check that we are searching for the next one (not a gap)
     assert(idx == GetChildCount());
@@ -72,10 +74,10 @@ StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc
     alignment->SetStaff(staff, doc, GetAboveSpacingType(staff));
     alignment->SetParent(this);
     alignment->SetParentSystem(GetSystem());
-    m_children.push_back(alignment);
+    children->push_back(alignment);
 
     if (m_bottomAlignment) {
-        this->m_children.push_back(m_bottomAlignment);
+        children->push_back(m_bottomAlignment);
     }
 
     return alignment;
@@ -85,7 +87,7 @@ StaffAlignment *SystemAligner::GetStaffAlignmentForStaffN(int staffN) const
 {
     StaffAlignment *alignment = NULL;
     for (int i = 0; i < this->GetChildCount(); ++i) {
-        alignment = vrv_cast<StaffAlignment *>(m_children.at(i));
+        alignment = vrv_cast<StaffAlignment *>(GetChildren()->at(i));
         assert(alignment);
 
         if ((alignment->GetStaff()) && (alignment->GetStaff()->GetN() == staffN)) return alignment;
@@ -109,7 +111,7 @@ void SystemAligner::FindAllPositionerPointingTo(ArrayOfFloatingPositioners *posi
     positioners->clear();
 
     StaffAlignment *alignment = NULL;
-    for (const auto child : m_children) {
+    for (const auto child : *this->GetChildren()) {
         alignment = vrv_cast<StaffAlignment *>(child);
         assert(alignment);
         FloatingPositioner *positioner = alignment->GetCorrespFloatingPositioner(object);
@@ -123,7 +125,7 @@ void SystemAligner::FindAllIntersectionPoints(
     SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin)
 {
     StaffAlignment *alignment = NULL;
-    for (const auto child : m_children) {
+    for (const auto child : *this->GetChildren()) {
         alignment = vrv_cast<StaffAlignment *>(child);
         assert(alignment);
         alignment->FindAllIntersectionPoints(line, boundingBox, classIds, margin);
@@ -153,7 +155,7 @@ double SystemAligner::GetJustificationSum(const Doc *doc) const
     assert(doc);
 
     double justificationSum = 0.;
-    for (const auto child : m_children) {
+    for (const auto child : *this->GetChildren()) {
         StaffAlignment *alignment = dynamic_cast<StaffAlignment *>(child);
         justificationSum += alignment ? alignment->GetJustificationFactor(doc) : 0.;
     }


### PR DESCRIPTION
The additional method GetChildrenForModification is meant to be called only in AddChild methods (or similar methods for the Aligner classes).