### PR TITLE
fix staffDef spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## [unreleased]
+* Support for `clef@visible` (@rettinghaus)
 * Support for `artic@glyph.num`
 * Support for arabic accidentals
+* Improved default rest positioning
 * Improved automatic cross staff rest positioning (@eNote-GmbH)
 * Improved cross-staff spacing
 * Improved slurs

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -26,7 +26,8 @@ class Clef : public LayerElement,
              public AttClefShape,
              public AttColor,
              public AttLineLoc,
-             public AttOctaveDisplacement {
+             public AttOctaveDisplacement,
+             public AttVisibility {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -24,12 +24,13 @@ namespace vrv {
 // Clef
 //----------------------------------------------------------------------------
 
-Clef::Clef() : LayerElement("clef-"), AttClefShape(), AttColor(), AttLineLoc(), AttOctaveDisplacement()
+Clef::Clef() : LayerElement("clef-"), AttClefShape(), AttColor(), AttLineLoc(), AttOctaveDisplacement(), AttVisibility()
 {
     RegisterAttClass(ATT_CLEFSHAPE);
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_LINELOC);
     RegisterAttClass(ATT_OCTAVEDISPLACEMENT);
+    RegisterAttClass(ATT_VISIBILITY);
 
     Reset();
 }
@@ -43,6 +44,7 @@ void Clef::Reset()
     ResetColor();
     ResetLineLoc();
     ResetOctaveDisplacement();
+    ResetVisibility();
 }
 
 int Clef::GetClefLocOffset() const

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1578,6 +1578,7 @@ void MEIOutput::WriteClef(pugi::xml_node currentNode, Clef *clef)
         cleffingLog.WriteCleffingLog(currentNode);
         AttCleffingVis cleffingVis;
         cleffingVis.SetClefColor(clef->GetColor());
+        cleffingVis.SetClefVisible(clef->GetVisible());
         cleffingVis.WriteCleffingVis(currentNode);
         return;
     }
@@ -1588,6 +1589,7 @@ void MEIOutput::WriteClef(pugi::xml_node currentNode, Clef *clef)
     clef->WriteColor(currentNode);
     clef->WriteLineLoc(currentNode);
     clef->WriteOctaveDisplacement(currentNode);
+    clef->WriteVisibility(currentNode);
 }
 
 void MEIOutput::WriteCustos(pugi::xml_node currentNode, Custos *custos)
@@ -3470,6 +3472,7 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
         vrvClef->SetDis(cleffingLog.GetClefDis());
         vrvClef->SetDisPlace(cleffingLog.GetClefDisPlace());
         vrvClef->SetColor(cleffingVis.GetClefColor());
+        vrvClef->SetVisible(cleffingVis.GetClefVisible());
         object->AddChild(vrvClef);
     }
 
@@ -4846,6 +4849,7 @@ bool MEIInput::ReadClef(Object *parent, pugi::xml_node clef)
     vrvClef->ReadColor(clef);
     vrvClef->ReadLineLoc(clef);
     vrvClef->ReadOctaveDisplacement(clef);
+    vrvClef->ReadVisibility(clef);
 
     parent->AddChild(vrvClef);
     ReadUnsupportedAttr(clef, vrvClef);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1182,7 +1182,6 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
             }
             // add it if necessary
             if (clef) {
-                // Make it an attribute for now
                 staffDef->AddChild(clef);
             }
 
@@ -1227,6 +1226,10 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
                     if (std::strncmp(xmlMode.c_str(), "none", 4)) {
                         keySig->SetMode(keySig->AttKeySigLog::StrToMode(xmlMode));
                     }
+                }
+                if (key.node().attribute("id")) {
+                    if (!keySig) keySig = new KeySig();
+                    keySig->SetUuid(key.node().attribute("id").as_string());
                 }
             }
             // add it if necessary
@@ -1302,7 +1305,6 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
             }
             // add it if necessary
             if (meterSig) {
-                // Make it an attribute for now
                 staffDef->AddChild(meterSig);
             }
 
@@ -1650,9 +1652,9 @@ void MusicXmlInput::ReadMusicXmlAttributes(
             if (!keySig) keySig = new KeySig();
             keySig->SetUuid(key.node().attribute("id").as_string());
         }
+        if (keySig) keySig->SetVisible(ConvertWordToBool(key.node().attribute("print-object").as_string()));
         // Add it if necessary
         if (keySig) {
-            // Make it an attribute for now
             scoreDef->AddChild(keySig);
         }
 
@@ -1692,8 +1694,6 @@ void MusicXmlInput::ReadMusicXmlAttributes(
             }
             // add it if necessary
             if (meterSig) {
-                // Make it an attribute for now
-                meterSig->IsAttribute(true);
                 scoreDef->AddChild(meterSig);
             }
         }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -551,10 +551,14 @@ int Layer::AlignHorizontally(FunctorParams *functorParams)
         params->m_scoreDefRole = SCOREDEF_INTERMEDIATE;
 
     if (this->GetStaffDefClef()) {
-        GetStaffDefClef()->AlignHorizontally(params);
+        if (GetStaffDefClef()->GetVisible() != BOOLEAN_false) {
+            GetStaffDefClef()->AlignHorizontally(params);
+        }
     }
     if (this->GetStaffDefKeySig()) {
-        GetStaffDefKeySig()->AlignHorizontally(params);
+        if (GetStaffDefKeySig()->GetVisible() != BOOLEAN_false) {
+            GetStaffDefKeySig()->AlignHorizontally(params);
+        }
     }
     if (this->GetStaffDefMensur()) {
         GetStaffDefMensur()->AlignHorizontally(params);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -572,6 +572,13 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     Clef *clef = vrv_cast<Clef *>(element);
     assert(clef);
+
+    // hidden clef
+    if (clef->GetVisible() == BOOLEAN_false) {
+        clef->SetEmptyBB();
+        return;
+    }
+
     int x, y;
     if (m_doc->GetType() == Facs && clef->HasFacs()) {
         y = ToLogicalY(staff->GetDrawingY());


### PR DESCRIPTION
This PR is a follow up on #2015: 
* support for `clef@visible`
* remove additional space for invisible staffDef children 
