### PR TITLE
Avoid space to be added for timestamp events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Improved positioning of ornaments with multiple layers
 * Improved articulations in normal and cross-staff contexts
 * Improved spacing of clef changes
+* Improved timestamp events alignments by avoiding extra-space to be added
 * Embedding of Leland font from MuseScore
 * Option for sometimes using encoded breaks, at configurable threshold (`--breaks smart` and `--breaks-smart-sb`) (@earboxer)
 * Options `--top-margin-artic and --bottom-margin-artic for articulation margins

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1956,8 +1956,11 @@ public:
  * member 0: the previous time position
  * member 1: the previous x rel position
  * member 2: duration of the longest note
- * member 3: the doc
- * member 4: the functor to be redirected to Aligner
+ * member 3: the last alignment that was not timestamp-only
+ * member 4: the list of timestamp-only alignment that needs to be adjusted
+ * member 5: the MeasureAligner
+ * member 6: the Doc
+ * member 7: the functor to be redirected to Aligner
  **/
 
 class SetAlignmentXPosParams : public FunctorParams {
@@ -1968,6 +1971,7 @@ public:
         m_previousXRel = 0;
         m_longestActualDur = 0;
         m_lastNonTimestamp = NULL;
+        m_measureAligner = NULL;
         m_doc = doc;
         m_functor = functor;
     }
@@ -1976,6 +1980,7 @@ public:
     int m_longestActualDur;
     Alignment *m_lastNonTimestamp;
     std::list<Alignment *> m_timestamps;
+    MeasureAligner *m_measureAligner;
     Doc *m_doc;
     Functor *m_functor;
 };

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -452,6 +452,15 @@ public:
     ///@}
 
     /**
+     * @name Set and Get the initial tstamp duration.
+     * Setter takes a meter unit parameter.
+     */
+    ///@{
+    void SetInitialTstamp(int meterUnit);
+    double GetInitialTstampDur() const { return m_initialTstampDur; }
+    ///@}
+
+    /**
      * Get left Alignment for the measure and for the left BarLine.
      * For each MeasureAligner, we keep and Alignment for the left position.
      * The Alignment time will be always -1.0 * DUR_MAX and will appear first in the list.
@@ -524,6 +533,12 @@ private:
      * Store measure's non-justifiable margin used by the scoreDef attributes.
      */
     int m_nonJustifiableLeftMargin;
+
+    /**
+     * The time duration of the timestamp between 0.0 and 1.0.
+     * This depends on the meter signature in the preceeding scoreDef
+     */
+    double m_initialTstampDur;
 };
 
 //----------------------------------------------------------------------------

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -116,6 +116,8 @@ void MeasureAligner::Reset()
     AddAlignment(m_rightBarLineAlignment);
     m_rightAlignment = new Alignment(0.0 * DUR_MAX, ALIGNMENT_MEASURE_END);
     AddAlignment(m_rightAlignment);
+
+    m_initialTstampDur = -DUR_MAX;
 }
 
 Alignment *MeasureAligner::GetAlignmentAtTime(double time, AlignmentType type)
@@ -169,6 +171,13 @@ double MeasureAligner::GetMaxTime() const
     assert(m_rightBarLineAlignment);
 
     return m_rightAlignment->GetTime();
+}
+
+void MeasureAligner::SetInitialTstamp(int meterUnit)
+{
+    if (meterUnit != 0) {
+        m_initialTstampDur = DUR_MAX / meterUnit * -1;
+    }
 }
 
 void MeasureAligner::AdjustProportionally(const ArrayOfAdjustmentTuples &adjustments)
@@ -779,8 +788,9 @@ int MeasureAligner::SetAlignmentXPos(FunctorParams *functorParams)
     // We start a new MeasureAligner
     // Reset the previous time position and x_rel to 0;
     params->m_previousTime = 0.0;
-    params->m_previousXRel = 0;
-    params->m_lastNonTimestamp = NULL;
+    params->m_previousXRel = params->m_doc->GetDrawingUnit(100);
+    params->m_lastNonTimestamp = m_leftBarLineAlignment;
+    params->m_measureAligner = this;
 
     return FUNCTOR_CONTINUE;
 }
@@ -1035,10 +1045,11 @@ int Alignment::SetAlignmentXPos(FunctorParams *functorParams)
         intervalTime = 0.0;
     }
 
-    // if (this->HasTimestampOnly()) {
-    //    params->m_timestamps.push_back(this);
-    // return FUNCTOR_CONTINUE;
-    //}
+    // Do not move aligner that are only time-stamps at this stage but add it to the pending list
+    if (this->HasTimestampOnly()) {
+        params->m_timestamps.push_back(this);
+        return FUNCTOR_CONTINUE;
+    }
 
     if (intervalTime > 0.0) {
         intervalXRel = HorizontalSpaceForDuration(intervalTime, params->m_longestActualDur,
@@ -1056,13 +1067,31 @@ int Alignment::SetAlignmentXPos(FunctorParams *functorParams)
     params->m_previousTime = m_time;
     params->m_previousXRel = m_xRel;
 
-    /*
-    for (auto &alignment : params->m_timestamps) {
-        LogMessage("%f", alignment->GetTime());
+    // This is an alignment which is not timestamp only. If we have a list of pendings timetamp
+    // alignments, then we now need to move them appropriately
+    if (!params->m_timestamps.empty() && params->m_lastNonTimestamp) {
+        int startXRel = params->m_lastNonTimestamp->GetXRel();
+        double startTime = params->m_lastNonTimestamp->GetTime();
+        double endTime = this->GetTime();
+        // We have timestamp alignments between the left barline and the first beat. We need
+        // to use the MeasureAligner::m_initialTstampDur to calculate the time (percentage) position
+        if (params->m_lastNonTimestamp->GetType() == ALIGNMENT_MEASURE_LEFT_BARLINE) {
+            startTime = params->m_measureAligner->GetInitialTstampDur();
+        }
+        // The duration since the last alignment and the current one
+        double duration = endTime - startTime;
+        int space = m_xRel - params->m_lastNonTimestamp->GetXRel();
+        // For each timestamp alignment, move them proporitionally to the space we currently have
+        for (auto &alignment : params->m_timestamps) {
+            // Avoid division by zero (nothing to move with the alignment anyway
+            if (duration == 0.0) break;
+            double percent = (alignment->GetTime() - startTime) / duration;
+            alignment->SetXRel(startXRel + space * percent);
+        }
+        params->m_timestamps.clear();
     }
-    params->m_timestamps.clear();
+
     params->m_lastNonTimestamp = this;
-    */
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -662,6 +662,9 @@ int Measure::AlignHorizontallyEnd(FunctorParams *functorParams)
     AlignHorizontallyParams *params = vrv_params_cast<AlignHorizontallyParams *>(functorParams);
     assert(params);
 
+    int meterUnit = (params->m_currentMeterSig) ? params->m_currentMeterSig->GetUnit() : 4;
+    m_measureAligner.SetInitialTstamp(meterUnit);
+
     // We also need to align the timestamps - we do it at the end since we need the *meterSig to be initialized by a
     // Layer. Obviously this will not work with different time signature. However, I am not sure how this would work
     // in MEI anyway.


### PR DESCRIPTION
This PR produces more regular spacing when control events have timestamps pointing to positions where no musical event occurs. For example:

![image](https://user-images.githubusercontent.com/689412/106747060-b286cf80-6623-11eb-9e94-b1560acd826f.png)

![image](https://user-images.githubusercontent.com/689412/106747144-cf230780-6623-11eb-85a4-f7bb985734fd.png)

![image](https://user-images.githubusercontent.com/689412/106747416-2f19ae00-6624-11eb-8c25-f0885a5114d7.png)

See the test-suite output below for additional examples. I am leaving the PR open for a day since this is a fairly significant change in case people have questions or comments.