### PR TITLE
Improve layout with cross-staff content

### DIFF
--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -116,7 +116,7 @@ public:
     bool m_beamHasChord;
     bool m_hasMultipleStemDir;
     bool m_cueSize;
-    bool m_isCrossStaff;
+    bool m_hasCrossStaffContent;
     int m_shortestDur;
     data_STEMDIRECTION m_notesStemDir;
     data_BEAMPLACE m_drawingPlace;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1126,6 +1126,7 @@ void Beam::FilterList(ArrayOfObjects *childList)
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff);
     Staff *beamStaff = staff;
+    /*
     if (this->HasBeamWith()) {
         Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
         assert(measure);
@@ -1144,6 +1145,7 @@ void Beam::FilterList(ArrayOfObjects *childList)
             }
         }
     }
+    */
 
     InitCoords(childList, beamStaff, this->GetPlace());
 }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -112,7 +112,7 @@ void BeamSegment::CalcBeam(
     // Set drawing stem positions
     CalcBeamPosition(doc, staff, layer, beamInterface, horizontal);
     if (BEAMPLACE_mixed == beamInterface->m_drawingPlace) {
-        if (!beamInterface->m_isCrossStaff && NeedToResetPosition(staff, doc, beamInterface)) {
+        if (!beamInterface->m_hasCrossStaffContent && NeedToResetPosition(staff, doc, beamInterface)) {
             CalcBeamInit(layer, staff, doc, beamInterface, place);
             CalcBeamPosition(doc, staff, layer, beamInterface, horizontal);
         }
@@ -635,7 +635,7 @@ void BeamSegment::CalcBeamPosition(
         }
         // cross-staff or beam@place=mixed
         else {
-            if (beamInterface->m_isCrossStaff) {
+            if (beamInterface->m_hasCrossStaffContent) {
                 data_STEMDIRECTION dir
                     = (coord->m_beamRelativePlace == BEAMPLACE_above) ? STEMDIRECTION_up : STEMDIRECTION_down;
                 coord->SetDrawingStemDir(dir, staff, doc, this, beamInterface);
@@ -879,7 +879,7 @@ void BeamSegment::CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterfac
     else if (beamInterface->m_notesStemDir == STEMDIRECTION_down) {
         beamInterface->m_drawingPlace = BEAMPLACE_below;
     }
-    else if (beamInterface->m_isCrossStaff) {
+    else if (beamInterface->m_hasCrossStaffContent) {
         beamInterface->m_drawingPlace = BEAMPLACE_mixed;
     }
     // Look at the layer direction or, finally, at the note position
@@ -1261,7 +1261,7 @@ void BeamElementCoord::SetDrawingStemDir(
     }
 
     int stemLen = segment->m_uniformStemLength;
-    if (interface->m_isCrossStaff || (BEAMPLACE_mixed == interface->m_drawingPlace)) {
+    if (interface->m_hasCrossStaffContent || (BEAMPLACE_mixed == interface->m_drawingPlace)) {
         if (((STEMDIRECTION_up == stemDir) && (stemLen < 0)) || ((STEMDIRECTION_down == stemDir) && (stemLen > 0))) {
             stemLen *= -1;
         }
@@ -1274,7 +1274,7 @@ void BeamElementCoord::SetDrawingStemDir(
 
     // Make sure the stem reaches the center of the staff
     // Mark the segment as extendedToCenter since we then want a reduced slope
-    if (interface->m_isCrossStaff || (BEAMPLACE_mixed == interface->m_drawingPlace)) {
+    if (interface->m_hasCrossStaffContent || (BEAMPLACE_mixed == interface->m_drawingPlace)) {
         segment->m_extendedToCenter = false;
     }
     else if (((stemDir == STEMDIRECTION_up) && (this->m_yBeam <= segment->m_verticalCenter))

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -81,7 +81,7 @@ void BeamDrawingInterface::Reset()
     m_beamHasChord = false;
     m_hasMultipleStemDir = false;
     m_cueSize = false;
-    m_isCrossStaff = false;
+    m_hasCrossStaffContent = false;
     m_shortestDur = 0;
     m_notesStemDir = STEMDIRECTION_NONE;
     m_drawingPlace = BEAMPLACE_NONE;
@@ -163,7 +163,7 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
 
         Staff *staff = current->GetCrossStaff(layer);
         if (staff != currentStaff) {
-            this->m_isCrossStaff = true;
+            this->m_hasCrossStaffContent = true;
         }
         currentStaff = staff;
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1569,7 +1569,7 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         Beam *beam = vrv_cast<Beam *>(this);
         assert(beam);
         // Ignore it if it has cross-staff content but is not entirely cross-staff itself
-        if (beam->m_isCrossStaff && !beam->m_crossStaff) return FUNCTOR_CONTINUE;
+        if (beam->m_hasCrossStaffContent && !beam->m_crossStaff) return FUNCTOR_CONTINUE;
     }
 
     // Take into account stem for notes in cross-staff situation and in beams

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1564,16 +1564,23 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    // Ignore beam in cross-staff situation
+    // Take into account beam in cross-staff situation
     if (this->Is(BEAM)) {
-        Beam *beam = dynamic_cast<Beam *>(this);
-        if (beam && beam->m_isCrossStaff) return FUNCTOR_CONTINUE;
+        Beam *beam = vrv_cast<Beam *>(this);
+        assert(beam);
+        // Ignore it if it has cross-staff content but is not entirely cross-staff itself
+        if (beam->m_isCrossStaff && !beam->m_crossStaff) return FUNCTOR_CONTINUE;
     }
 
-    // Ignore stem for notes in cross-staff situation and in beams
+    // Take into account stem for notes in cross-staff situation and in beams
     if (this->Is(STEM)) {
         Note *note = dynamic_cast<Note *>(this->GetParent());
-        if (note && note->m_crossStaff && note->IsInBeam()) return FUNCTOR_CONTINUE;
+        if (note && note->m_crossStaff && note->IsInBeam()) {
+            Beam *beam = vrv_cast<Beam *>(note->GetFirstAncestor(BEAM));
+            assert(beam);
+            // Ignore it but only if the beam is not entirely cross-staff itself
+            if (!beam->m_crossStaff) return FUNCTOR_CONTINUE;
+        }
     }
 
     if (this->Is(FB) || this->Is(FIGURE)) {


### PR DESCRIPTION
* Fixes #1607
* Fixes #1566
* Also improves #1380 and #1799 
* `beam@beam.with` is no longer supported