### PR TITLE
Develop editor

### DIFF
--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -107,7 +107,7 @@ verovio.toolkit.prototype.edit = function ( editorAction )
 
 verovio.toolkit.prototype.editInfo = function ()
 {
-    return JSON.parse( verovio.vrvToolkit.editInfo( this.ptr ) );
+    return verovio.vrvToolkit.editInfo( this.ptr );
 };
 
 verovio.toolkit.prototype.getAvailableOptions = function ()

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -107,7 +107,7 @@ verovio.toolkit.prototype.edit = function ( editorAction )
 
 verovio.toolkit.prototype.editInfo = function ()
 {
-    return verovio.vrvToolkit.editInfo( this.ptr );
+    return JSON.parse( verovio.vrvToolkit.editInfo( this.ptr ) );
 };
 
 verovio.toolkit.prototype.getAvailableOptions = function ()

--- a/include/vrv/editortoolkit.h
+++ b/include/vrv/editortoolkit.h
@@ -31,7 +31,7 @@ public:
     {
         m_doc = doc;
         m_view = view;
-        m_editInfo = "";
+        m_editInfo.reset();
     }
     virtual ~EditorToolkit() {}
 
@@ -42,12 +42,12 @@ public:
     /**
      * Get information on the last editor function used
      */
-    virtual std::string EditInfo() { return m_editInfo; }
+    virtual std::string EditInfo() { return m_editInfo.json(); }
 
 protected:
     Doc *m_doc;
     View *m_view;
-    std::string m_editInfo;
+    jsonxx::Object m_editInfo;
 };
 } // namespace vrv
 

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -18,6 +18,8 @@
 #include "chord.h"
 #include "clef.h"
 #include "comparison.h"
+#include "dir.h"
+#include "dynam.h"
 #include "hairpin.h"
 #include "layer.h"
 #include "measure.h"
@@ -42,7 +44,7 @@ namespace vrv {
 
 std::string EditorToolkitCMN::EditInfo()
 {
-    return m_chainedId;
+    return m_editInfo.json();
 }
 
 bool EditorToolkitCMN::ParseEditorAction(const std::string &json_editorAction, bool commitOnly)
@@ -206,7 +208,7 @@ bool EditorToolkitCMN::Chain(jsonxx::Array actions)
     m_chainedId = "";
     for (int i = 0; i < (int)actions.size(); i++) {
         status = this->ParseEditorAction(actions.get<jsonxx::Object>(i).json(), !status);
-        m_editInfo = m_chainedId;
+        m_editInfo.import("uuid", m_chainedId);
     }
     return status;
 }
@@ -310,7 +312,8 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     interface->SetEndid("#" + endid);
 
     this->m_chainedId = element->GetUuid();
-
+    m_editInfo.import("uuid", element->GetUuid());
+    
     return true;
 }
 
@@ -333,16 +336,15 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
         return false;
     }
 
-    /*
     Measure *measure = vrv_cast<Measure *>(start->GetFirstAncestor(MEASURE));
     assert(measure);
 
     ControlElement *element = NULL;
-    if (elementType == "dynam") {
-        element = new Slur();
+    if (elementType == "dir") {
+        element = new Dir();
     }
-    else if (elementType == "hairpin") {
-        element = new Hairpin();
+    else if (elementType == "dynam") {
+        element = new Dynam();
     }
     else {
         LogMessage("Inserting control event '%s' is not supported", elementType.c_str());
@@ -353,12 +355,11 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     TimeSpanningInterface *interface = element->GetTimeSpanningInterface();
     assert(interface);
     measure->AddChild(element);
-    interface->SetStartid(startid);
-    interface->SetEndid(endid);
+    interface->SetStartid("#" + startid);
 
     this->m_chainedId = element->GetUuid();
-    */
-
+    m_editInfo.import("uuid", element->GetUuid());
+    
     return true;
 }
 

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -27,6 +27,7 @@
 #include "rest.h"
 #include "slur.h"
 #include "staff.h"
+#include "tie.h"
 #include "vrv.h"
 
 //--------------------------------------------------------------------------------
@@ -290,6 +291,9 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     if (elementType == "slur") {
         element = new Slur();
     }
+    else if (elementType == "tie") {
+        element = new Tie();
+    }
     else if (elementType == "hairpin") {
         element = new Hairpin();
     }
@@ -302,8 +306,8 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     TimeSpanningInterface *interface = element->GetTimeSpanningInterface();
     assert(interface);
     measure->AddChild(element);
-    interface->SetStartid(startid);
-    interface->SetEndid(endid);
+    interface->SetStartid("#" + startid);
+    interface->SetEndid("#" + endid);
 
     this->m_chainedId = element->GetUuid();
 


### PR DESCRIPTION
This PR addresses #2022 and #2023. 

For #2022, the `std::string m_editInfo` in `EditorToolkitCMN` was made a JSON object that now stores the `uuid` of the last edit operation and returns it in `EditorToolkitCMN::EditInfo()`. This is now more similar to the behaviour of `EditorToolkitNeume` where detailed error messages are stored in a JSON object `m_infoObject`. 

`tie`, `dir`, and `dynam` are now added as examples for control elements with only a startid or a startid and a endid.

Bevor merging, we should discuss, how the editor could grow. 