### PR TITLE
Improve cross staff tuplets

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -54,6 +54,7 @@ class Syl;
 class System;
 class SystemAligner;
 class Transposer;
+class TupletNum;
 class Verse;
 
 //----------------------------------------------------------------------------
@@ -453,6 +454,35 @@ public:
     int m_freeSpace;
     int m_staffSize;
     Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
+// AdjustTupletNumOverlapParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: tupletNum relative position for which is being calculatied
+ * member 1: drawing position of tupletNum
+ * member 2: margin for tupletNum vertical overlap
+ * member 3: flag to indicate whether cross-staff elements should be considered
+ * member 4: resulting relative Y for the tupletNum
+ **/
+class AdjustTupletNumOverlapParams : public FunctorParams {
+public:
+    AdjustTupletNumOverlapParams(TupletNum* tupletNum)
+    {
+        m_tupletNum = tupletNum;
+        m_drawingNumPos = STAFFREL_basic_NONE;
+        m_verticalMargin = 0;
+        m_ignoreCrossStaff = false;
+        m_yRel = 0;
+    }
+
+    TupletNum *m_tupletNum;
+    data_STAFFREL_basic m_drawingNumPos;
+    int m_verticalMargin;
+    bool m_ignoreCrossStaff;
+    int m_yRel;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -256,6 +256,11 @@ public:
     virtual int AdjustGraceXPos(FunctorParams *functorParams);
     ///@}
 
+     /**
+     * See Object::AdjustTupletNumOverlap
+     */
+    virtual int AdjustTupletNumOverlap(FunctorParams *functorParams);
+
     /**
      * See Object::AdjustXPos
      */

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -865,6 +865,11 @@ public:
     virtual int AdjustTupletsY(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
+     * Calculate the y relative position of tupletNum based on overlaps with other elements
+     */
+    virtual int AdjustTupletNumOverlap(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Adjust the position of the StaffAlignment.
      */
     virtual int AdjustYPos(FunctorParams *) { return FUNCTOR_CONTINUE; }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1203,7 +1203,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     // ignore elements that are not in the beam or are direct children of the beam
     if (!params->m_beam || (Is({ NOTE, CHORD }) && (GetFirstAncestor(BEAM) == params->m_beam) && !IsGraceNote()))
         return FUNCTOR_SIBLINGS;
-    if (Is({ GRACEGRP, TUPLET })) return FUNCTOR_CONTINUE;
+    if (Is({ GRACEGRP, TUPLET, TUPLET_NUM, TUPLET_BRACKET })) return FUNCTOR_CONTINUE;
 
     Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
     assert(staff);
@@ -1308,6 +1308,32 @@ int LayerElement::AdjustGraceXPos(FunctorParams *functorParams)
     params->m_graceUpcomingMaxPos = std::min(selfLeft, params->m_graceUpcomingMaxPos);
 
     return FUNCTOR_SIBLINGS;
+}
+
+int LayerElement::AdjustTupletNumOverlap(FunctorParams* functorParams) 
+{
+    AdjustTupletNumOverlapParams *params = vrv_params_cast<AdjustTupletNumOverlapParams *>(functorParams);
+    assert(params);
+
+    if (!Is({ ARTIC, ARTIC_PART, ACCID, CHORD, DOT, FLAG, NOTE, REST, STEM }) || !HasSelfBB()) return FUNCTOR_CONTINUE;
+    
+    if (params->m_ignoreCrossStaff && Is({ CHORD, NOTE, REST }) && m_crossStaff) return FUNCTOR_SIBLINGS;
+
+    if (!params->m_tupletNum->HorizontalSelfOverlap(this)
+        && !params->m_tupletNum->VerticalSelfOverlap(this, params->m_verticalMargin)) {
+        return FUNCTOR_CONTINUE;
+    }
+    
+    if (params->m_drawingNumPos == STAFFREL_basic_above) {
+        int dist = GetSelfTop();
+        if (params->m_yRel < dist) params->m_yRel = dist;
+    }
+    else {
+        int dist = GetSelfBottom();
+        if (params->m_yRel > dist) params->m_yRel = dist;
+    }               
+
+    return FUNCTOR_CONTINUE;
 }
 
 int LayerElement::AdjustXPos(FunctorParams *functorParams)

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -512,6 +512,9 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
             Beam *beam = this->GetNumAlignedBeam();
             // If we have a beam first move it to the appropriate postion
             if (beam) {
+                if (m_crossStaff) {
+                    yReference = m_crossStaff->GetDrawingY();
+                }
                 int xMid = tupletNum->GetDrawingXMid(params->m_doc);
                 int yMid = beam->m_beamSegment.m_startingY
                     + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.m_startingX);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -422,7 +422,7 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
 
     int verticalLine = params->m_doc->GetDrawingUnit(staffSize);
     int verticalMargin = 2 * verticalLine;
-    int yReference = staff->GetDrawingY();
+    const int yReference = m_crossStaff ? m_crossStaff->GetDrawingY() : staff->GetDrawingY();
 
     TupletBracket *tupletBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
     if (tupletBracket && (this->GetBracketVisible() != BOOLEAN_false)) {
@@ -463,10 +463,6 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
             tupletBracket->SetDrawingYRel(tupletBracket->GetDrawingYRel() - articPadding + bracketVerticalMargin);
         }
         else {
-            if (m_crossStaff) {
-                yReference = m_crossStaff->GetDrawingY();
-            }
-
             // Default position is above or below the staff
             int yRel
                 = (m_drawingBracketPos == STAFFREL_basic_above) ? 0 : -params->m_doc->GetDrawingStaffSize(staffSize);
@@ -513,10 +509,6 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
             int numVerticalMargin = verticalMargin;
             numVerticalMargin *= (m_drawingNumPos == STAFFREL_basic_above) ? 1 : -1;
 
-            if (m_crossStaff) {
-                yReference = m_crossStaff->GetDrawingY();
-            }
-
             Beam *beam = this->GetNumAlignedBeam();
             // If we have a beam first move it to the appropriate postion
             if (beam) {
@@ -546,7 +538,7 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
                 if (!descendant->HasSelfBB()) {
                     continue;
                 }
-                if (!tupletNum->HorizontalSelfOverlap(descendant)) {
+                if (!tupletNum->HorizontalSelfOverlap(descendant) && !tupletNum->VerticalSelfOverlap(descendant)) {
                     continue;
                 }
                 if (m_drawingNumPos == STAFFREL_basic_above) {

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -463,6 +463,10 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
             tupletBracket->SetDrawingYRel(tupletBracket->GetDrawingYRel() - articPadding + bracketVerticalMargin);
         }
         else {
+            if (m_crossStaff) {
+                yReference = m_crossStaff->GetDrawingY();
+            }
+
             // Default position is above or below the staff
             int yRel
                 = (m_drawingBracketPos == STAFFREL_basic_above) ? 0 : -params->m_doc->GetDrawingStaffSize(staffSize);
@@ -509,12 +513,14 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
             int numVerticalMargin = verticalMargin;
             numVerticalMargin *= (m_drawingNumPos == STAFFREL_basic_above) ? 1 : -1;
 
+            if (m_crossStaff) {
+                yReference = m_crossStaff->GetDrawingY();
+            }
+
             Beam *beam = this->GetNumAlignedBeam();
             // If we have a beam first move it to the appropriate postion
             if (beam) {
-                if (m_crossStaff) {
-                    yReference = m_crossStaff->GetDrawingY();
-                }
+                
                 int xMid = tupletNum->GetDrawingXMid(params->m_doc);
                 int yMid = beam->m_beamSegment.m_startingY
                     + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.m_startingX);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -538,7 +538,8 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
                 if (!descendant->HasSelfBB()) {
                     continue;
                 }
-                if (!tupletNum->HorizontalSelfOverlap(descendant) && !tupletNum->VerticalSelfOverlap(descendant)) {
+                if (!tupletNum->HorizontalSelfOverlap(descendant)
+                    && !tupletNum->VerticalSelfOverlap(descendant, verticalMargin)) {
                     continue;
                 }
                 if (m_drawingNumPos == STAFFREL_basic_above) {


### PR DESCRIPTION
closes #1799, closes #1844, closes #1579
Overall improvements for the cross staff tuplets with couple fixes to their positioning. 
Also fixes positioning of the tuplet number where it would either overlap with beam or would be placed too low on the same level as stems (as described in #1579 ).
Example of rendering from the referred issues:
![image](https://user-images.githubusercontent.com/1819669/102361933-78526780-3fbc-11eb-9e1c-e8af973e7b29.png)
![image](https://user-images.githubusercontent.com/1819669/102362007-8dc79180-3fbc-11eb-8ea0-2c671faadd3a.png)

Example of cross staff tuplets:
![image](https://user-images.githubusercontent.com/1819669/102362130-b18ad780-3fbc-11eb-96c3-eb9b6c1dd9fd.png)
