### PR TITLE
Allow page footer to be shown when using --adjust-page-height

### DIFF
--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -179,7 +179,7 @@ bool Doc::GenerateDocumentScoreDef()
 
 bool Doc::GenerateFooter()
 {
-    if (m_mdivScoreDef.FindDescendantByType(PGFOOT) || m_options->m_adjustPageHeight.GetValue()) {
+    if (m_mdivScoreDef.FindDescendantByType(PGFOOT)) {
         return false;
     }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -739,25 +739,23 @@ int Page::AlignSystems(FunctorParams *functorParams)
     }
 
     RunningElement *footer = this->GetFooter();
-    Doc *doc = vrv_cast<Doc *>(GetFirstAncestor(DOC));
     if (footer) {
-        if (doc->GetOptions()->m_adjustPageHeight.GetValue()) {
+        if (params->m_doc->GetOptions()->m_adjustPageHeight.GetValue()) {
             int yRel = params->m_shift;
             if (GetChildCount()) {
                 for (Object *object : *GetChildren()) {
                     if (object->Is(SYSTEM)) {
                         System *system = vrv_cast<System *>(object);
                         yRel -= system->GetHeight();
-                        // TODO: Also subtract the system margin from yRel.
-                        // int systemMargin = system->GetIdx() ? params->m_systemMargin : 0;
-                        // if (systemMargin) {
-                        //    // One of these two...?
-                        //    const int margin
-                        //        = systemMargin - (params->m_prevBottomOverflow +
-                        //        system->m_systemAligner.GetOverflowAbove(params->m_doc));
-                        //    const int margin = doc->GetOptions()->m_spacingSystem.GetValue()) *
-                        //    doc->GetDrawingUnit(100); yRel -= margin > 0 ? margin : 0;
-                        //}
+                        // Also subtract the system margin from yRel, when there are multiple systems.
+                        int systemMargin = system->GetIdx() ? params->m_systemMargin : 0;
+                        if (systemMargin) {
+                            // TODO: Make sure this margin calculation is correct
+                            const int margin = systemMargin
+                                - (params->m_prevBottomOverflow
+                                    + system->m_systemAligner.GetOverflowAbove(params->m_doc) * 2);
+                            yRel -= margin > 0 ? margin : 0;
+                        }
                     }
                 }
             }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -591,10 +591,10 @@ int Page::GetContentHeight() const
     assert(last);
     int height = doc->m_drawingPageContentHeight - last->GetDrawingYRel() + last->GetHeight();
 
-    // Not sure what to do with the footer when adjusted page height is requested...
-    // if (this->GetFooter()) {
-    //    height += this->GetFooter()->GetTotalHeight();
-    //}
+    // Properly account for margins and footer when adjustPageHeight is set.
+    if (this->GetFooter()) {
+        height += this->GetFooter()->GetTotalHeight();
+    }
 
     return height;
 }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -737,10 +737,36 @@ int Page::AlignSystems(FunctorParams *functorParams)
         header->SetDrawingYRel(params->m_shift);
         params->m_shift -= header->GetTotalHeight() + bottomMarginPgHead;
     }
+
     RunningElement *footer = this->GetFooter();
+    Doc *doc = vrv_cast<Doc *>(GetFirstAncestor(DOC));
     if (footer) {
-        // We add twice the top margin, once for the origin moved at the top and one for the bottom margin
-        footer->SetDrawingYRel(footer->GetTotalHeight());
+        if (doc->GetOptions()->m_adjustPageHeight.GetValue()) {
+            int yRel = params->m_shift;
+            if (GetChildCount()) {
+                for (Object *object : *GetChildren()) {
+                    if (object->Is(SYSTEM)) {
+                        System *system = vrv_cast<System *>(object);
+                        yRel -= system->GetHeight();
+                        // TODO: Also subtract the system margin from yRel.
+                        // int systemMargin = system->GetIdx() ? params->m_systemMargin : 0;
+                        // if (systemMargin) {
+                        //    // One of these two...?
+                        //    const int margin
+                        //        = systemMargin - (params->m_prevBottomOverflow +
+                        //        system->m_systemAligner.GetOverflowAbove(params->m_doc));
+                        //    const int margin = doc->GetOptions()->m_spacingSystem.GetValue()) *
+                        //    doc->GetDrawingUnit(100); yRel -= margin > 0 ? margin : 0;
+                        //}
+                    }
+                }
+            }
+            footer->SetDrawingYRel(yRel);
+        }
+        else {
+            // We add twice the top margin, once for the origin moved at the top and one for the bottom margin
+            footer->SetDrawingYRel(footer->GetTotalHeight());
+        }
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
Works on https://github.com/rism-ch/verovio/issues/1802

~~This PR will allow some text elements to be rendered relative to the bottom of the page, if they start with the character 'M' (note how this is marked as WIP).~~

Here's a MusicXML file you can use to test this (~~notice how the footer text overlaps the lyrics for verse 2 when you run with `--adjust-page-height`~~).

~~**EDIT:** If you run this code with a file with multiple systems, then the footer will overlap the last system a bit.~~

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <movement-title> His Eye Is on the Sparrow</movement-title>
  <identification>
    <creator type="composer">Charles H. Gabriel</creator>
    <creator type="lyricist">Civilla D. Martin</creator>
    <encoding>
      <software>MuseScore 3.5.0</software>
      <encoding-date>2020-11-11</encoding-date>
      <supports element="accidental" type="yes"/>
      <supports element="beam" type="yes"/>
      <supports element="print" attribute="new-page" type="no"/>
      <supports element="print" attribute="new-system" type="no"/>
      <supports element="stem" type="yes"/>
      </encoding>
    </identification>
  <defaults>
    <page-layout>
      <page-height>1683.78</page-height>
      <page-width>1190.55</page-width>
      <page-margins type="even">
        <left-margin>56.6929</left-margin>
        <right-margin>56.6929</right-margin>
        <top-margin>56.6929</top-margin>
        <bottom-margin>113.386</bottom-margin>
        </page-margins>
      <page-margins type="odd">
        <left-margin>56.6929</left-margin>
        <right-margin>56.6929</right-margin>
        <top-margin>56.6929</top-margin>
        <bottom-margin>113.386</bottom-margin>
        </page-margins>
      </page-layout>
    </defaults>
  <credit page="1">
    <credit-words default-x="56.6929" default-y="0" justify="left" valign="top">My.Hymnary.org/song/77</credit-words>
    </credit>
  <part-list>
    <score-part id="P1">
      <part-name></part-name>
      <score-instrument id="P1-I1">
        <instrument-name></instrument-name>
        </score-instrument>
      <midi-device id="P1-I1" port="1"></midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>1</midi-program>
        <volume>78.7402</volume>
        <pan>0</pan>
        </midi-instrument>
      </score-part>
    </part-list>
  <part id="P1">
    <measure number="1" width="598.04">
      <print>
        <system-layout>
          <system-margins>
            <left-margin>-0.00</left-margin>
            <right-margin>0.00</right-margin>
            </system-margins>
          <top-system-distance>70.00</top-system-distance>
          </system-layout>
        </print>
      <attributes>
        <divisions>2</divisions>
        <key>
          <fifths>0</fifths>
          </key>
        <time>
          <beats>6</beats>
          <beat-type>8</beat-type>
          </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
          </clef>
        </attributes>
      <direction placement="above">
        <direction-type>
          <metronome parentheses="no" default-x="-38.74" relative-y="20.00">
            <beat-unit>quarter</beat-unit>
            <per-minute>100</per-minute>
            </metronome>
          </direction-type>
        <sound tempo="100"/>
        </direction>
      <note default-x="85.11" default-y="-30.00">
        <pitch>
          <step>G</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <beam number="1">begin</beam>
        <lyric number="1" default-x="6.58" default-y="-79.08" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>Why</text>
          </lyric>
        <lyric number="2" default-x="2.59" default-y="-105.42" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>“Let</text>
          </lyric>
        </note>
      <note default-x="176.42" default-y="-25.00">
        <pitch>
          <step>A</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <lyric number="1" default-x="6.58" default-y="-79.08" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>should</text>
          </lyric>
        <lyric number="2" default-x="6.58" default-y="-105.42" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>not</text>
          </lyric>
        </note>
      <note default-x="267.73" default-y="-30.00">
        <pitch>
          <step>G</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <beam number="1">end</beam>
        <lyric number="1" default-x="6.58" default-y="-79.08" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>I</text>
          </lyric>
        <lyric number="2" default-x="6.58" default-y="-105.42" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>your</text>
          </lyric>
        </note>
      <note default-x="359.04" default-y="-40.00">
        <pitch>
          <step>E</step>
          <octave>4</octave>
          </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
        <lyric number="1" default-x="6.58" default-y="-79.08" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>feel</text>
          </lyric>
        <lyric number="2" default-x="6.58" default-y="-105.42" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>heart</text>
          </lyric>
        </note>
      <note default-x="505.13" default-y="-50.00">
        <pitch>
          <step>C</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <lyric number="1" default-x="6.58" default-y="-79.08" relative-y="-30.00">
          <syllabic>begin</syllabic>
          <text>dis</text>
          </lyric>
        <lyric number="2" default-x="6.58" default-y="-105.42" relative-y="-30.00">
          <syllabic>single</syllabic>
          <text>be</text>
          </lyric>
        </note>
      </measure>
    <measure number="2" width="479.12">
      <note default-x="25.02" default-y="-45.00">
        <pitch>
          <step>D</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <lyric number="1" default-x="6.58" default-y="-79.08" relative-y="-30.00">
          <syllabic>middle</syllabic>
          <text>cour</text>
          </lyric>
        <lyric number="2" default-x="6.58" default-y="-105.42" relative-y="-30.00">
          <syllabic>begin</syllabic>
          <text>trou</text>
          </lyric>
        </note>
      <note default-x="104.21" default-y="-40.00">
        <pitch>
          <step>E</step>
          <octave>4</octave>
          </pitch>
        <duration>2</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
        <notations>
          <tied type="start"/>
          </notations>
        <lyric number="1" default-x="11.41" default-y="-79.08" relative-y="-30.00">
          <syllabic>end</syllabic>
          <text>aged?</text>
          </lyric>
        <lyric number="2" default-x="13.43" default-y="-105.42" relative-y="-30.00">
          <syllabic>end</syllabic>
          <text>bled,”</text>
          </lyric>
        </note>
      <note default-x="262.61" default-y="-40.00">
        <pitch>
          <step>E</step>
          <octave>4</octave>
          </pitch>
        <duration>3</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>quarter</type>
        <dot/>
        <stem>up</stem>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
        </barline>
      </measure>
    </part>
  </score-partwise>
```

TODOs:

- [x] Use a better condition for enabling this (maybe define constant VRV_100PERCENT, or use negative numbers, if that won't break anything)
- [x] don't use magic number (-1100) for negative dy offset
- [x] Fix placement so it doesn't overlap the system, and still allows for the same amount of page-margin-bottom