### PR TITLE
Develop footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Support for `mNum@fontsize` (@rettinghaus)
 * Support for `accidental-mark` in MusicXML import (@rettinghaus)
 * Improved barline rendition (@rettinghaus)
+* Option --footer extended with 'always' value to show footer with --adjust-page-height
 
 ## [3.0.1] - 2020-10-22
 * Fix bug with mensural notation notes

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -53,7 +53,7 @@ class OptionGrp;
 
 enum option_BREAKS { BREAKS_none = 0, BREAKS_auto, BREAKS_line, BREAKS_encoded };
 
-enum option_FOOTER { FOOTER_none = 0, FOOTER_auto, FOOTER_encoded };
+enum option_FOOTER { FOOTER_none = 0, FOOTER_auto, FOOTER_encoded, FOOTER_always };
 
 enum option_HEADER { HEADER_none = 0, HEADER_auto, HEADER_encoded };
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -179,7 +179,7 @@ bool Doc::GenerateDocumentScoreDef()
 
 bool Doc::GenerateFooter()
 {
-    if (m_mdivScoreDef.FindDescendantByType(PGFOOT) || m_options->m_adjustPageHeight.GetValue()) {
+    if (m_mdivScoreDef.FindDescendantByType(PGFOOT)) {
         return false;
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -25,7 +25,7 @@ std::map<int, std::string> Option::s_breaks
     = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" }, { BREAKS_line, "line" }, { BREAKS_encoded, "encoded" } };
 
 std::map<int, std::string> Option::s_footer
-    = { { FOOTER_none, "none" }, { FOOTER_auto, "auto" }, { FOOTER_encoded, "encoded" } };
+    = { { FOOTER_none, "none" }, { FOOTER_auto, "auto" }, { FOOTER_encoded, "encoded" }, { FOOTER_always, "always" } };
 
 std::map<int, std::string> Option::s_header
     = { { HEADER_none, "none" }, { HEADER_auto, "auto" }, { HEADER_encoded, "encoded" } };

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -591,10 +591,9 @@ int Page::GetContentHeight() const
     assert(last);
     int height = doc->m_drawingPageContentHeight - last->GetDrawingYRel() + last->GetHeight();
 
-    // Not sure what to do with the footer when adjusted page height is requested...
-    // if (this->GetFooter()) {
-    //    height += this->GetFooter()->GetTotalHeight();
-    //}
+    if (this->GetFooter()) {
+        height += this->GetFooter()->GetTotalHeight();
+    }
 
     return height;
 }
@@ -737,12 +736,6 @@ int Page::AlignSystems(FunctorParams *functorParams)
         header->SetDrawingYRel(params->m_shift);
         params->m_shift -= header->GetTotalHeight() + bottomMarginPgHead;
     }
-    RunningElement *footer = this->GetFooter();
-    if (footer) {
-        // We add twice the top margin, once for the origin moved at the top and one for the bottom margin
-        footer->SetDrawingYRel(footer->GetTotalHeight());
-    }
-
     return FUNCTOR_CONTINUE;
 }
 
@@ -757,6 +750,18 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
     RunningElement *footer = this->GetFooter();
     if (footer) {
         this->m_drawingJustifiableHeight -= footer->GetTotalHeight();
+
+        if (params->m_doc->GetOptions()->m_adjustPageHeight.GetValue()) {
+            if (GetChildCount()) {
+                System *last = dynamic_cast<System *>(GetChildren()->back());
+                assert(last);
+                footer->SetDrawingYRel(last->GetDrawingYRel() - last->GetHeight());
+            }
+        }
+        else {
+            // We add twice the top margin, once for the origin moved at the top and one for the bottom margin
+            footer->SetDrawingYRel(footer->GetTotalHeight());
+        }
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -751,6 +751,7 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
     if (footer) {
         this->m_drawingJustifiableHeight -= footer->GetTotalHeight();
 
+        // Move it up below the last system
         if (params->m_doc->GetOptions()->m_adjustPageHeight.GetValue()) {
             if (GetChildCount()) {
                 System *last = dynamic_cast<System *>(GetChildren()->back());
@@ -759,7 +760,6 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
             }
         }
         else {
-            // We add twice the top margin, once for the origin moved at the top and one for the bottom margin
             footer->SetDrawingYRel(footer->GetTotalHeight());
         }
     }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -594,8 +594,11 @@ bool Toolkit::LoadData(const std::string &data)
         return false;
     }
 
+    bool adjustPageHeight = m_options->m_adjustPageHeight.GetValue();
+    int footerOption = m_options->m_footer.GetValue();
+    // With adjusted page height, show the footer if explicitly set (i.e., not with "auto")
     // generate the page header and footer if necessary
-    if (m_options->m_footer.GetValue() == FOOTER_auto) {
+    if (adjustPageHeight && (footerOption == FOOTER_always || footerOption == FOOTER_encoded)) {
         m_doc.GenerateFooter();
     }
     if (m_options->m_header.GetValue() == HEADER_auto) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -601,6 +601,9 @@ bool Toolkit::LoadData(const std::string &data)
     if (adjustPageHeight && (footerOption == FOOTER_always || footerOption == FOOTER_encoded)) {
         m_doc.GenerateFooter();
     }
+    if (!adjustPageHeight && (footerOption == FOOTER_auto)) {
+        m_doc.GenerateFooter();
+    }
     if (m_options->m_header.GetValue() == HEADER_auto) {
         m_doc.GenerateHeader();
     }


### PR DESCRIPTION
Adding footer 'always' value. This value displays displays the footer (encoded or generated) when the --adjust-page-height option is set. Default behaviour ('auto') remains unchanged.

Corresponding test added https://github.com/rism-ch/verovio.org/commit/da38bb80a0a8e647a3a87fe6cde45f6cc448ccbe