### PR TITLE
Improve arpeggio rendering

### DIFF
--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -57,6 +57,11 @@ public:
     void GetDrawingTopBottomNotes(Note *&top, Note *&bottom);
 
     /**
+     * Get cross staff of the front element if all elements of arpeggio are cross-staff
+     */
+    Staff *GetCrossStaff();
+
+    /**
      * @name Getter to interfaces
      */
     ///@{

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -800,7 +800,7 @@ int Alignment::AdjustArpeg(FunctorParams *functorParams)
             auto parent = measure->GetParent();
             Measure *previous = vrv_cast<Measure *>(parent->GetPrevious(measure, MEASURE));
             if (previous) {
-                Alignment* alignment = previous->m_measureAligner.GetRightBarLineAlignment();
+                Alignment *alignment = previous->m_measureAligner.GetRightBarLineAlignment();
                 alignment->GetLeftRight(-1, minLeft, maxRight);
                 if (maxRight != VRV_UNSET) {
                     const int previousWidth = previous->GetWidth();

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -794,6 +794,22 @@ int Alignment::AdjustArpeg(FunctorParams *functorParams)
             this->GetLeftRight(-1, minLeft, maxRight);
         }
 
+        // Make sure that there is no overlap with right barline of the previous measure
+        if ((maxRight == VRV_UNSET) && (m_type == ALIGNMENT_MEASURE_LEFT_BARLINE)) {
+            Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
+            auto parent = measure->GetParent();
+            Measure *previous = vrv_cast<Measure *>(parent->GetPrevious(measure, MEASURE));
+            if (previous) {
+                Alignment* alignment = previous->m_measureAligner.GetRightBarLineAlignment();
+                alignment->GetLeftRight(-1, minLeft, maxRight);
+                if (maxRight != VRV_UNSET) {
+                    const int previousWidth = previous->GetWidth();
+                    minLeft -= previousWidth;
+                    maxRight -= previousWidth;
+                }
+            }
+        }
+
         // Nothing, just continue
         if (maxRight == VRV_UNSET) {
             ++iter;
@@ -802,7 +818,7 @@ int Alignment::AdjustArpeg(FunctorParams *functorParams)
 
         int overlap = maxRight - std::get<1>(*iter)->GetCurrentFloatingPositioner()->GetSelfLeft();
         // HARDCODED
-        overlap += params->m_doc->GetDrawingUnit(100) / 2;
+        overlap += params->m_doc->GetDrawingUnit(100) / 2 * 3;
         // LogDebug("maxRight %d, %d %d", maxRight, std::get<2>(*iter), overlap);
         if (overlap > 0) {
             ArrayOfAdjustmentTuples boundaries{ std::make_tuple(this, std::get<0>(*iter), overlap) };


### PR DESCRIPTION
Fixes two problems:
1. Invalid apreggio placement with cross-staff chords (while chords with all cross-staff notes were placed properly)
2. Arpeggio were placed too close to the barline

<details><summary>Before:</summary>

![image](https://user-images.githubusercontent.com/1819669/100441782-acb6c000-30af-11eb-9947-e6186573d04f.png)
</details>
<details><summary>After:</summary>

![image](https://user-images.githubusercontent.com/1819669/100441629-75e0aa00-30af-11eb-9d5c-f70bdc7165b2.png)
</details>

<details><summary>Example:</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title />
            </titleStmt>
            <pubStmt />
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application isodate="2019-07-26T18:11:13" version="2.2.0-dev-5af3720-dirty">
                    <name>Verovio</name>
                    <p>Transcoded from Humdrum</p>
                </application>
            </appInfo>
        </encodingDesc>
        <workList>
            <work>
                <title />
            </work>
        </workList>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mdiv-0000000185785269">
                <score xml:id="score-0000001527786517">
                    <scoreDef xml:id="scoredef-0000000329098877" midi.bpm="400">
                        <staffGrp xml:id="staffgrp-0000001658129805" symbol="brace" bar.thru="true">
                            <labelAbbr xml:id="labelAbbr-0000000955151882" />
                            <staffDef xml:id="staffdef-0000000209116315" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" n="1" lines="5" />
                            <staffDef xml:id="staffdef-0000001365067336" clef.shape="F" clef.line="4" meter.count="4" meter.unit="4" n="2" lines="5" />
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="section-L1F1">
                        <measure xml:id="measure-L1" n="0">
                            <staff xml:id="staff-0000001163108496" n="1">
                                <layer xml:id="layer-L1F2N1" n="1">
                                    <note xml:id="note-L4F2" dur="1" oct="4" pname="c" accid.ges="n" />
                                </layer>
                            </staff>
                            <staff xml:id="staff-0000001245920871" n="2">
                                <layer xml:id="layer-L1F1N1" n="1">
                                    <mRest xml:id="mrest-L4F1" />
                                </layer>
                            </staff>
                        </measure>
                        <measure xml:id="measure-L5" n="2">
                            <staff xml:id="staff-L5F2N1" n="1">
                                <layer xml:id="layer-L5F2N1" n="1">
                                    <chord xml:id="chord-L6F2" dur="1">
                                        <note xml:id="note-L6F2S1" oct="4" pname="d" accid.ges="n" />
                                        <note xml:id="note-L6F2S2" oct="4" pname="f" accid.ges="n" />
                                        <note xml:id="note-L6F2S3" oct="4" pname="a" accid.ges="n" />
                                    </chord>
                                </layer>
                            </staff>
                            <staff xml:id="staff-L5F1N1" n="2">
                                <layer xml:id="layer-L5F1N1" n="1">
                                    <mRest xml:id="mrest-L6F1" />
                                </layer>
                            </staff>
                            <arpeg xml:id="arpeg-L6F2" plist="#chord-L6F2" />
                        </measure>
                        <measure xml:id="measure-L7" n="3">
                            <staff xml:id="staff-L7F2N1" n="1">
                                <layer xml:id="layer-L7F2N1" n="1">
                                    <chord xml:id="chord-L8F2" dur="1">
                                        <note xml:id="note-L8F2S1" oct="4" pname="d" accid="f" />
                                        <note xml:id="note-L8F2S2" oct="4" pname="f" accid="f" />
                                        <note xml:id="note-L8F2S3" oct="4" pname="a" accid="f" />
                                    </chord>
                                </layer>
                            </staff>
                            <staff xml:id="staff-L7F1N1" n="2">
                                <layer xml:id="layer-L7F1N1" n="1">
                                    <mRest xml:id="mrest-L8F1" />
                                </layer>
                            </staff>
                            <arpeg xml:id="arpeg-L8F2" plist="#chord-L8F2" />
                        </measure>
                        <measure xml:id="measure-L9" n="4">
                            <staff xml:id="staff-L9F2N1" n="1">
                                <layer xml:id="layer-L9F2N1" n="1">
                                    <chord xml:id="chord-L10F2" dur="1" staff="2" stem.dir="up">
                                        <note xml:id="note-L10F2S1" type="marked" oct="3" pname="d" color="chartreuse" accid="f" />
                                        <note xml:id="note-L10F2S2" type="marked" oct="3" pname="f" color="chartreuse" accid="f" />
                                        <note xml:id="note-L10F2S3" type="marked" oct="3" pname="a" color="chartreuse" accid="f" />
                                    </chord>
                                </layer>
                            </staff>
                            <staff xml:id="staff-L9F1N1" n="2">
                                <layer xml:id="layer-L9F1N1" n="1">
                                    <mRest xml:id="mrest-L10F1" ploc="g" oloc="2" />
                                </layer>
                            </staff>
                            <arpeg xml:id="arpeg-L10F2" plist="#chord-L10F2" />
                        </measure>
                        <measure xml:id="measure-L11" right="end" n="5">
                            <staff xml:id="staff-L11F2N1" n="1">
                                <layer xml:id="layer-L11F2N1" n="1">
                                    <chord xml:id="chord-L12F2" dur="1" stem.dir="up">
                                        <note xml:id="note-L12F2S1" staff="2" oct="3" pname="d" accid="f" />
                                        <note xml:id="note-L12F2S2" staff="2" oct="3" pname="f" accid="f" />
                                        <note xml:id="note-L12F2S3" staff="2" oct="3" pname="a" accid="f" />
                                        <note xml:id="note-L12F2S4" oct="4" pname="d" accid="f" />
                                    </chord>
                                </layer>
                            </staff>
                            <staff xml:id="staff-L11F1N1" n="2">
                                <layer xml:id="layer-L11F1N1" n="1">
                                    <mRest xml:id="mrest-L12F1" ploc="g" oloc="2" />
                                </layer>
                            </staff>
                            <arpeg xml:id="arpeg-L12F2" plist="#chord-L12F2" />
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
</details>