### PR TITLE
Fix rest positioning 

### DIFF
--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -80,11 +80,6 @@ public:
      */
     wchar_t GetRestGlyph() const;
 
-    /**
-     * Get the vertical offset for each glyph.
-     */
-    int GetRestLocOffset(int loc);
-
     //----------//
     // Functors //
     //----------//

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2855,7 +2855,8 @@ void MusicXmlInput::ReadMusicXmlNote(
                     // we need to split up this one
                     artic->SetArtic(artics);
                     artic->SetColor(articulation.attribute("color").as_string());
-                    artic->SetPlace(artic->AttPlacement::StrToStaffrel(articulation.attribute("placement").as_string()));
+                    artic->SetPlace(
+                        artic->AttPlacement::StrToStaffrel(articulation.attribute("placement").as_string()));
                     element->AddChild(artic);
                     artics.clear();
                     artic = new Artic();

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1116,6 +1116,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
             Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
             assert(staff);
             loc = staff->m_drawingLines - 1;
+            if (loc % 2 != 0) --loc;
+            if (staff->m_drawingLines > 1) loc += 2;
             // Limitation: GetLayerCount does not take into account editorial markup
             // should be refined later
             bool hasMultipleLayer = (staffY->GetChildCount(LAYER) > 1);
@@ -1128,10 +1130,6 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 else {
                     loc -= 2;
                 }
-            }
-            // add offset
-            else if (staff->m_drawingLines > 3) {
-                loc += 2;
             }
         }
 
@@ -1154,6 +1152,10 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
             Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
             assert(staff);
             loc = staff->m_drawingLines - 1;
+            if ((rest->GetDur() < DUR_4) && (loc % 2 != 0)) --loc;
+            // Adjust special cases
+            if ((rest->GetDur() == DUR_1) && (staff->m_drawingLines > 1)) loc += 2;
+            if ((rest->GetDur() == DUR_BR) && (staff->m_drawingLines < 2)) loc -= 2;
 
             Beam *beam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, 1));
             // Limitation: GetLayerCount does not take into account editorial markup
@@ -1273,7 +1275,6 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 loc = rest->GetOptimalLayerLocation(staff, layer, loc);
             }
         }
-        loc = rest->GetRestLocOffset(loc);
         rest->SetDrawingLoc(loc);
         this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, loc));
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -229,16 +229,6 @@ wchar_t Rest::GetRestGlyph() const
     return symc;
 }
 
-int Rest::GetRestLocOffset(int loc)
-{
-    switch (this->GetActualDur()) {
-        case DUR_1: loc += 2; break;
-        default: loc += 0; break;
-    }
-
-    return loc;
-}
-
 void Rest::UpdateFromTransLoc(const TransPitch &tp)
 {
     if (HasOloc() && HasPloc()) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1108,6 +1108,24 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     DrawSmuflCode(dc, x, y, rest, staff->m_drawingStaffSize, drawingCueSize);
 
+    // single legder line for whole rest glyphs
+    if ((measure->m_measureAligner.GetMaxTime() < (DUR_MAX * 2))
+        && (y > staff->GetDrawingY()
+            || y < staff->GetDrawingY()
+                    - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize))) {
+        const int width = m_doc->GetGlyphWidth(rest, staff->m_drawingStaffSize, drawingCueSize);
+        int ledgerLineThickness
+            = m_doc->GetOptions()->m_ledgerLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        int ledgerLineExtension
+            = m_doc->GetOptions()->m_ledgerLineExtension.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        if (drawingCueSize) {
+            ledgerLineThickness *= m_doc->GetOptions()->m_graceFactor.GetValue();
+            ledgerLineExtension *= m_doc->GetOptions()->m_graceFactor.GetValue();
+        }
+
+        DrawHorizontalLine(dc, x - ledgerLineExtension, x + width + ledgerLineExtension, y, ledgerLineThickness);
+    }
+
     dc->EndGraphic(element, this);
 }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1191,11 +1191,11 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
     const int num = std::min(multiRest->GetNum(), 999);
 
     // Position centered in staff
-    y1 = staff->GetDrawingY();
-    y2 = y1 - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
+    y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
     if (multiRest->HasLoc()) {
         y2 -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1 - multiRest->GetLoc());
     }
+    y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
     if (((num > 4) && !multiRest->HasBlock()) || (num > 15) || (multiRest->GetBlock() == BOOLEAN_true)) {
         // This is 1/2 the length of the black rectangle
@@ -1205,8 +1205,6 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
             width = (width > fixedWidth) ? fixedWidth : width;
         }
         if (width > m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 4) {
-            y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-
             // xCentered is the central point, claculate x and x2
             x1 = xCentered - width / 2;
             x2 = xCentered + width / 2;
@@ -1225,13 +1223,11 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
                 dc, x2 - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y1 + border, x2, y2 - border);
 
             dc->ReactivateGraphic();
-
         }
     }
     else {
         // Position centered in staff
-        y2 += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        y2 += (staff->m_drawingLines%2 != 0) ? m_doc->GetDrawingUnit(staff->m_drawingStaffSize) : 0;
 
         const int lgWidth = m_doc->GetGlyphWidth(SMUFL_E4E1_restLonga, staff->m_drawingStaffSize, false);
         const int brWidth = m_doc->GetGlyphWidth(SMUFL_E4E2_restDoubleWhole, staff->m_drawingStaffSize, false);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1198,8 +1198,6 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
 
     multiRest->CenterDrawingX();
 
-    int x1, x2, y1, y2;
-
     dc->StartGraphic(element, "", element->GetUuid());
 
     const int measureWidth = measure->GetInnerWidth();
@@ -1209,11 +1207,11 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
     const int num = std::min(multiRest->GetNum(), 999);
 
     // Position centered in staff
-    y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
+    int y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
     if (multiRest->HasLoc()) {
         y2 -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1 - multiRest->GetLoc());
     }
-    y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    int y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
     if (((num > 4) && !multiRest->HasBlock()) || (num > 15) || (multiRest->GetBlock() == BOOLEAN_true)) {
         // This is 1/2 the length of the black rectangle
@@ -1223,9 +1221,9 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
             width = (width > fixedWidth) ? fixedWidth : width;
         }
         if (width > m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 4) {
-            // xCentered is the central point, claculate x and x2
-            x1 = xCentered - width / 2;
-            x2 = xCentered + width / 2;
+            // xCentered is the central point, calculate x1 and x2
+            const int x1 = xCentered - width / 2;
+            const int x2 = xCentered + width / 2;
 
             // bounding box is not relevant for the multi-rest rectangle
             dc->DeactivateGraphicX();
@@ -1244,8 +1242,10 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         }
     }
     else {
-        // Position centered in staff
-        y2 += (staff->m_drawingLines%2 != 0) ? m_doc->GetDrawingUnit(staff->m_drawingStaffSize) : 0;
+        if (staff->m_drawingLines % 2 != 0) {
+            y2 += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            y1 += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        }
 
         const int lgWidth = m_doc->GetGlyphWidth(SMUFL_E4E1_restLonga, staff->m_drawingStaffSize, false);
         const int brWidth = m_doc->GetGlyphWidth(SMUFL_E4E2_restDoubleWhole, staff->m_drawingStaffSize, false);
@@ -1255,7 +1255,7 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         width += ((num % 4) / 2) * (brWidth + m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
         width = (num % 2) ? width + sbWidth : width - m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
-        x1 = xCentered - width / 2;
+        int x1 = xCentered - width / 2;
 
         int count = num;
         while ((count / 4)) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1191,7 +1191,8 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
     const int num = std::min(multiRest->GetNum(), 999);
 
     // Position centered in staff
-    y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
+    y1 = staff->GetDrawingY();
+    y2 = y1 - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
     if (multiRest->HasLoc()) {
         y2 -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1 - multiRest->GetLoc());
     }
@@ -1203,27 +1204,29 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
             const int fixedWidth = multiRest->AttWidth::GetWidth() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
             width = (width > fixedWidth) ? fixedWidth : width;
         }
+        if (width > m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 4) {
+            y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
-        // a is the central point, claculate x and x2
-        x1 = xCentered - width / 2;
-        x2 = xCentered + width / 2;
+            // xCentered is the central point, claculate x and x2
+            x1 = xCentered - width / 2;
+            x2 = xCentered + width / 2;
 
-        y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+            // bounding box is not relevant for the multi-rest rectangle
+            dc->DeactivateGraphicX();
 
-        // bounding box is not relevant for the multi-rest rectangle
-        dc->DeactivateGraphicX();
+            // Draw the base rect
+            DrawFilledRectangle(dc, x1, y1, x2, y2);
 
-        // Draw the base rect
-        DrawFilledRectangle(dc, x1, y1, x2, y2);
+            // Draw two lines at beginning and end
+            int border = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            DrawFilledRectangle(
+                dc, x1, y1 + border, x1 + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y2 - border);
+            DrawFilledRectangle(
+                dc, x2 - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y1 + border, x2, y2 - border);
 
-        // Draw two lines at beginning and end
-        int border = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        DrawFilledRectangle(
-            dc, x1, y1 + border, x1 + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y2 - border);
-        DrawFilledRectangle(
-            dc, x2 - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 2, y1 + border, x2, y2 - border);
+            dc->ReactivateGraphic();
 
-        dc->ReactivateGraphic();
+        }
     }
     else {
         // Position centered in staff

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -49,20 +49,19 @@ void View::DrawMensuralNote(DeviceContext *dc, LayerElement *element, Layer *lay
     Note *note = vrv_cast<Note *>(element);
     assert(note);
 
-    int yNote = element->GetDrawingY();
-    int xNote = element->GetDrawingX();
-    int drawingDur = note->GetDrawingDur();
-    int radius = note->GetDrawingRadius(m_doc);
-    int staffY = staff->GetDrawingY();
-    int verticalCenter = 0;
-    bool mensural_black = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
+    const int yNote = element->GetDrawingY();
+    const int xNote = element->GetDrawingX();
+    const int drawingDur = note->GetDrawingDur();
+    const int radius = note->GetDrawingRadius(m_doc);
+    const int staffY = staff->GetDrawingY();
+    const bool mensural_black = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
 
     /************** Stem/notehead direction: **************/
 
     data_STEMDIRECTION layerStemDir;
     data_STEMDIRECTION stemDir = STEMDIRECTION_NONE;
 
-    verticalCenter = staffY - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2;
+    int verticalCenter = staffY - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2;
     if (note->HasStemDir()) {
         stemDir = note->GetStemDir();
     }
@@ -118,10 +117,10 @@ void View::DrawMensuralRest(DeviceContext *dc, LayerElement *element, Layer *lay
     Rest *rest = vrv_cast<Rest *>(element);
     assert(rest);
 
-    bool drawingCueSize = rest->GetDrawingCueSize();
-    int drawingDur = rest->GetActualDur();
-    int x = element->GetDrawingX();
-    int y = element->GetDrawingY();
+    const bool drawingCueSize = rest->GetDrawingCueSize();
+    const int drawingDur = rest->GetActualDur();
+    const int x = element->GetDrawingX();
+    const int y = element->GetDrawingY();
 
     switch (drawingDur) {
         case DUR_MX: charCode = SMUFL_E9F0_mensuralRestMaxima; break;
@@ -673,7 +672,7 @@ void View::CalcBrevisPoints(
 
     // Calculate size of the rectangle
     topLeft->x = note->GetDrawingX();
-    int width = 2 * note->GetDrawingRadius(m_doc, true);
+    const int width = 2 * note->GetDrawingRadius(m_doc, true);
     bottomRight->x = topLeft->x + width;
 
     double heightFactor = (isMensuralBlack) ? 0.8 : 1.0;
@@ -713,7 +712,7 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
     assert(note2);
     assert(staff);
 
-    int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+    const int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
 
     Point *topLeft = &points[0];
     Point *bottomLeft = &points[1];


### PR DESCRIPTION
Switching to rest glyphs introduced some glitches. 
Current rendering: 
![rests-now](https://user-images.githubusercontent.com/7693447/105996507-b4441680-60aa-11eb-8084-a31b582fb048.png)

After fix:
![rests-after](https://user-images.githubusercontent.com/7693447/105996530-be661500-60aa-11eb-806a-015c55a17432.png)

MEI example from #1740
closes #1740