### PR TITLE
Vertical tempo alignment improvement

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -503,6 +503,28 @@ public:
     Doc *m_doc;
 };
 
+
+//----------------------------------------------------------------------------
+// AdjustTempoParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the systemAligner
+ * member 1: the doc
+ **/
+
+class AdjustTempoParams : public FunctorParams {
+public:
+    AdjustTempoParams(Doc *doc)
+    {
+        m_systemAligner = NULL;
+        m_doc = doc;
+    }
+
+    SystemAligner *m_systemAligner;
+    Doc *m_doc;
+};
+
 //----------------------------------------------------------------------------
 // AdjustTupletNumOverlapParams
 //----------------------------------------------------------------------------

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -188,7 +188,7 @@ public:
     /* Return true and X position of the first accidental from the accid space of alignment reference for specific staff
      * (found by staffN parameter). Return false and 0 otherwise.
      */
-    std::pair<int, bool> GetAccidAdjustedPosition(Doc *doc, int staffN);
+    std::pair<int, bool> GetAccidAdjustedPosition(Doc *doc, int staffN, int staffSize);
 
     //----------//
     // Functors //
@@ -319,9 +319,9 @@ public:
     bool HasMultipleLayer() const { return (m_layerCount > 1); }
 
     /**
-     * Return first accidental from the accid space of the alignment reference
+     * Return const pointer to the accid space
      */
-    Accid *GetFrontAccid() const;
+    const std::vector<Accid *> *GetAccidSpace(bool docChildren = true) const { return &m_accidSpace; }
 
     //----------//
     // Functors //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -185,11 +185,6 @@ public:
      */
     bool HasTimestampOnly();
 
-    /* Return true and X position of the first accidental from the accid space of alignment reference for specific staff
-     * (found by staffN parameter). Return false and 0 otherwise.
-     */
-    std::pair<int, bool> GetAccidAdjustedPosition(Doc *doc, int staffN, int staffSize);
-
     //----------//
     // Functors //
     //----------//
@@ -317,11 +312,6 @@ public:
      * Return true if the reference has elements from multiple layers.
      */
     bool HasMultipleLayer() const { return (m_layerCount > 1); }
-
-    /**
-     * Return const pointer to the accid space
-     */
-    const std::vector<Accid *> *GetAccidSpace(bool docChildren = true) const { return &m_accidSpace; }
 
     //----------//
     // Functors //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -764,6 +764,11 @@ public:
     virtual int AdjustAccidX(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
+     * Adjust the x position of accidental.
+     */
+    virtual int AdjustTempo(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * @name Adjust the x position of a right barline in order to make sure the is no text content
      * overlflowing in the right margin
      */

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -189,6 +189,11 @@ public:
     ///@}
 
     /**
+     * See Object::AdjustTempo
+     */
+    virtual int AdjustTempo(FunctorParams *functorParams);
+
+    /**
      * See Object::AlignVertically
      */
     ///@{

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -58,15 +58,27 @@ public:
      */
     virtual bool IsSupportedChild(Object *object);
 
+    /**
+     * @name Get the X drawing position
+     */
+    ///@{
+    int GetDrawingXRelativeToStaff(int staffN);
+
     //----------//
     // Functors //
     //----------//
+
+    /**
+     * See Object::AdjustTempoX
+     */
+    virtual int AdjustTempo(FunctorParams *functorParams);
 
 private:
     //
 public:
     //
 private:
+    std::map<int, int> m_drawingXRel;
 };
 
 } // namespace vrv

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -476,7 +476,7 @@ std::pair<int, bool> Alignment::GetAccidAdjustedPosition(Doc *doc, int staffN, i
     Accid *accid = vrv_cast<Accid *>(*iter);
     const int accidGlyphWidth = doc->GetGlyphWidth(accid->GetAccidGlyph(accid->GetAccid()), staffSize, false);
 
-    return { (*iter)->GetDrawingX() - accidGlyphWidth, true };
+    return { (*iter)->GetDrawingX() - accidGlyphWidth / 2, true };
 }
 
 bool Alignment::IsSupportedChild(Object *child)

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -461,24 +461,6 @@ void Alignment::ClearGraceAligners()
     m_graceAligners.clear();
 }
 
-std::pair<int, bool> Alignment::GetAccidAdjustedPosition(Doc *doc, int staffN, int staffSize)
-{
-    if (!HasAlignmentReference(staffN)) return { 0, false };
-
-    AlignmentReference *reference = GetAlignmentReference(staffN);
-    if (!reference) return { 0, false };
-
-    const std::vector<Accid *> *alignmentAccidentals = reference->GetAccidSpace();
-    if (alignmentAccidentals->empty()) return { 0, false };
-
-    auto iter = std::min_element(alignmentAccidentals->cbegin(), alignmentAccidentals->cend(),
-        [](const Accid *left, const Accid *right) { return left->GetDrawingX() < right->GetDrawingX(); });
-    Accid *accid = vrv_cast<Accid *>(*iter);
-    const int accidGlyphWidth = doc->GetGlyphWidth(accid->GetAccidGlyph(accid->GetAccid()), staffSize, false);
-
-    return { (*iter)->GetDrawingX() - accidGlyphWidth / 2, true };
-}
-
 bool Alignment::IsSupportedChild(Object *child)
 {
     assert(dynamic_cast<AlignmentReference *>(child));

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -359,6 +359,11 @@ void Page::LayOutHorizontally()
     AdjustArpegParams adjustArpegParams(doc, &adjustArpeg);
     this->Process(&adjustArpeg, &adjustArpegParams, &adjustArpegEnd);
 
+    // Adjust the tempo
+    Functor adjustTempo(&Object::AdjustTempo);
+    AdjustTempoParams adjustTempoParams(doc);
+    this->Process(&adjustTempo, &adjustTempoParams);
+
     // Adjust the position of the tuplets
     FunctorDocParams adjustTupletsXParams(doc);
     Functor adjustTupletsX(&Object::AdjustTupletsX);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -559,6 +559,16 @@ int System::AdjustSylSpacingEnd(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int System::AdjustTempo(FunctorParams *functorParams)
+{
+    AdjustTempoParams *params = vrv_params_cast<AdjustTempoParams *>(functorParams);
+    assert(params);
+
+    params->m_systemAligner = &m_systemAligner;
+
+    return FUNCTOR_CONTINUE;
+}
+
 int System::AdjustYPos(FunctorParams *functorParams)
 {
     AdjustYPosParams *params = vrv_params_cast<AdjustYPosParams *>(functorParams);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2151,8 +2151,8 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
                 [](Object *left, Object *right) { return left->GetDrawingX() < right->GetDrawingX(); });
 
             Accid *accid = vrv_cast<Accid *>(*iter);
-            params.m_x
-                = (*iter)->GetDrawingX() - m_doc->GetGlyphWidth(accid->GetAccidGlyph(accid->GetAccid()), 100, false);
+            params.m_x = (*iter)->GetDrawingX()
+                - m_doc->GetGlyphWidth(accid->GetAccidGlyph(accid->GetAccid()), 100, false) / 2;
         }
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2129,33 +2129,6 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
     int lineCount = tempo->GetNumberOfLines(tempo);
 
     TextDrawingParams params;
-
-    // see if we have a meter signature for this measure
-    MeasureAlignerTypeComparison alignmentComparison(ALIGNMENT_SCOREDEF_METERSIG);
-    Alignment *pos
-        = dynamic_cast<Alignment *>(measure->m_measureAligner.FindDescendantByComparison(&alignmentComparison, 1));
-    params.m_x = tempo->GetStart()->GetDrawingX();
-    if (!tempo->HasStartid()) {
-        if ((tempo->GetTstamp() <= 1) && pos)
-            params.m_x = measure->GetDrawingX() + pos->GetXRel();
-        else
-            params.m_x -= 2 * tempo->GetStart()->GetDrawingRadius(m_doc);
-    }
-    else if (tempo->HasStartid()) {
-        LayerElement *parent = tempo->GetStart();
-        ClassIdComparison comp(ACCID);
-        ListOfObjects children;
-        parent->FindAllDescendantByComparison(&children, &comp);
-        if (!children.empty()) {
-            auto iter = std::min_element(children.begin(), children.end(),
-                [](Object *left, Object *right) { return left->GetDrawingX() < right->GetDrawingX(); });
-
-            Accid *accid = vrv_cast<Accid *>(*iter);
-            params.m_x = (*iter)->GetDrawingX()
-                - m_doc->GetGlyphWidth(accid->GetAccidGlyph(accid->GetAccid()), 100, false) / 2;
-        }
-    }
-
     data_HORIZONTALALIGNMENT alignment = tempo->GetChildRendAlignment();
     // Tempo are left aligned by default;
     if (alignment == 0) alignment = HORIZONTALALIGNMENT_left;
@@ -2167,13 +2140,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
             continue;
         }
 
-        if (!tempo->HasStartid() && !pos) {
-            Alignment *dirAlignment = tempo->GetStart()->GetAlignment();
-            params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
-            auto [xPos, result]
-                = dirAlignment->GetAccidAdjustedPosition(m_doc, (*staffIter)->GetN(), (*staffIter)->m_drawingStaffSize);
-            if (result) params.m_x = xPos;
-        }
+        params.m_x = tempo->GetDrawingXRelativeToStaff((*staffIter)->GetN());
         params.m_boxedRend.clear();
         params.m_y = tempo->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2147,7 +2147,12 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         ListOfObjects children;
         parent->FindAllDescendantByComparison(&children, &comp);
         if (!children.empty()) {
-            params.m_x = children.front()->GetDrawingX();
+            auto iter = std::min_element(children.begin(), children.end(),
+                [](Object *left, Object *right) { return left->GetDrawingX() < right->GetDrawingX(); });
+
+            Accid *accid = vrv_cast<Accid *>(*iter);
+            params.m_x
+                = (*iter)->GetDrawingX() - m_doc->GetGlyphWidth(accid->GetAccidGlyph(accid->GetAccid()), 100, false);
         }
     }
 
@@ -2165,7 +2170,8 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         if (!tempo->HasStartid() && !pos) {
             Alignment *dirAlignment = tempo->GetStart()->GetAlignment();
             params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
-            auto [xPos, result] = dirAlignment->GetAccidAdjustedPosition(m_doc, (*staffIter)->GetN());
+            auto [xPos, result]
+                = dirAlignment->GetAccidAdjustedPosition(m_doc, (*staffIter)->GetN(), (*staffIter)->m_drawingStaffSize);
             if (result) params.m_x = xPos;
         }
         params.m_boxedRend.clear();


### PR DESCRIPTION
Addressed things, mentioned in #2029.
I left FindAllDescendantByComparison() since improved implementation requires all of the children, instead of just first in the list. This works better for chords like following, that have the same accidental for each note (and first accidental wouldn't necessarily be the leftmost):
![image](https://user-images.githubusercontent.com/1819669/106876689-a745a980-66e0-11eb-96fe-a89aae4acc84.png)
