### PR TITLE
Expose scoreTime in vrvToolkit

### DIFF
--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -175,6 +175,7 @@ $exports .= "'_vrvToolkit_getOptions',";
 $exports .= "'_vrvToolkit_getPageCount',";
 $exports .= "'_vrvToolkit_getPageWithElement',";
 $exports .= "'_vrvToolkit_getTimeForElement',";
+$exports .= "'_vrvToolkit_getTimesForElement',";
 $exports .= "'_vrvToolkit_getVersion',";
 $exports .= "'_vrvToolkit_loadData',";
 $exports .= "'_vrvToolkit_redoLayout',";

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -51,6 +51,9 @@ verovio.vrvToolkit.getPageWithElement = Module.cwrap( 'vrvToolkit_getPageWithEle
 // double getTimeForElement(Toolkit *ic, const char *xmlId)
 verovio.vrvToolkit.getTimeForElement = Module.cwrap( 'vrvToolkit_getTimeForElement', 'number', ['number', 'string'] );
 
+// string getTimesForElement(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getTimesForElement = Module.cwrap( 'vrvToolkit_getTimesForElement', 'string', ['number', 'string'] );
+
 // char *getMIDIValuesForElement(Toolkit *ic, const char *xmlId)
 verovio.vrvToolkit.getMIDIValuesForElement = Module.cwrap( 'vrvToolkit_getMIDIValuesForElement', 'string', ['number', 'string'] );
 
@@ -186,6 +189,11 @@ verovio.toolkit.prototype.getPageWithElement = function ( xmlId )
 verovio.toolkit.prototype.getTimeForElement = function ( xmlId )
 {
     return verovio.vrvToolkit.getTimeForElement( this.ptr, xmlId );
+};
+
+verovio.toolkit.prototype.getTimesForElement = function ( xmlId )
+{
+    return JSON.parse( verovio.vrvToolkit.getTimesForElement( this.ptr, xmlId ) );
 };
 
 verovio.toolkit.prototype.getVersion = function ()

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -243,6 +243,12 @@ public:
     std::string GetMIDIValuesForElement(const std::string &xmlId);
 
     /**
+     * Return the score time at which the element is the ID (xml:id) is notated.
+     * Returns 0 if no element is found.
+     */
+    int GetScoreTimeForElement(const std::string &xmlId);
+
+    /**
      * @name Set and get the scale
      */
     ///@{

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -243,10 +243,12 @@ public:
     std::string GetMIDIValuesForElement(const std::string &xmlId);
 
     /**
-     * Return the score time at which the element is the ID (xml:id) is notated.
+     * Return a JSON object string with the following key values for a given note:
+     * scoreTimeOnset, scoreTimeOffset, scoreTimeTiedDuration,
+     * realTimeOnsetMilliseconds, realTimeOffsetMilliseconds, realTimeTiedDurationMilliseconds.
      * Returns 0 if no element is found.
      */
-    int GetScoreTimeForElement(const std::string &xmlId);
+    std::string GetTimesForElement(const std::string &xmlId);
 
     /**
      * @name Set and get the scale

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1538,6 +1538,24 @@ int Toolkit::GetTimeForElement(const std::string &xmlId)
     return timeofElement;
 }
 
+int Toolkit::GetScoreTimeForElement(const std::string &xmlId)
+{
+    Object *element = m_doc.FindDescendantByUuid(xmlId);
+
+    if (!element) {
+        LogWarning("Element '%s' not found", xmlId.c_str());
+        return 0;
+    }
+
+    int scoreTimeofElement = 0;
+    if (element->Is(NOTE)) {
+        Note *note = vrv_cast<Note *>(element);
+        assert(note);
+        scoreTimeofElement = note->GetScoreTimeOnset();
+    }
+    return scoreTimeofElement;
+}
+
 std::string Toolkit::GetMIDIValuesForElement(const std::string &xmlId)
 {
     Object *element = m_doc.FindDescendantByUuid(xmlId);

--- a/tools/c_wrapper.cpp
+++ b/tools/c_wrapper.cpp
@@ -131,6 +131,13 @@ double vrvToolkit_getTimeForElement(Toolkit *tk, const char *xmlId)
     return tk->GetTimeForElement(xmlId);
 }
 
+const char *vrvToolkit_getTimesForElement(Toolkit *tk, const char *xmlId)
+{
+    tk->ResetLogBuffer();
+    tk->SetCString(tk->GetTimesForElement(xmlId));
+    return tk->GetCString();
+}
+
 const char *vrvToolkit_getVersion(Toolkit *tk)
 {
     tk->SetCString(tk->GetVersion());


### PR DESCRIPTION
This PR exposes `scoreTime` of a `note` with a given `xml:id` through the toolkit. This would be a useful method for using Verovio for an editor package.

(In order to make this PR work in javascript, the emscripten scripts would have to be updated, that I do not dare to touch.)