### PR TITLE
Refine automatic rest positioning

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -288,15 +288,8 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
         }
     }
 
-    const int maxOtherLayerOffset = 10;
-    return isTopLayer
-        ? std::max(
-            { (otherLayerRelativeLocation > maxOtherLayerOffset ? maxOtherLayerOffset : otherLayerRelativeLocation),
-                currentLayerRelativeLocation, defaultLocation })
-        : std::min(
-            { (otherLayerRelativeLocation < -maxOtherLayerOffset ? -maxOtherLayerOffset : otherLayerRelativeLocation),
-                currentLayerRelativeLocation, defaultLocation });
-
+    return isTopLayer ? std::max({ otherLayerRelativeLocation, currentLayerRelativeLocation, defaultLocation })
+                      : std::min({ otherLayerRelativeLocation, currentLayerRelativeLocation, defaultLocation });
 }
 
 std::pair<int, RestAccidental> Rest::GetLocationRelativeToOtherLayers(
@@ -322,6 +315,11 @@ std::pair<int, RestAccidental> Rest::GetLocationRelativeToOtherLayers(
         //  If note on other layer is not on the same x position as rest - ignore its accidental
         if (GetAlignment()->GetTime() != vrv_cast<LayerElement *>(object)->GetAlignment()->GetTime()) {
             currentElementInfo.second = RA_none;
+            // limit how much rest can be offset when there is duration overlap, but no x position overlap
+            if (abs(currentElementInfo.first) > 4) {
+                if (finalElementInfo.first != VRV_UNSET) continue;
+                currentElementInfo.first = isTopLayer ? 4 : -4;
+            }
         }
         if ((VRV_UNSET == finalElementInfo.first) || (isTopLayer && (finalElementInfo.first < currentElementInfo.first))
             || (!isTopLayer && (finalElementInfo.first > currentElementInfo.first))) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -288,8 +288,15 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
         }
     }
 
-    return isTopLayer ? std::max({ otherLayerRelativeLocation, currentLayerRelativeLocation, defaultLocation })
-                      : std::min({ otherLayerRelativeLocation, currentLayerRelativeLocation, defaultLocation });
+    const int maxOtherLayerOffset = 10;
+    return isTopLayer
+        ? std::max(
+            { (otherLayerRelativeLocation > maxOtherLayerOffset ? maxOtherLayerOffset : otherLayerRelativeLocation),
+                currentLayerRelativeLocation, defaultLocation })
+        : std::min(
+            { (otherLayerRelativeLocation < -maxOtherLayerOffset ? -maxOtherLayerOffset : otherLayerRelativeLocation),
+                currentLayerRelativeLocation, defaultLocation });
+
 }
 
 std::pair<int, RestAccidental> Rest::GetLocationRelativeToOtherLayers(


### PR DESCRIPTION
This change will limit extreme rest positioning in some cases and avoid large gaps in the rendering, where rest had to be placed far away.
Rendering before:
![image](https://user-images.githubusercontent.com/1819669/104559022-6f50c680-564c-11eb-900d-24b81a7dd929.png)

Rendering after:
![image](https://user-images.githubusercontent.com/1819669/104559098-8e4f5880-564c-11eb-8091-e5fef5239d10.png)

This is not going to impact positioning of other rests, just the ones where offset was getting far too large. 

