### PR TITLE
assign layer if no layer is present

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -224,11 +224,7 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int dur
 Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
 {
     // Find voice number of node
-    int layerNum = 1;
-    std::string layerNumStr = GetContentOfChild(node, "voice");
-    if (!layerNumStr.empty()) {
-        layerNum = atoi(layerNumStr.c_str());
-    }
+    int layerNum = node.child("voice").text().as_int();
     if (layerNum < 1) {
         LogWarning("MusicXML import: Layer %d cannot be found", layerNum);
         layerNum = 1;
@@ -247,13 +243,10 @@ Layer *MusicXmlInput::SelectLayer(pugi::xml_node node, Measure *measure)
                 return SelectLayer(layerNum, staff);
             }
         }
+        if ((*staff->GetChildren()).empty()) return SelectLayer(layerNum, staff);
     }
     // if not, take staff info of node element
-    int staffNum = 1;
-    std::string staffNumStr = GetContentOfChild(node, "staff");
-    if (!staffNumStr.empty()) {
-        staffNum = atoi(staffNumStr.c_str());
-    }
+    int staffNum = node.child("staff").text().as_int();
     if ((staffNum < 1) || (staffNum > measure->GetChildCount(STAFF))) {
         LogWarning("MusicXML import: Staff %d cannot be found", staffNum);
         staffNum = 1;


### PR DESCRIPTION
In some cases layer assignements were wrong in MusicXML import, because there were no layers in the first place. I addressed this and it seems to work fine as far as I tested it without affecting other files. 