### PR TITLE
Remove extra AddChild

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -2046,7 +2046,6 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
                     zone->SetLry(zone->GetLry() + 200);
 
                     assert(m_doc->GetFacsimile());
-                    m_doc->GetFacsimile()->FindDescendantByType(SURFACE)->AddChild(zone);
                     FacsimileInterface *fi = dynamic_cast<FacsimileInterface *>((*syl).GetFacsimileInterface());
                     assert(fi);
                     Object *surface = m_doc->GetFacsimile()->FindDescendantByType(SURFACE);


### PR DESCRIPTION
There's an extra call to `Object::AddChild` in `EditorToolkitNeume::Ungroup` that results in an invalid MEI file. This just removes the extra call.