### PR TITLE
CMake: run get_git_commit.sh from build directory.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 
 execute_process(
     COMMAND ../tools/get_git_commit.sh
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     OUTPUT_VARIABLE GIT_COMMIT
 )
 


### PR DESCRIPTION
This fixes the build when running cmake from another directory, i.e. this now works:
`cd verovio && cmake -Hcmake -Btools`