### PR TITLE
"smart" breaks mode: Use `<sb>` as suggested system breaks, occasionally ignore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Option for sometimes using encoded breaks, at configurable threshold (`--breaks smart` and `--breaks-smart-sb`) (@earboxer)
 * Improved automatic cross staff rest positioning (@eNote-GmbH)
 
 ## [3.1.0] - 2021-01-12

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -260,10 +260,11 @@ public:
 
     /**
      * Casts off the entire document, with options for obeying breaks.
-     * @param useSb - 1 to use the sb from the document, 2 to sometimes us the sb from the document.
-     * @param usePg - true to use the pb from the document.
+     * @param useSb - true to use the sb from the document.
+     * @param usePb - true to use the pb from the document.
+     * @param smart - true to sometimes use encoded sb and pb.
      */
-    void CastOffDocBase(int useSb, bool usePb);
+    void CastOffDocBase(bool useSb, bool usePb, bool smart = false);
 
     /**
      * Casts off the running elements (headers and footer)

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -247,6 +247,12 @@ public:
     void CastOffDoc();
 
     /**
+     * Casts off the entire document, only using the document's system breaks
+     * if they would be close to the end in the normal document.
+     */
+    void CastOffSmartDoc();
+
+    /**
      * Casts off the entire document, using the document's line breaks,
      * but adding its own page breaks.
      */
@@ -254,10 +260,10 @@ public:
 
     /**
      * Casts off the entire document, with options for obeying breaks.
-     * @param useSb - true to use the sb from the document.
+     * @param useSb - 1 to use the sb from the document, 2 to sometimes us the sb from the document.
      * @param usePg - true to use the pb from the document.
      */
-    void CastOffDocBase(bool useSb, bool usePb);
+    void CastOffDocBase(int useSb, bool usePb);
 
     /**
      * Casts off the running elements (headers and footer)

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -952,11 +952,12 @@ public:
  * member 5: the current scoreDef width
  * member 6: the current pending objects (ScoreDef, Endings, etc.) to be place at the beginning of a system
  * member 7: the doc
+ * member 8: whether to smartly use encoded system breaks
  **/
 
 class CastOffSystemsParams : public FunctorParams {
 public:
-    CastOffSystemsParams(System *contentSystem, Page *page, System *currentSystem, Doc *doc)
+    CastOffSystemsParams(System *contentSystem, Page *page, System *currentSystem, Doc *doc, bool smart)
     {
         m_contentSystem = contentSystem;
         m_page = page;
@@ -965,6 +966,7 @@ public:
         m_systemWidth = 0;
         m_currentScoreDefWidth = 0;
         m_doc = doc;
+        m_smart = smart;
     }
     System *m_contentSystem;
     Page *m_page;
@@ -974,6 +976,7 @@ public:
     int m_currentScoreDefWidth;
     ArrayOfObjects m_pendingObjects;
     Doc *m_doc;
+    bool m_smart;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -494,6 +494,7 @@ public:
     OptionBool m_adjustPageHeight;
     OptionBool m_adjustPageWidth;
     OptionIntMap m_breaks;
+    OptionDbl m_breaksSmartSb;
     OptionIntMap m_condense;
     OptionBool m_condenseFirstPage;
     OptionBool m_condenseTempoPages;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -51,7 +51,7 @@ class OptionGrp;
 // Option defines
 //----------------------------------------------------------------------------
 
-enum option_BREAKS { BREAKS_none = 0, BREAKS_auto, BREAKS_line, BREAKS_encoded };
+enum option_BREAKS { BREAKS_none = 0, BREAKS_auto, BREAKS_line, BREAKS_smart, BREAKS_encoded };
 
 enum option_CONDENSE { CONDENSE_none = 0, CONDENSE_auto, CONDENSE_all, CONDENSE_encoded };
 

--- a/include/vrv/sb.h
+++ b/include/vrv/sb.h
@@ -45,6 +45,11 @@ public:
      */
     virtual int CastOffEncoding(FunctorParams *functorParams);
 
+    /**
+     * See Object::CastOffSystems
+     */
+    virtual int CastOffSystems(FunctorParams *functorParams);
+
 private:
     //
 public:

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -827,15 +827,18 @@ void Doc::CastOffDoc()
 {
     Doc::CastOffDocBase(false, false);
 }
+
 void Doc::CastOffLineDoc()
 {
     Doc::CastOffDocBase(true, false);
 }
+
 void Doc::CastOffSmartDoc()
 {
-    Doc::CastOffDocBase(2, false);
+    Doc::CastOffDocBase(false, false, true);
 }
-void Doc::CastOffDocBase(int useSb, bool usePb)
+
+void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
 {
     Pages *pages = this->GetPages();
     assert(pages);
@@ -857,14 +860,13 @@ void Doc::CastOffDocBase(int useSb, bool usePb)
     System *currentSystem = new System();
     contentPage->AddChild(currentSystem);
 
-    if (useSb == 1 && !usePb) {
+    if (useSb && !usePb && !smart) {
         CastOffEncodingParams castOffEncodingParams(this, contentPage, currentSystem, contentSystem, false);
 
         Functor castOffEncoding(&Object::CastOffEncoding);
         contentSystem->Process(&castOffEncoding, &castOffEncodingParams);
     }
     else {
-        bool smart = (useSb == 2);
         CastOffSystemsParams castOffSystemsParams(contentSystem, contentPage, currentSystem, this, smart);
         castOffSystemsParams.m_systemWidth
             = this->m_drawingPageContentWidth - currentSystem->m_systemLeftMar - currentSystem->m_systemRightMar;

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -831,7 +831,11 @@ void Doc::CastOffLineDoc()
 {
     Doc::CastOffDocBase(true, false);
 }
-void Doc::CastOffDocBase(bool useSb, bool usePb)
+void Doc::CastOffSmartDoc()
+{
+    Doc::CastOffDocBase(2, false);
+}
+void Doc::CastOffDocBase(int useSb, bool usePb)
 {
     Pages *pages = this->GetPages();
     assert(pages);
@@ -853,14 +857,15 @@ void Doc::CastOffDocBase(bool useSb, bool usePb)
     System *currentSystem = new System();
     contentPage->AddChild(currentSystem);
 
-    if (useSb && !usePb) {
+    if (useSb == 1 && !usePb) {
         CastOffEncodingParams castOffEncodingParams(this, contentPage, currentSystem, contentSystem, false);
 
         Functor castOffEncoding(&Object::CastOffEncoding);
         contentSystem->Process(&castOffEncoding, &castOffEncodingParams);
     }
     else {
-        CastOffSystemsParams castOffSystemsParams(contentSystem, contentPage, currentSystem, this);
+        bool smart = (useSb == 2);
+        CastOffSystemsParams castOffSystemsParams(contentSystem, contentPage, currentSystem, this, smart);
         castOffSystemsParams.m_systemWidth
             = this->m_drawingPageContentWidth - currentSystem->m_systemLeftMar - currentSystem->m_systemRightMar;
         castOffSystemsParams.m_shift = -contentSystem->GetDrawingLabelsWidth();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -626,6 +626,11 @@ Options::Options()
     m_breaks.Init(BREAKS_auto, &Option::s_breaks);
     this->Register(&m_breaks, "breaks", &m_general);
 
+    m_breaksSmartSb.SetInfo("Smart breaks sb usage threshold",
+        "In smart breaks mode, the portion of system width usage at which an encoded sb will be used");
+    m_breaksSmartSb.Init(0.66, 0.0, 1.0);
+    this->Register(&m_breaksSmartSb, "breaksSmartSb", &m_general);
+
     m_condense.SetInfo("Condense", "Control condensed score layout");
     m_condense.Init(CONDENSE_auto, &Option::s_condense);
     this->Register(&m_condense, "condense", &m_general);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -21,8 +21,8 @@
 
 namespace vrv {
 
-std::map<int, std::string> Option::s_breaks
-    = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" }, { BREAKS_line, "line" }, { BREAKS_encoded, "encoded" } };
+std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },
+    { BREAKS_line, "line" }, { BREAKS_smart, "smart" }, { BREAKS_encoded, "encoded" } };
 
 std::map<int, std::string> Option::s_condense
     = { { CONDENSE_none, "none" }, { CONDENSE_auto, "auto" }, { CONDENSE_encoded, "encoded" } };

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -15,6 +15,7 @@
 
 #include "editorial.h"
 #include "functorparams.h"
+#include "measure.h"
 #include "page.h"
 #include "system.h"
 #include "vrv.h"
@@ -62,8 +63,21 @@ int Sb::CastOffSystems(FunctorParams *functorParams)
     CastOffSystemsParams *params = vrv_params_cast<CastOffSystemsParams *>(functorParams);
     assert(params);
     if (params->m_smart) {
-        // TODO: Break the layout if this system is almost full.
+        // Get the last measure of the currentSystem
+        Measure *measure
+            = dynamic_cast<Measure *>(params->m_currentSystem->GetChild(params->m_currentSystem->GetChildCount() - 1));
+        if (measure != NULL) {
+            int measureRightX = measure->GetDrawingX() + measure->GetWidth() - params->m_shift;
+            // LogDebug("ratio: %f\n", (float)measureRightX / (float)params->m_systemWidth);
+            if (measureRightX > params->m_systemWidth * .66) {
+                // Use this system break.
+                params->m_currentSystem = new System();
+                params->m_page->AddChild(params->m_currentSystem);
+                params->m_shift += measureRightX;
+            }
+        }
     }
+    return FUNCTOR_SIBLINGS;
 }
 
 } // namespace vrv

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -13,6 +13,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "doc.h"
 #include "editorial.h"
 #include "functorparams.h"
 #include "measure.h"
@@ -69,7 +70,8 @@ int Sb::CastOffSystems(FunctorParams *functorParams)
         if (measure != NULL) {
             int measureRightX = measure->GetDrawingX() + measure->GetWidth() - params->m_shift;
             // LogDebug("ratio: %f\n", (float)measureRightX / (float)params->m_systemWidth);
-            if (measureRightX > params->m_systemWidth * .66) {
+            double smartSbThresh = params->m_doc->GetOptions()->m_breaksSmartSb.GetValue();
+            if (measureRightX > params->m_systemWidth * smartSbThresh) {
                 // Use this system break.
                 params->m_currentSystem = new System();
                 params->m_page->AddChild(params->m_currentSystem);

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -57,4 +57,13 @@ int Sb::CastOffEncoding(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
+int Sb::CastOffSystems(FunctorParams *functorParams)
+{
+    CastOffSystemsParams *params = vrv_params_cast<CastOffSystemsParams *>(functorParams);
+    assert(params);
+    if (params->m_smart) {
+        // TODO: Break the layout if this system is almost full.
+    }
+}
+
 } // namespace vrv

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -635,7 +635,8 @@ bool Toolkit::LoadData(const std::string &data)
     // be converted
     if (m_doc.GetType() == Transcription || m_doc.GetType() == Facs) breaks = BREAKS_none;
     if (breaks != BREAKS_none) {
-        if (input->HasLayoutInformation() && (breaks == BREAKS_encoded || breaks == BREAKS_line)) {
+        if (input->HasLayoutInformation()
+            && (breaks == BREAKS_encoded || breaks == BREAKS_line || breaks == BREAKS_smart)) {
             if (breaks == BREAKS_encoded) {
                 // LogElapsedTimeStart();
                 m_doc.CastOffEncodingDoc();
@@ -644,6 +645,9 @@ bool Toolkit::LoadData(const std::string &data)
             else if (breaks == BREAKS_line) {
                 m_doc.CastOffLineDoc();
             }
+            else if (breaks == BREAKS_smart) {
+                m_doc.CastOffSmartDoc();
+            }
         }
         else {
             if (breaks == BREAKS_encoded) {
@@ -651,6 +655,9 @@ bool Toolkit::LoadData(const std::string &data)
             }
             else if (breaks == BREAKS_line) {
                 LogWarning("Requesting layout with line breaks but nothing provided in the data");
+            }
+            else if (breaks == BREAKS_smart) {
+                LogWarning("Requesting layout with smart breaks but nothing provided in the data");
             }
             // LogElapsedTimeStart();
             m_doc.CastOffDoc();


### PR DESCRIPTION
This is a proposed solution to https://github.com/rism-ch/verovio/issues/1931

The implementation is as following:

* Behaves like `--breaks=auto`, except for
* when the current system is over n% full, it will allow an encoded system break to be effective. (n is set to 66%)

(It's not exactly what I had in mind with #1931, but it might be better).

From the example file, it seems to behave as expected.

`tools/verovio --breaks smart --unit 8 ~/Downloads/1946trumpet.mei`
<img width="535" alt="Screen Shot 2021-01-12 at 16 43 54" src="https://user-images.githubusercontent.com/12452738/104378204-a06ab300-54f5-11eb-805a-1f24e147ee53.png">

`tools/verovio --breaks smart --unit 20 --page-width 1500 ~/Downloads/1946trumpet.mei`
<img width="396" alt="Screen Shot 2021-01-12 at 16 45 01" src="https://user-images.githubusercontent.com/12452738/104378186-95b01e00-54f5-11eb-8710-ddced0b25330.png">

`tools/verovio --breaks smart --unit 8 --page-width 3500 ~/Downloads/1946trumpet.mei`
<img width="867" alt="Screen Shot 2021-01-12 at 16 46 47" src="https://user-images.githubusercontent.com/12452738/104378302-c728e980-54f5-11eb-895d-8feb87b6f995.png">


WIP Things to check
- `[ ]` ~~Make `<pb>` behave as expected.~~ (We can add "smart" behavior for this in the future).