### PR TITLE
Add styling support for multi-measure rests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Support for `multiRest@loc` (@rettinghaus)
 * Support for `mNum@fontsize` (@rettinghaus)
 * Support for `accidental-mark` in MusicXML import (@rettinghaus)
 * Improved barline rendition (@rettinghaus)

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -9,8 +9,10 @@
 #define __VRV_MULTIREST_H__
 
 #include "atts_cmn.h"
+#include "atts_shared.h"
 #include "atts_visual.h"
 #include "layerelement.h"
+#include "positioninterface.h"
 
 namespace vrv {
 
@@ -21,7 +23,7 @@ namespace vrv {
 /**
  * This class models the MEI <multiRest> element.
  */
-class MultiRest : public LayerElement, public AttColor, public AttMultiRestVis, public AttNumbered, public AttWidth {
+class MultiRest : public LayerElement, public PositionInterface, public AttColor, public AttMultiRestVis, public AttNumbered, public AttWidth {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -23,7 +23,12 @@ namespace vrv {
 /**
  * This class models the MEI <multiRest> element.
  */
-class MultiRest : public LayerElement, public PositionInterface, public AttColor, public AttMultiRestVis, public AttNumbered, public AttWidth {
+class MultiRest : public LayerElement,
+                  public PositionInterface,
+                  public AttColor,
+                  public AttMultiRestVis,
+                  public AttNumbered,
+                  public AttWidth {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -21,7 +21,7 @@ namespace vrv {
 /**
  * This class models the MEI <multiRest> element.
  */
-class MultiRest : public LayerElement, public AttColor, public AttMultiRestVis, public AttNumbered {
+class MultiRest : public LayerElement, public AttColor, public AttMultiRestVis, public AttNumbered, public AttWidth {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1754,6 +1754,7 @@ void MEIOutput::WriteMultiRest(pugi::xml_node currentNode, MultiRest *multiRest)
     multiRest->WriteColor(currentNode);
     multiRest->WriteMultiRestVis(currentNode);
     multiRest->WriteNumbered(currentNode);
+    multiRest->WriteWidth(currentNode);
 }
 
 void MEIOutput::WriteMultiRpt(pugi::xml_node currentNode, MultiRpt *multiRpt)
@@ -4965,6 +4966,7 @@ bool MEIInput::ReadMultiRest(Object *parent, pugi::xml_node multiRest)
     vrvMultiRest->ReadColor(multiRest);
     vrvMultiRest->ReadMultiRestVis(multiRest);
     vrvMultiRest->ReadNumbered(multiRest);
+    vrvMultiRest->ReadWidth(multiRest);
 
     parent->AddChild(vrvMultiRest);
     ReadUnsupportedAttr(multiRest, vrvMultiRest);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1750,6 +1750,7 @@ void MEIOutput::WriteMultiRest(pugi::xml_node currentNode, MultiRest *multiRest)
     assert(multiRest);
 
     WriteLayerElement(currentNode, multiRest);
+    WritePositionInterface(currentNode, multiRest);
     multiRest->WriteColor(currentNode);
     multiRest->WriteMultiRestVis(currentNode);
     multiRest->WriteNumbered(currentNode);
@@ -4960,6 +4961,7 @@ bool MEIInput::ReadMultiRest(Object *parent, pugi::xml_node multiRest)
     MultiRest *vrvMultiRest = new MultiRest();
     ReadLayerElement(multiRest, vrvMultiRest);
 
+    ReadPositionInterface(multiRest, vrvMultiRest);
     vrvMultiRest->ReadColor(multiRest);
     vrvMultiRest->ReadMultiRestVis(multiRest);
     vrvMultiRest->ReadNumbered(multiRest);

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -13,7 +13,8 @@ namespace vrv {
 // MultiRest
 //----------------------------------------------------------------------------
 
-MultiRest::MultiRest() : LayerElement("multirest-"), PositionInterface(), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()
+MultiRest::MultiRest()
+    : LayerElement("multirest-"), PositionInterface(), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()
 {
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -13,8 +13,9 @@ namespace vrv {
 // MultiRest
 //----------------------------------------------------------------------------
 
-MultiRest::MultiRest() : LayerElement("multirest-"), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()
+MultiRest::MultiRest() : LayerElement("multirest-"), PositionInterface(), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()
 {
+    RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_MULTIRESTVIS);
     RegisterAttClass(ATT_NUMBERED);
@@ -27,6 +28,7 @@ MultiRest::~MultiRest() {}
 void MultiRest::Reset()
 {
     LayerElement::Reset();
+    PositionInterface::Reset();
     ResetColor();
     ResetMultiRestVis();
     ResetNumbered();

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -13,11 +13,12 @@ namespace vrv {
 // MultiRest
 //----------------------------------------------------------------------------
 
-MultiRest::MultiRest() : LayerElement("multirest-"), AttColor(), AttMultiRestVis(), AttNumbered()
+MultiRest::MultiRest() : LayerElement("multirest-"), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_MULTIRESTVIS);
     RegisterAttClass(ATT_NUMBERED);
+    RegisterAttClass(ATT_WIDTH);
     Reset();
 }
 
@@ -29,6 +30,7 @@ void MultiRest::Reset()
     ResetColor();
     ResetMultiRestVis();
     ResetNumbered();
+    ResetWidth();
 }
 
 } // namespace vrv

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1254,8 +1254,8 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         // This is 1/2 the length of the black rectangle
         int width = measureWidth - 2 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
         if (multiRest->HasWidth()) {
-            width = multiRest->AttWidth::GetWidth();
-            if (width > measureWidth) LogWarning("measure too short");
+            const int fixedWidth = multiRest->AttWidth::GetWidth() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            width = (width > fixedWidth) ? fixedWidth : width;
         }
 
         // a is the central point, claculate x and x2
@@ -1264,6 +1264,9 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
 
         // Position centered in staff
         y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
+        if (multiRest->HasLoc()) {
+            y2 -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1 - multiRest->GetLoc());
+        }
         y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
         // bounding box is not relevant for the multi-rest rectangle

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1244,19 +1244,23 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    int width = measure->GetInnerWidth();
-    int xCentered = multiRest->GetDrawingX();
+    const int measureWidth = measure->GetInnerWidth();
+    const int xCentered = multiRest->GetDrawingX();
 
     // We do not support more than three chars
     int num = std::min(multiRest->GetNum(), 999);
 
     if ((num > 2) || (multiRest->GetBlock() == BOOLEAN_true)) {
         // This is 1/2 the length of the black rectangle
-        int length = width - 2 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        int width = measureWidth - 2 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        if (multiRest->HasWidth()) {
+            width = multiRest->AttWidth::GetWidth();
+            if (width > measureWidth) LogWarning("measure too short");
+        }
 
         // a is the central point, claculate x and x2
-        x1 = xCentered - length / 2;
-        x2 = xCentered + length / 2;
+        x1 = xCentered - width / 2;
+        x2 = xCentered + width / 2;
 
         // Position centered in staff
         y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;


### PR DESCRIPTION
This PR add support for `@loc` and `@width` on `<multiRest>`. For now the width of the measure will not be adjusted to the width of the rest. 

![rest-012](https://user-images.githubusercontent.com/7693447/101160864-0713cb80-3630-11eb-99ce-09c61d6b38df.png)

I'll add the corresponding MEI file to the test suite.