### PR TITLE
Allow mRests to be cue sized

### DIFF
--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -383,7 +383,7 @@ private:
     /**
      * Addjusts flag placement and stem length if they are crossing notehead or ledger lines
      */
-    void AdjustFlagPlacement(Doc *doc, Flag* flag, int staffSize, int verticalCenter, int duration);
+    void AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int verticalCenter, int duration);
 
 public:
     //

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -324,7 +324,7 @@ protected:
     void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff);
     void DrawMeterSigFigures(DeviceContext *dc, int x, int y, int num, int den, Staff *staff);
     void DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smulfCode, int num, bool line, Staff *staff);
-    void DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff);
+    void DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff, bool cueSize = false);
     void DrawRestLong(DeviceContext *dc, int x, int y, Staff *staff);
     void DrawRestWhole(DeviceContext *dc, int x, int y, int valeur, bool cueSize, Staff *staff);
     ///@}

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2645,6 +2645,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 AddLayerElement(layer, chord, duration);
                 m_elementStackMap.at(layer).push_back(chord);
                 element = chord;
+                if (cue) chord->SetCue(BOOLEAN_true);
                 if (grace) {
                     if (grace.attribute("slash")) {
                         chord->SetGrace(GRACE_unacc);
@@ -2671,7 +2672,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             if (!cue) {
                 chord->SetCue(BOOLEAN_NONE);
             }
-            else if (chord->GetCue() != BOOLEAN_NONE) {
+            else if (cue && chord->GetCue() != BOOLEAN_NONE) {
                 chord->SetCue(BOOLEAN_true);
             }
             grace = pugi::xml_node();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1171,9 +1171,10 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     if (measure->m_measureAligner.GetMaxTime() >= (DUR_MAX * 2)) {
         if (!mRest->HasLoc()) y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-        const int offset = drawingCueSize?  m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_graceFactor.GetValue() / 2 : m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
-        DrawRestBreve(
-            dc, mRest->GetDrawingX() - offset, y, staff, drawingCueSize);
+        const int offset = drawingCueSize
+            ? m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_graceFactor.GetValue() / 2
+            : m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
+        DrawRestBreve(dc, mRest->GetDrawingX() - offset, y, staff, drawingCueSize);
     }
     else
         DrawRestWhole(dc,

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1170,7 +1170,7 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     bool drawingCueSize = element->GetDrawingCueSize();
 
     if (measure->m_measureAligner.GetMaxTime() >= (DUR_MAX * 2)) {
-        y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        if (!mRest->HasLoc()) y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
         DrawRestBreve(
             dc, mRest->GetDrawingX() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2, y, staff, drawingCueSize);
     }
@@ -1772,7 +1772,10 @@ void View::DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff, bool cue
 
     x1 = x;
     int width = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (cueSize) width *= m_options->m_graceFactor.GetValue();
+    if (cueSize) {
+        x1 += width * (1 - m_options->m_graceFactor.GetValue()) / 2;
+        width *= m_options->m_graceFactor.GetValue();
+    }
     x2 = x + width;
 
     y1 = y;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1171,8 +1171,9 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     if (measure->m_measureAligner.GetMaxTime() >= (DUR_MAX * 2)) {
         if (!mRest->HasLoc()) y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        const int offset = drawingCueSize?  m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_graceFactor.GetValue() / 2 : m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
         DrawRestBreve(
-            dc, mRest->GetDrawingX() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2, y, staff, drawingCueSize);
+            dc, mRest->GetDrawingX() - offset, y, staff, drawingCueSize);
     }
     else
         DrawRestWhole(dc,
@@ -1772,10 +1773,7 @@ void View::DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff, bool cue
 
     x1 = x;
     int width = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (cueSize) {
-        x1 += width * (1 - m_options->m_graceFactor.GetValue()) / 2;
-        width *= m_options->m_graceFactor.GetValue();
-    }
+    if (cueSize) width *= m_options->m_graceFactor.GetValue();
     x2 = x + width;
 
     y1 = y;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1777,7 +1777,10 @@ void View::DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff, bool cue
 
     y1 = y;
     int height = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-    if (cueSize) height *= m_options->m_graceFactor.GetValue();
+    if (cueSize) {
+        y1 += height * (1 - m_options->m_graceFactor.GetValue()) / 2;
+        height *= m_options->m_graceFactor.GetValue();
+    }
     y2 = y1 + height;
 
     DrawFilledRectangle(dc, x1, y2, x2, y1);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1456,7 +1456,7 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     switch (drawingDur) {
         case DUR_LG: DrawRestLong(dc, x, y, staff); break;
-        case DUR_BR: DrawRestBreve(dc, x, y, staff); break;
+        case DUR_BR: DrawRestBreve(dc, x, y, staff, drawingCueSize); break;
         case DUR_1:
         case DUR_2: DrawRestWhole(dc, x, y, drawingDur, drawingCueSize, staff); break;
         default:

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1167,14 +1167,17 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     int y = element->GetDrawingY();
 
+    bool drawingCueSize = element->GetDrawingCueSize();
+
     if (measure->m_measureAligner.GetMaxTime() >= (DUR_MAX * 2)) {
         y -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-        DrawRestBreve(dc, mRest->GetDrawingX() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2, y, staff);
+        DrawRestBreve(
+            dc, mRest->GetDrawingX() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2, y, staff, drawingCueSize);
     }
     else
         DrawRestWhole(dc,
-            mRest->GetDrawingX() - m_doc->GetDrawingLedgerLineLength(staff->m_drawingStaffSize, false) * 2 / 3, y,
-            DUR_1, false, staff);
+            mRest->GetDrawingX() - m_doc->GetDrawingLedgerLineLength(staff->m_drawingStaffSize, drawingCueSize) * 2 / 3,
+            y, DUR_1, drawingCueSize, staff);
 
     dc->EndGraphic(element, this);
 }
@@ -1763,15 +1766,19 @@ void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smuflCode, int
     }
 }
 
-void View::DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff)
+void View::DrawRestBreve(DeviceContext *dc, int x, int y, Staff *staff, bool cueSize)
 {
     int x1, x2, y1, y2;
 
     x1 = x;
-    x2 = x + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    int width = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    if (cueSize) width *= m_options->m_graceFactor.GetValue();
+    x2 = x + width;
 
     y1 = y;
-    y2 = y1 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    int height = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    if (cueSize) height *= m_options->m_graceFactor.GetValue();
+    y2 = y1 + height;
 
     DrawFilledRectangle(dc, x1, y2, x2, y1);
 }
@@ -1794,6 +1801,7 @@ void View::DrawRestWhole(DeviceContext *dc, int x, int y, int valeur, bool cueSi
     int x1, x2, y1, y2, vertic;
     y1 = y;
     vertic = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    if (cueSize) vertic *= m_options->m_graceFactor.GetValue();
 
     int off
         = m_doc->GetDrawingLedgerLineLength(staff->m_drawingStaffSize, cueSize) * 2 / 3; // i.e., la moitie de la ronde


### PR DESCRIPTION
This PR adds support for `@cue` attribute on `<mRest>`.

Closes #1086