### PR TITLE
Unlink syllables when one is deleted

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -1432,6 +1432,19 @@ bool EditorToolkitNeume::Remove(std::string elementId)
         obj = parent;
         parent = parent->GetParent();
         if (obj->FindDescendantByType(NC) == NULL) {
+            // Check if it is part of a linked/split syllable and unlink
+            Syllable *li = vrv_cast<Syllable *>(obj);
+            assert(li);
+            if (li->HasPrecedes() || li->HasFollows()) {
+                std::string linkedID = (li->HasPrecedes() ? li->GetPrecedes() : li->GetFollows());
+                if (linkedID.compare(0, 1, "#") == 0) linkedID.erase(0, 1);
+                Syllable *linkedSyllable
+                    = vrv_cast<Syllable *>(m_doc->GetDrawingPage()->FindDescendantByUuid(linkedID));
+                if (linkedSyllable != NULL) {
+                    if (linkedSyllable->HasPrecedes()) linkedSyllable->SetPrecedes("");
+                    if (linkedSyllable->HasFollows()) linkedSyllable->SetFollows("");
+                }
+            }
             // Delete the syllable empty of neumes
             std::string syllableId = obj->GetUuid();
             result &= parent->DeleteChild(obj);


### PR DESCRIPTION
The `precedes` and `follows` attributes are used to keep track of syllables that continue onto another line. Usually syllables must be unlinked before deletion, but if all the neume contents of one syllable element (part of the syllable on one line) are deleted then the syllable container will be deleted too. Previously, it would not be checked if it was part of a linked syllable before deletion, resulting in another syllable referencing a now nonexistent syllable. This removes the reference to the syllable element to be deleted.