### PR TITLE
Revert "CMake: run get_git_commit.sh from build directory."

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -90,7 +90,6 @@ endif()
 
 execute_process(
     COMMAND ../tools/get_git_commit.sh
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     OUTPUT_VARIABLE GIT_COMMIT
 )
 


### PR DESCRIPTION
Reverts rism-ch/verovio#1882 because this does not work anymore
```
laurent@laika verovio % cd bindings 
laurent@laika bindings % cmake ../cmake -DBUILD_AS_PYTHON=ON -B python
laurent@laika bindings % cd python 
laurent@laika python % make -j 8
```
Since `./include/vrv/git_commit.h` is not generated. @matangover could you fix it and redo a PR? Thanks