### PR TITLE
Flag position improvement

### DIFF
--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -333,6 +333,7 @@ void Stem::AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &
 void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int verticalCenter, int duration)
 {
     Note *note = vrv_cast<Note *>(GetFirstAncestor(NOTE));
+    if (!note) return;
 
     const data_STEMDIRECTION stemDirection = GetDrawingStemDir();
     // For overlapping purposes we don't care for flags shorter than 16th since they grow in opposite direction

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -368,7 +368,11 @@ void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int vertical
     const int displacementMargin = (position - ledgerPosition) * directionBias;
 
     if (displacementMargin < 0) {
-        const int heightToAdjust = (displacementMargin / adjustmentStep - 1) * adjustmentStep * directionBias;
+        int offset = 0;
+        if ((stemDirection == STEMDIRECTION_down) && (displacementMargin % adjustmentStep > -adjustmentStep / 6)) {
+            offset = adjustmentStep / 2;
+        }
+        const int heightToAdjust = (displacementMargin / adjustmentStep - 1) * adjustmentStep * directionBias - offset;
         SetDrawingStemLen(GetDrawingStemLen() + heightToAdjust);
         flag->SetDrawingYRel(-GetDrawingStemLen());
     }

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -369,7 +369,7 @@ void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int vertical
 
     if (displacementMargin < 0) {
         int offset = 0;
-        if ((stemDirection == STEMDIRECTION_down) && (displacementMargin % adjustmentStep > -adjustmentStep / 6)) {
+        if ((stemDirection == STEMDIRECTION_down) && (displacementMargin % adjustmentStep > -adjustmentStep / 3)) {
             offset = adjustmentStep / 2;
         }
         const int heightToAdjust = (displacementMargin / adjustmentStep - 1) * adjustmentStep * directionBias - offset;


### PR DESCRIPTION
Slight improvement for the flag positioning. In some cases (e.g. with different fonts) calculated offset for the flags led to higher notes having flags positioned lower than lower notes.

<details><summary>Here some examples:</summary>

![image](https://user-images.githubusercontent.com/1819669/100995650-bda87b00-3560-11eb-92d4-19f3605f955a.png)
![image](https://user-images.githubusercontent.com/1819669/100996208-77075080-3561-11eb-85d9-33f9e1bd2a6e.png)
</details>
<details><summary>This fix makes those offsets go away:</summary>

![image](https://user-images.githubusercontent.com/1819669/100995940-255ec600-3561-11eb-922e-956cdf900d2e.png)
![image](https://user-images.githubusercontent.com/1819669/100995963-2ee82e00-3561-11eb-9b7c-dcde10c888a8.png)
</details>