### PR TITLE
Render custos y-position from pitch info

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -771,7 +771,16 @@ void View::DrawCustos(DeviceContext *dc, LayerElement *element, Layer *layer, St
     int x, y;
     if (custos->HasFacs() && m_doc->GetType() == Facs) {
         x = custos->GetDrawingX();
+        // Recalculate y from pitch to prevent visual/meaning mismatch
+        Clef *clef = layer->GetClef(element);
         y = ToLogicalY(staff->GetDrawingY());
+        PitchInterface pi;
+        pi.SetPname(PITCHNAME_c);
+        pi.SetOct(3);
+        // Convert from lines & spaces from bottom to from top
+        int C3OffsetFromTop = ((staff->m_drawingLines - 1) * 2) - clef->GetClefLocOffset();
+        int custosOffsetFromTop = C3OffsetFromTop + pi.PitchDifferenceTo(custos);
+        y -= custosOffsetFromTop * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     }
     else {
         x = element->GetDrawingX();


### PR DESCRIPTION
Need to do this to ensure a match between position of the custos on the
staff and pitch info since small errors in facsimile y-position can
compound through editing and lead to big problems.

Sorry about introducing bug #1776 as well!