### PR TITLE
Improve tremolo rendering with beams

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -237,6 +237,11 @@ public:
 
     int CalculateStemLength(Staff *staff, data_STEMDIRECTION stemDir);
 
+    /**
+     * Return stem length adjustment in half units, depending on the @stem.mode attribute 
+     */
+    int CalculateStemModAdjustment(int stemLength, int directionBias);
+
     int m_x;
     int m_yBeam; // y value of stem top position
     int m_dur; // drawing duration

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1339,16 +1339,30 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
         }
     }
     
+    return stemLen + CalculateStemModAdjustment(stemLen, directionBias);
+}
+
+int BeamElementCoord::CalculateStemModAdjustment(int stemLength, int directionBias)
+{
     // handle @stem.mod attribute to properly draw beams with tremolos
-    const int slashFactor = (m_closestNote->GetStemMod() < 8) ? m_closestNote->GetStemMod() - 1 : 0;
-    const int stemLengthInUnits = abs(stemLen / 2);
+    int slashFactor = 0;
+    if (m_element->Is(NOTE)) {
+        if (m_closestNote->GetStemMod() < STEMMODIFIER_sprech) slashFactor = m_closestNote->GetStemMod() - 1;
+    }
+    else if (m_element->Is(CHORD)) {
+        Chord *chord = vrv_cast<Chord *>(m_element);
+        assert(chord);
+        if (chord->GetStemMod() < STEMMODIFIER_sprech) slashFactor = chord->GetStemMod() - 1;
+    }
+    const int stemLengthInUnits = abs(stemLength / 2);
     // if stem length is very short and is not enough to fit slashes, we need to adjust it
     if (stemLengthInUnits - 3 < slashFactor) {
-        stemLen += directionBias * (3 + slashFactor - stemLengthInUnits) * 4;
+        return (directionBias * (3 + slashFactor - stemLengthInUnits) * 4);
     }
 
-    return stemLen;
+    return 0;
 }
+
 
 void BeamElementCoord::SetClosestNote(data_STEMDIRECTION stemDir)
 {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1315,7 +1315,8 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
         extend = false;
     }
 
-    int stemLen = (stemDir == STEMDIRECTION_up) ? 1 : -1;
+    const int directionBias = (stemDir == STEMDIRECTION_up) ? 1 : -1;
+    int stemLen = directionBias;
     // For 8th notes, use the shortened stem (if shortened)
     if (this->m_dur == DUR_8) {
         if (stemLenInHalfUnits != standardStemLen) {
@@ -1336,6 +1337,14 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
             case (DUR_1024): stemLen *= (extend) ? 38 : 36; break;
             default: stemLen *= 14;
         }
+    }
+    
+    // handle @stem.mod attribute to properly draw beams with tremolos
+    const int slashFactor = (m_closestNote->GetStemMod() < 8) ? m_closestNote->GetStemMod() - 1 : 0;
+    const int stemLengthInUnits = abs(stemLen / 2);
+    // if stem length is very short and is not enough to fit slashes, we need to adjust it
+    if (stemLengthInUnits - 3 < slashFactor) {
+        stemLen += directionBias * (3 + slashFactor - stemLengthInUnits) * 4;
     }
 
     return stemLen;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1203,7 +1203,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     // ignore elements that are not in the beam or are direct children of the beam
     if (!params->m_beam || (Is({ NOTE, CHORD }) && (GetFirstAncestor(BEAM) == params->m_beam) && !IsGraceNote()))
         return FUNCTOR_SIBLINGS;
-    if (Is({ GRACEGRP, TUPLET, TUPLET_NUM, TUPLET_BRACKET })) return FUNCTOR_CONTINUE;
+    if (Is({ GRACEGRP, TUPLET, TUPLET_NUM, TUPLET_BRACKET, BTREM })) return FUNCTOR_CONTINUE;
 
     Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
     assert(staff);


### PR DESCRIPTION
Fixes problem with tremolo rendering with beams, where slashes would overlap with notes and some strange beam placement as well.
![image](https://user-images.githubusercontent.com/1819669/104574930-44bc3900-565f-11eb-9901-7500b4729a9c.png)

After the fix:
![image](https://user-images.githubusercontent.com/1819669/104574988-57cf0900-565f-11eb-8b31-7b1de09aaf3a.png)
