### PR TITLE
CMake: run get_git_commit.sh from CMake directory.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 
 execute_process(
     COMMAND ../tools/get_git_commit.sh
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     OUTPUT_VARIABLE GIT_COMMIT
 )
 


### PR DESCRIPTION
This fixes the build when running cmake from another directory, i.e. this now works:
`cd verovio && cmake -Hcmake -Btools`

This supersedes https://github.com/rism-ch/verovio/pull/1882, which was reverted in https://github.com/rism-ch/verovio/pull/1923. To fix the problem, I changed it to now use the CMake _source_ directory instead of the _build_ directory, because the source directory is guaranteed to stay constant.