### PR TITLE
Allow redoLayout to work for --breaks smart mode

### DIFF
--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -79,6 +79,8 @@ int Sb::CastOffSystems(FunctorParams *functorParams)
             }
         }
     }
+    // Keep the <sb> in the internal MEI, even if we're not using it to break the system.
+    MoveItselfTo(params->m_currentSystem);
     return FUNCTOR_SIBLINGS;
 }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1233,6 +1233,9 @@ void Toolkit::RedoLayout()
     if (m_options->m_breaks.GetValue() == BREAKS_line) {
         m_doc.CastOffLineDoc();
     }
+    else if(m_options->m_breaks.GetValue() == BREAKS_smart){
+        m_doc.CastOffSmartDoc();
+    }
     else {
         m_doc.CastOffDoc();
     }


### PR DESCRIPTION
Analogous to https://github.com/rism-ch/verovio/pull/1416, but for https://github.com/rism-ch/verovio/pull/1944

In order for redoLayout to work in smart breaks mode, we need to store the `<sb>` internally, so it shouldn't get thrown out by `CastOffSystems`.

This also has the side effect of causing `verovio --breaks auto`, `verovio --breaks encoded`, and `verovio --breaks smart` to all have the same MEI output as each other (though they're different from `verovio --breaks line` :/ ).