### PR TITLE
keyAccid not available when keySig is attribute

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -35,6 +35,9 @@ class Fb;
 class Gliss;
 class Hairpin;
 class Harm;
+class InstrDef;
+class Label;
+class LabelAbbr;
 class Layer;
 class LayerElement;
 class Measure;
@@ -377,6 +380,10 @@ private:
     /* meter signature */
     int m_meterCount = 4;
     int m_meterUnit = 4;
+    /* part information */
+    Label *m_label = NULL;
+    LabelAbbr *m_labelAbbr = NULL;
+    InstrDef *m_instrdef = NULL;
     /* LastElementID */
     std::string m_ID;
     /* A map of stacks for piling open LayerElements (beams, tuplets, chords, btrem, ftrem) separately per layer */

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1780,7 +1780,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     = m_measureCounts.at(measure) - m_bracketStack.front().second.m_lastMeasureCount;
                 m_bracketStack.front().first->SetLendsym(
                     ConvertLineEndSymbol(bracket.node().attribute("line-end").as_string()));
-                m_bracketStack.front().first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                if (measureDifference >= 0) {
+                    m_bracketStack.front().first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                }
                 m_bracketStack.erase(m_bracketStack.begin());
             }
         }
@@ -1833,12 +1835,14 @@ void MusicXmlInput::ReadMusicXmlDirection(
             while (iter != m_openDashesStack.end()) {
                 if (iter->second.m_dirN == dashesNumber && iter->second.m_staffNum == staffNum) {
                     const int measureDifference = m_measureCounts.at(measure) - iter->second.m_measureCount;
-                    if (iter->first->Is(DYNAM))
-                        dynamic_cast<Dynam *>(iter->first)
-                            ->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
-                    if (iter->first->Is(DIR))
-                        dynamic_cast<Dir *>(iter->first)
-                            ->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                    if (measureDifference >= 0) {
+                        if (iter->first->Is(DYNAM))
+                            dynamic_cast<Dynam *>(iter->first)
+                                ->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                        if (iter->first->Is(DIR))
+                            dynamic_cast<Dir *>(iter->first)
+                                ->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                    }
                     iter = m_openDashesStack.erase(iter);
                 }
                 else {
@@ -2007,7 +2011,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
             for (iter = m_hairpinStack.begin(); iter != m_hairpinStack.end(); ++iter) {
                 if (iter->second.m_dirN == hairpinNumber) {
                     const int measureDifference = m_measureCounts.at(measure) - iter->second.m_lastMeasureCount;
-                    iter->first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                    if (measureDifference >= 0) {
+                        iter->first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                    }
                     if (wedge->node().attribute("spread")) {
                         iter->first->SetOpening(wedge->node().attribute("spread").as_double() / 5);
                     }
@@ -2164,7 +2170,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
         if (HasAttributeWithValue(lead.node(), "type", "stop")) {
             const int measureDifference
                 = m_measureCounts.at(measure) - m_bracketStack.front().second.m_lastMeasureCount;
-            m_bracketStack.front().first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+            if (measureDifference >= 0) {
+                m_bracketStack.front().first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+            }
             m_bracketStack.erase(m_bracketStack.begin());
         }
         else {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1158,7 +1158,6 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
                     keySig->SetSig(keySig->AttKeySigLog::StrToKeysignature(keySigStr));
                 }
                 else if (key.node().child("key-step")) {
-                    keySig->SetSig(keySig->AttKeySigLog::StrToKeysignature("mixed"));
                     for (pugi::xml_node keyStep : key.node().children("key-step")) {
                         KeyAccid *keyAccid = new KeyAccid();
                         keyAccid->SetPname(ConvertStepToPitchName(keyStep.text().as_string()));
@@ -1181,7 +1180,6 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
             }
             // add it if necessary
             if (keySig) {
-                keySig->IsAttribute(true);
                 staffDef->AddChild(keySig);
             }
 
@@ -1560,7 +1558,6 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         }
         else if (key.node().child("key-step")) {
             if (!keySig) keySig = new KeySig();
-            keySig->SetSig(keySig->AttKeySigLog::StrToKeysignature("mixed"));
             for (pugi::xml_node keyStep = key.node().child("key-step"); keyStep;
                  keyStep = keyStep.next_sibling("key-step")) {
                 KeyAccid *keyAccid = new KeyAccid();
@@ -1592,7 +1589,6 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         // Add it if necessary
         if (keySig) {
             // Make it an attribute for now
-            keySig->IsAttribute(true);
             scoreDef->AddChild(keySig);
         }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3236,7 +3236,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         if (HasAttributeWithValue(tremolo.node(), "type", "stop")) {
             RemoveLastFromStack(FTREM, layer);
         }
-        else if (!HasAttributeWithValue(tremolo.node(), "type", "start") && !nextIsChord) {
+        else if (!HasAttributeWithValue(tremolo.node(), "type", "start") && !isChord) {
             RemoveLastFromStack(BTREM, layer);
         }
     }


### PR DESCRIPTION
This PR prevents `keySig` to be an attribute in MusicXML import, because when adding children to it MEI output will be invalid. 
@lpugin perhaps we should always check `keySig` for children when trying to make it an attribute?