### PR TITLE
Improve vertical tempo alignment

### DIFF
--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -181,9 +181,15 @@ public:
     bool HasAlignmentReference(int staffN);
 
     /**
+
      * Return true if the alignment contains only references to timestamp attributes.
      */
     bool HasTimestampOnly();
+
+    /* Return true and X position of the first accidental from the accid space of alignment reference for specific staff
+     * (found by staffN parameter). Return false and 0 otherwise.
+     */
+    std::pair<int, bool> GetAccidAdjustedPosition(Doc *doc, int staffN);
 
     //----------//
     // Functors //
@@ -312,6 +318,11 @@ public:
      * Return true if the reference has elements from multiple layers.
      */
     bool HasMultipleLayer() const { return (m_layerCount > 1); }
+
+    /**
+     * Return first accidental from the accid space of the alignment reference
+     */
+    Accid *GetFrontAccid() const;
 
     //----------//
     // Functors //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -181,7 +181,6 @@ public:
     bool HasAlignmentReference(int staffN);
 
     /**
-
      * Return true if the alignment contains only references to timestamp attributes.
      */
     bool HasTimestampOnly();

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -461,6 +461,19 @@ void Alignment::ClearGraceAligners()
     m_graceAligners.clear();
 }
 
+std::pair<int, bool> Alignment::GetAccidAdjustedPosition(Doc* doc, int staffN)
+{
+    if (!HasAlignmentReference(staffN)) return { 0, false };
+
+    AlignmentReference *reference = GetAlignmentReference(staffN);
+    if (!reference) return { 0, false };
+
+    Accid *accid = reference->GetFrontAccid();
+    if (!accid) return { 0, false };
+
+    return { accid->GetDrawingX(), true };
+}
+
 bool Alignment::IsSupportedChild(Object *child)
 {
     assert(dynamic_cast<AlignmentReference *>(child));
@@ -711,6 +724,13 @@ void AlignmentReference::AdjustAccidWithAccidSpace(Accid *accid, Doc *doc, int s
     for (auto child : *this->GetChildren()) {
         accid->AdjustX(dynamic_cast<LayerElement *>(child), doc, staffSize, leftAccids);
     }
+}
+
+Accid *AlignmentReference::GetFrontAccid() const
+{
+    if (m_accidSpace.empty()) return NULL;
+
+    return m_accidSpace.front();
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1466,23 +1466,8 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
 
     int lineCount = dir->GetNumberOfLines(dir);
 
-    MeasureAlignerTypeComparison alignmentComparison(ALIGNMENT_SCOREDEF_METERSIG);
-    Alignment *pos
-        = dynamic_cast<Alignment *>(measure->m_measureAligner.FindDescendantByComparison(&alignmentComparison, 1));
     // If we have not timestamp
     params.m_x = dir->GetStart()->GetDrawingX() + dir->GetStart()->GetDrawingRadius(m_doc);
-    if (!dir->HasStartid() && (dir->GetTstamp() <= 1) && pos) {
-        params.m_x = measure->GetDrawingX() + pos->GetXRel();
-    }
-    else if (dir->HasStartid()) {
-        LayerElement *parent = dir->GetStart();
-        ClassIdComparison comp(ACCID);
-        ListOfObjects children;
-        parent->FindAllDescendantByComparison(&children, &comp);
-        if (!children.empty()) {
-            params.m_x = children.front()->GetDrawingX();
-        }
-    }
 
     data_HORIZONTALALIGNMENT alignment = dir->GetChildRendAlignment();
     // dir are left aligned by default (with both @tstamp and @startid)
@@ -1494,12 +1479,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
         if (!system->SetCurrentFloatingPositioner((*staffIter)->GetN(), dir, dir->GetStart(), *staffIter)) {
             continue;
         }
-        if (!dir->HasStartid() && !pos) {
-            Alignment *dirAlignment = dir->GetStart()->GetAlignment();
-            params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
-            auto [xPos, result] = dirAlignment->GetAccidAdjustedPosition(m_doc, (*staffIter)->GetN());
-            if (result) params.m_x = xPos;
-        }
+
         params.m_boxedRend.clear();
         params.m_y = dir->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
@@ -2161,6 +2141,15 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         else
             params.m_x -= 2 * tempo->GetStart()->GetDrawingRadius(m_doc);
     }
+    else if (tempo->HasStartid()) {
+        LayerElement *parent = tempo->GetStart();
+        ClassIdComparison comp(ACCID);
+        ListOfObjects children;
+        parent->FindAllDescendantByComparison(&children, &comp);
+        if (!children.empty()) {
+            params.m_x = children.front()->GetDrawingX();
+        }
+    }
 
     data_HORIZONTALALIGNMENT alignment = tempo->GetChildRendAlignment();
     // Tempo are left aligned by default;
@@ -2172,7 +2161,13 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         if (!system->SetCurrentFloatingPositioner((*staffIter)->GetN(), tempo, tempo->GetStart(), *staffIter)) {
             continue;
         }
-
+        
+        if (!tempo->HasStartid() && !pos) {
+            Alignment *dirAlignment = tempo->GetStart()->GetAlignment();
+            params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
+            auto [xPos, result] = dirAlignment->GetAccidAdjustedPosition(m_doc, (*staffIter)->GetN());
+            if (result) params.m_x = xPos;
+        }
         params.m_boxedRend.clear();
         params.m_y = tempo->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1480,7 +1480,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
         ListOfObjects children;
         parent->FindAllDescendantByComparison(&children, &comp);
         if (!children.empty()) {
-            params.m_x = children.front()->GetDrawingX() - dir->GetStart()->GetDrawingRadius(m_doc);
+            params.m_x = children.front()->GetDrawingX();
         }
     }
 
@@ -1493,6 +1493,12 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
     for (staffIter = staffList.begin(); staffIter != staffList.end(); ++staffIter) {
         if (!system->SetCurrentFloatingPositioner((*staffIter)->GetN(), dir, dir->GetStart(), *staffIter)) {
             continue;
+        }
+        if (!dir->HasStartid() && !pos) {
+            Alignment *dirAlignment = dir->GetStart()->GetAlignment();
+            params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
+            auto [xPos, result] = dirAlignment->GetAccidAdjustedPosition(m_doc, (*staffIter)->GetN());
+            if (result) params.m_x = xPos;
         }
         params.m_boxedRend.clear();
         params.m_y = dir->GetDrawingY();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1474,6 +1474,15 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
     if (!dir->HasStartid() && (dir->GetTstamp() <= 1) && pos) {
         params.m_x = measure->GetDrawingX() + pos->GetXRel();
     }
+    else if (dir->HasStartid()) {
+        LayerElement *parent = dir->GetStart();
+        ClassIdComparison comp(ACCID);
+        ListOfObjects children;
+        parent->FindAllDescendantByComparison(&children, &comp);
+        if (!children.empty()) {
+            params.m_x = children.front()->GetDrawingX() - dir->GetStart()->GetDrawingRadius(m_doc);
+        }
+    }
 
     data_HORIZONTALALIGNMENT alignment = dir->GetChildRendAlignment();
     // dir are left aligned by default (with both @tstamp and @startid)

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1466,8 +1466,14 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
 
     int lineCount = dir->GetNumberOfLines(dir);
 
+    MeasureAlignerTypeComparison alignmentComparison(ALIGNMENT_SCOREDEF_METERSIG);
+    Alignment *pos
+        = dynamic_cast<Alignment *>(measure->m_measureAligner.FindDescendantByComparison(&alignmentComparison, 1));
     // If we have not timestamp
     params.m_x = dir->GetStart()->GetDrawingX() + dir->GetStart()->GetDrawingRadius(m_doc);
+    if (!dir->HasStartid() && (dir->GetTstamp() <= 1) && pos) {
+        params.m_x = measure->GetDrawingX() + pos->GetXRel();
+    }
 
     data_HORIZONTALALIGNMENT alignment = dir->GetChildRendAlignment();
     // dir are left aligned by default (with both @tstamp and @startid)


### PR DESCRIPTION
closes #2013 
Improves positioning of the vertical tempo alignment - in case when there are accidentals present, tempo should be aligned with them, instead of the note.
![image](https://user-images.githubusercontent.com/1819669/106742899-4d80a900-6626-11eb-8630-03b426502480.png)

This works with both @startid and @tmstamp