### PR TITLE
Transposition: Fix detecting current key signature for nested staff part

### DIFF
--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1255,7 +1255,7 @@ void Doc::TransposeDoc()
         // Find the starting key tonic of the data to use in calculating the tranposition interval:
         // Set transposition by key tonic.
         // Detect the current key from the keysignature.
-        KeySig *keysig = dynamic_cast<KeySig *>(this->m_mdivScoreDef.FindDescendantByType(KEYSIG, 3));
+        KeySig *keysig = dynamic_cast<KeySig *>(this->m_mdivScoreDef.FindDescendantByType(KEYSIG));
         // If there is no keysignature, assume it is C.
         TransPitch currentKey = TransPitch(0, 0, 0);
         if (keysig && keysig->HasPname()) {


### PR DESCRIPTION
`verovio --transpose C intro.mei`

Notice the structure is `scoreDef > staffGrp > staffGrp > staffDef > keySig`. Since `staffGrp` can contain `staffGrp`,
- [x] we should probably make this infinite instead of just incrementing it by one.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000009042897">
            <score xml:id="score-0000001660114589">
               <scoreDef xml:id="scoredef-0000000125587867">
                  <staffGrp xml:id="staffgrp-0000001937073551">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <staffDef xml:id="staffdef-0000000792783809" n="1" lines="5" ppq="2">
                           <clef xml:id="clef-0000000621073663" shape="G" line="2" />
                           <keySig xml:id="keysig-0000001614529621" mode="major" sig="3s" />
                           <meterSig xml:id="msig-0000001943460302" count="4" unit="4" />
                        </staffDef>
                        <staffDef xml:id="staffdef-0000001687979737" n="2" lines="5" ppq="2">
                           <clef xml:id="clef-0000000511024844" shape="F" line="4" />
                           <keySig xml:id="keysig-0000001007448755" mode="major" sig="3s" />
                           <meterSig xml:id="msig-0000001430152337" count="4" unit="4" />
                        </staffDef>
                        <grpSym xml:id="grpsym-0000001933350735" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000001438355499">
                  <pb xml:id="pb-0000000217457414" />
                  <measure xml:id="measure-0000000250740388" right="end" n="0">
                     <mNum xml:id="mnum-0000000787004656" />
                     <staff xml:id="staff-0000000835471519" n="1">
                        <layer xml:id="layer-0000000001146060" n="1">
                           <rest xml:id="rest-0000002081961244" dur.ppq="1" dur="8" />
                           <beam xml:id="beam-0000000472679599">
                              <note xml:id="note-0000000784010140" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                              <note xml:id="note-0000001497685387" dur.ppq="1" dur="8" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="note-0000000942472822" dur.ppq="1" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001521735747" n="2">
                        <layer xml:id="layer-0000000839511548" n="5">
                           <rest xml:id="rest-0000000703026446" dur.ppq="1" dur="8" />
                           <rest xml:id="rest-0000000310452128" dur.ppq="2" dur="4" />
                           <rest xml:id="rest-0000001531136733" dur.ppq="1" dur="8" />
                        </layer>
                     </staff>
                     <tempo xml:id="tempo-0000001429947706" place="above" staff="1" tstamp="1.000000" midi.bpm="66" mm="66.000000" mm.unit="4">
                        <rend xml:id="rend-0000000641601165" fontname="VerovioText"></rend> = 66</tempo>
                     <dynam xml:id="dynam-0000000424083690" place="below" staff="1" tstamp="1.500000" val="49" vgrp="40">
                        <rend xml:id="rend-0000000076353437" halign="right">p</rend>
                     </dynam>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```