### PR TITLE
Automatic cross staff rest positining fix

### DIFF
--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -134,7 +134,7 @@ private:
      * Get the rest vertical location relative to location of elements placed on other layers
      */
     std::pair<int, RestAccidental> GetLocationRelativeToOtherLayers(
-        const ListOfObjects &layersList, Layer *currentLayer);
+        const ListOfObjects &layersList, Layer *currentLayer, bool isTopLayer);
 
     /**
      * Get the rest vertical location relative to location of elements placed on current layers


### PR DESCRIPTION
As mentioned by @craigsapp in #1947, having `@layer="5"` on first layer is not exactly normal behavior. Not only that, previous code actually depended on having different layer numbers for cross-staff elements (which is clearly wrong). 

Commit ac4299a fixes this and works properly with correct numbering of the layers. Same example as in #1947, but with proper layer numbering renders properly.
![image](https://user-images.githubusercontent.com/1819669/104449115-c43a0180-55a6-11eb-953f-9264ebb8f468.png)
