### PR TITLE
Develop fix grpsym

### DIFF
--- a/doc/test-suite.py
+++ b/doc/test-suite.py
@@ -63,6 +63,7 @@ if __name__ == "__main__":
 
             # filenames (input MEI and output SVG)
             meiFile = os.path.join(path1, item1, item2)
+            print(meiFile)
             name, ext = os.path.splitext(item2)
             svgFile = os.path.join(path2, item1, name + '.svg')
             pngFile = os.path.join(path2, item1, name + '.png')

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -221,17 +221,22 @@ public:
      * It uses the MusObject::SetPageScoreDef functor method for parsing the file.
      * This will be done only if m_currentScoreDefDone is false or force is true.
      */
-    void SetCurrentScoreDefDoc(bool force = false);
+    void ScoreDefSetCurrentDoc(bool force = false);
 
     /**
      * Check whether we need to optimize score based on the condense option
      */
-    bool IsOptimizationNeeded();
+    bool ScoreDefNeedsOptimization();
 
     /**
      * Optimize the scoreDef once the document is cast-off.
      */
-    void OptimizeScoreDefDoc();
+    void ScoreDefOptimizeDoc();
+
+    /**
+     * Set the GrpSym start / end for each System once ScoreDef is set and (if necessary) optimized
+     */
+    void ScoreDefSetGrpSymDoc();
 
     /**
      * Prepare the document for drawing.
@@ -509,7 +514,7 @@ private:
 
     /**
      * A flag to indicate whether the currentScoreDef has been set or not.
-     * If yes, SetCurrentScoreDef will not parse the document (again) unless
+     * If yes, ScoreDefSetCurrent will not parse the document (again) unless
      * the force parameter is set.
      */
     bool m_currentScoreDefDone;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1638,40 +1638,6 @@ public:
 };
 
 //----------------------------------------------------------------------------
-// OptimizeScoreDefParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the current scoreDef
- * member 1: the current staffDef
- * member 2: the flag indicating if we are optimizing encoded layout
- * member 3: the doc
- **/
-
-class OptimizeScoreDefParams : public FunctorParams {
-public:
-    OptimizeScoreDefParams(Doc *doc, Functor *functor, Functor *functorEnd)
-    {
-        m_currentScoreDef = NULL;
-        m_encoded = false;
-        m_firstScoreDef = true;
-        m_hasFermata = false;
-        m_hasTempo = false;
-        m_doc = doc;
-        m_functor = functor;
-        m_functorEnd = functorEnd;
-    }
-    ScoreDef *m_currentScoreDef;
-    bool m_encoded;
-    bool m_firstScoreDef;
-    bool m_hasFermata;
-    bool m_hasTempo;
-    Doc *m_doc;
-    Functor *m_functor;
-    Functor *m_functorEnd;
-};
-
-//----------------------------------------------------------------------------
 // PrepareBoundariesParams
 //----------------------------------------------------------------------------
 
@@ -2027,7 +1993,41 @@ public:
 };
 
 //----------------------------------------------------------------------------
-// SetCurrentScoreDefParams
+// ScoreDefOptimizeParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the current scoreDef
+ * member 1: the current staffDef
+ * member 2: the flag indicating if we are optimizing encoded layout
+ * member 3: the doc
+ **/
+
+class ScoreDefOptimizeParams : public FunctorParams {
+public:
+    ScoreDefOptimizeParams(Doc *doc, Functor *functor, Functor *functorEnd)
+    {
+        m_currentScoreDef = NULL;
+        m_encoded = false;
+        m_firstScoreDef = true;
+        m_hasFermata = false;
+        m_hasTempo = false;
+        m_doc = doc;
+        m_functor = functor;
+        m_functorEnd = functorEnd;
+    }
+    ScoreDef *m_currentScoreDef;
+    bool m_encoded;
+    bool m_firstScoreDef;
+    bool m_hasFermata;
+    bool m_hasTempo;
+    Doc *m_doc;
+    Functor *m_functor;
+    Functor *m_functorEnd;
+};
+
+//----------------------------------------------------------------------------
+// ScoreDefSetCurrentParams
 //----------------------------------------------------------------------------
 
 /**
@@ -2040,9 +2040,9 @@ public:
  * member 6: the doc
  **/
 
-class SetCurrentScoreDefParams : public FunctorParams {
+class ScoreDefSetCurrentParams : public FunctorParams {
 public:
-    SetCurrentScoreDefParams(Doc *doc, ScoreDef *upcomingScoreDef)
+    ScoreDefSetCurrentParams(Doc *doc, ScoreDef *upcomingScoreDef)
     {
         m_currentScoreDef = NULL;
         m_currentStaffDef = NULL;
@@ -2059,6 +2059,34 @@ public:
     System *m_currentSystem;
     bool m_drawLabels;
     Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
+// ScoreDefSetGrpSymParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the functor to be redirected to the System::m_currentScoreDef
+ **/
+
+class ScoreDefSetGrpSymParams : public FunctorParams {
+public:
+    ScoreDefSetGrpSymParams(Functor *functor) { m_functor = functor; }
+    Functor *m_functor;
+};
+
+//----------------------------------------------------------------------------
+// ScoreDefUnsetCurrentParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the functor to be redirected to Aligner
+ **/
+
+class ScoreDefUnsetCurrentParams : public FunctorParams {
+public:
+    ScoreDefUnsetCurrentParams(Functor *functor) { m_functor = functor; }
+    Functor *m_functor;
 };
 
 //----------------------------------------------------------------------------
@@ -2154,20 +2182,6 @@ public:
 class ReorderByXPosParams : public FunctorParams {
 public:
     int modifications = 0;
-};
-
-//----------------------------------------------------------------------------
-// UnsetCurrentScoreDefParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the functor to be redirected to Aligner
- **/
-
-class UnsetCurrentScoreDefParams : public FunctorParams {
-public:
-    UnsetCurrentScoreDefParams(Functor *functor) { m_functor = functor; }
-    Functor *m_functor;
 };
 
 } // namespace vrv

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -69,6 +69,11 @@ public:
      */
     virtual int PrepareGroupSymbols(FunctorParams *functorParams);
 
+    /**
+     * See Object::OptimizeScoreDef
+     */
+    virtual int OptimizeScoreDefEnd(FunctorParams *functorParams);
+
 private:
     //
 public:

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -65,14 +65,9 @@ public:
     //----------//
 
     /**
-     * See Object::PrepareGroupSymbols
+     * See Object::ScoreDefSetGrpSym
      */
-    virtual int PrepareGroupSymbols(FunctorParams *functorParams);
-
-    /**
-     * See Object::OptimizeScoreDef
-     */
-    virtual int OptimizeScoreDefEnd(FunctorParams *functorParams);
+    virtual int ScoreDefSetGrpSym(FunctorParams *functorParams);
 
 private:
     //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -333,9 +333,9 @@ public:
     virtual int AdjustAccidX(FunctorParams *functorParams);
 
     /**
-     * See Object::UnsetCurrentScoreDef
+     * See Object::UnscoreDefSetCurrent
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
 
 private:
     //

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -189,9 +189,9 @@ public:
     virtual int ConvertToUnCastOffMensural(FunctorParams *params);
 
     /**
-     * See Object::UnsetCurrentScoreDef
+     * See Object::UnscoreDefSetCurrent
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
 
     /**
      * See Object::ResetHorizontalAlignment

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -251,14 +251,14 @@ public:
     ///@}
 
     /**
-     * See Object::UnsetCurrentScoreDef
+     * See Object::UnscoreDefSetCurrent
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
 
     /**
-     * See Object::OptimizeScoreDef
+     * See Object::ScoreDefOptimize
      */
-    virtual int OptimizeScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefOptimize(FunctorParams *functorParams);
 
     /**
      * See Object::ResetHorizontalAlignment

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -960,15 +960,15 @@ public:
      * It also includes a scoreDef for each measure where a change occured before.
      * A change can be either a scoreDef before or a clef, meterSig, etc. within the previous measure.
      */
-    virtual int SetCurrentScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefSetCurrent(FunctorParams *functorParams);
 
     /**
      * Optimize the scoreDef for each system.
      * For automatic breaks, looks for staves with only mRests.
      */
     ///@{
-    virtual int OptimizeScoreDef(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int OptimizeScoreDefEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int ScoreDefOptimize(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int ScoreDefOptimizeEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**
@@ -979,7 +979,7 @@ public:
     /**
      * Unset the initial scoreDef of each system and measure
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int ScoreDefUnsetCurrent(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
      * Set drawing flags for the StaffDef for indicating whether clefs, keysigs, etc. need
@@ -1012,7 +1012,7 @@ public:
     /**
      * Prepare group symbol starting and ending staffDefs for drawing
      */
-    virtual int PrepareGroupSymbols(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int ScoreDefSetGrpSym(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
      * Associate LayerElement with @facs to the appropriate zone

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -193,7 +193,7 @@ public:
      * Hold the top scoreDef of the page.
      * The value must be initialized by going through the whole score for finding
      * all the clef or key changes that might occur within the text.
-     * The value is initialized by the Object::SetCurrentScoreDef functor.
+     * The value is initialized by the Object::ScoreDefSetCurrent functor.
      */
     ScoreDef m_drawingScoreDef;
 

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -148,14 +148,14 @@ public:
     virtual int ConvertToCastOffMensural(FunctorParams *params);
 
     /**
-     * See Object::UnsetCurrentScoreDef
+     * See Object::UnscoreDefSetCurrent
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
 
     /**
-     * See Object::OptimizeScoreDef
+     * See Object::ScoreDefOptimize
      */
-    virtual int OptimizeScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefOptimize(FunctorParams *functorParams);
 
     /**
      * See Object::ResetVerticalAlignment

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -84,9 +84,9 @@ public:
     //----------//
 
     /**
-     * See Object::OptimizeScoreDef
+     * See Object::ScoreDefOptimize
      */
-    virtual int OptimizeScoreDefEnd(FunctorParams *functorParams);
+    virtual int ScoreDefOptimizeEnd(FunctorParams *functorParams);
 
 protected:
     /**

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -132,17 +132,22 @@ public:
     //----------//
 
     /**
-     * See Object::UnsetCurrentScoreDef
+     * See Object::UnscoreDefSetCurrent
      */
-    virtual int UnsetCurrentScoreDef(FunctorParams *functorParams);
+    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
 
     /**
-     * See Object::OptimizeScoreDef
+     * See Object::ScoreDefOptimize
      */
     ///@{
-    virtual int OptimizeScoreDef(FunctorParams *functorParams);
-    virtual int OptimizeScoreDefEnd(FunctorParams *functorParams);
+    virtual int ScoreDefOptimize(FunctorParams *functorParams);
+    virtual int ScoreDefOptimizeEnd(FunctorParams *functorParams);
     ///@}
+
+    /**
+     * See Object::ScoreDefSetGrpSym
+     */
+    virtual int ScoreDefSetGrpSym(FunctorParams *functorParams);
 
     /**
      * See Object::ResetHorizontalAlignment

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -761,6 +761,9 @@ void Doc::PrepareDrawing()
             syl->CreateDefaultZone(this);
         }
     }
+    
+    Functor scoreDefSetGrpSym(&Object::ScoreDefSetGrpSym);
+    m_mdivScoreDef.Process(&scoreDefSetGrpSym, NULL);
 
     // LogElapsedTimeEnd ("Preparing drawing");
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -257,7 +257,7 @@ void Doc::CalculateMidiTimemap()
         if (!page) {
             return;
         }
-        this->SetCurrentScoreDefDoc();
+        this->ScoreDefSetCurrentDoc();
         page->LayOutHorizontally();
     }
 
@@ -762,43 +762,37 @@ void Doc::PrepareDrawing()
         }
     }
 
-    /************ Resolve group symbols ************/
-    // Group symbols need to be resolved using scoreDef, since there might be @starid/@endid attirbutes that determine
-    // their positioning
-    Functor prepareGroupSymbols(&Object::PrepareGroupSymbols);
-    m_mdivScoreDef.Process(&prepareGroupSymbols, NULL);
-
     // LogElapsedTimeEnd ("Preparing drawing");
 
     m_drawingPreparationDone = true;
 }
 
-void Doc::SetCurrentScoreDefDoc(bool force)
+void Doc::ScoreDefSetCurrentDoc(bool force)
 {
     if (m_currentScoreDefDone && !force) {
         return;
     }
 
     if (m_currentScoreDefDone) {
-        Functor unsetCurrentScoreDef(&Object::UnsetCurrentScoreDef);
-        UnsetCurrentScoreDefParams unsetCurrentScoreDefParams(&unsetCurrentScoreDef);
-        this->Process(&unsetCurrentScoreDef, &unsetCurrentScoreDefParams);
+        Functor scoreDefUnsetCurrent(&Object::ScoreDefUnsetCurrent);
+        ScoreDefUnsetCurrentParams scoreDefUnsetCurrentParams(&scoreDefUnsetCurrent);
+        this->Process(&scoreDefUnsetCurrent, &scoreDefUnsetCurrentParams);
     }
 
     ScoreDef upcomingScoreDef = m_mdivScoreDef;
-    SetCurrentScoreDefParams setCurrentScoreDefParams(this, &upcomingScoreDef);
-    Functor setCurrentScoreDef(&Object::SetCurrentScoreDef);
+    ScoreDefSetCurrentParams scoreDefSetCurrentParams(this, &upcomingScoreDef);
+    Functor scoreDefSetCurrent(&Object::ScoreDefSetCurrent);
 
     // First process the current scoreDef in order to fill the staffDef with
     // the appropriate drawing values
-    upcomingScoreDef.Process(&setCurrentScoreDef, &setCurrentScoreDefParams);
+    upcomingScoreDef.Process(&scoreDefSetCurrent, &scoreDefSetCurrentParams);
 
-    this->Process(&setCurrentScoreDef, &setCurrentScoreDefParams);
+    this->Process(&scoreDefSetCurrent, &scoreDefSetCurrentParams);
 
     m_currentScoreDefDone = true;
 }
 
-bool Doc::IsOptimizationNeeded()
+bool Doc::ScoreDefNeedsOptimization()
 {
     if (m_options->m_condense.GetValue() == CONDENSE_none) return false;
     // optimize scores only if encoded
@@ -814,13 +808,23 @@ bool Doc::IsOptimizationNeeded()
     return optimize;
 }
 
-void Doc::OptimizeScoreDefDoc()
+void Doc::ScoreDefOptimizeDoc()
 {
-    Functor optimizeScoreDef(&Object::OptimizeScoreDef);
-    Functor optimizeScoreDefEnd(&Object::OptimizeScoreDefEnd);
-    OptimizeScoreDefParams optimizeScoreDefParams(this, &optimizeScoreDef, &optimizeScoreDefEnd);
+    Functor scoreDefOptimize(&Object::ScoreDefOptimize);
+    Functor scoreDefOptimizeEnd(&Object::ScoreDefOptimizeEnd);
+    ScoreDefOptimizeParams scoreDefOptimizeParams(this, &scoreDefOptimize, &scoreDefOptimizeEnd);
 
-    this->Process(&optimizeScoreDef, &optimizeScoreDefParams, &optimizeScoreDefEnd);
+    this->Process(&scoreDefOptimize, &scoreDefOptimizeParams, &scoreDefOptimizeEnd);
+}
+
+void Doc::ScoreDefSetGrpSymDoc()
+{
+    // Group symbols need to be resolved using scoreDef, since there might be @starid/@endid attirbutes that determine
+    // their positioning
+    Functor scoreDefSetGrpSym(&Object::ScoreDefSetGrpSym);
+    // m_mdivScoreDef.Process(&scoreDefSetGrpSym, NULL);
+    ScoreDefSetGrpSymParams scoreDefSetGrpSymParams(&scoreDefSetGrpSym);
+    this->Process(&scoreDefSetGrpSym, &scoreDefSetGrpSymParams);
 }
 
 void Doc::CastOffDoc()
@@ -848,7 +852,7 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
         return;
     }
 
-    this->SetCurrentScoreDefDoc();
+    this->ScoreDefSetCurrentDoc();
 
     Page *contentPage = this->SetDrawingPage(0);
     assert(contentPage);
@@ -880,12 +884,13 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     }
     delete contentSystem;
 
-    bool optimize = IsOptimizationNeeded();
+    bool optimize = ScoreDefNeedsOptimization();
     // Reset the scoreDef at the beginning of each system
-    this->SetCurrentScoreDefDoc(true);
+    this->ScoreDefSetCurrentDoc(true);
     if (optimize) {
-        this->OptimizeScoreDefDoc();
+        this->ScoreDefOptimizeDoc();
     }
+    this->ScoreDefSetGrpSymDoc();
 
     // Here we redo the alignment because of the new scoreDefs
     // We can actually optimise this and have a custom version that does not redo all the calculation
@@ -907,10 +912,11 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     contentPage->Process(&castOffPages, &castOffPagesParams);
     delete contentPage;
 
-    this->SetCurrentScoreDefDoc(true);
+    this->ScoreDefSetCurrentDoc(true);
     if (optimize) {
-        this->OptimizeScoreDefDoc();
+        this->ScoreDefOptimizeDoc();
     }
+    this->ScoreDefSetGrpSymDoc();
 }
 
 void Doc::CastOffRunningElements(CastOffPagesParams *params)
@@ -972,12 +978,12 @@ void Doc::UnCastOffDoc()
     // We need to reset the drawing page to NULL
     // because idx will still be 0 but contentPage is dead!
     this->ResetDrawingPage();
-    this->SetCurrentScoreDefDoc(true);
+    this->ScoreDefSetCurrentDoc(true);
 }
 
 void Doc::CastOffEncodingDoc()
 {
-    this->SetCurrentScoreDefDoc();
+    this->ScoreDefSetCurrentDoc();
 
     Pages *pages = this->GetPages();
     assert(pages);
@@ -1008,11 +1014,12 @@ void Doc::CastOffEncodingDoc()
     // We need to reset the drawing page to NULL
     // because idx will still be 0 but contentPage is dead!
     this->ResetDrawingPage();
-    this->SetCurrentScoreDefDoc(true);
+    this->ScoreDefSetCurrentDoc(true);
 
-    if (IsOptimizationNeeded()) {
-        this->OptimizeScoreDefDoc();
+    if (ScoreDefNeedsOptimization()) {
+        this->ScoreDefOptimizeDoc();
     }
+    this->ScoreDefSetGrpSymDoc();
 }
 
 void Doc::ConvertToPageBasedDoc()
@@ -1059,7 +1066,7 @@ void Doc::ConvertToCastOffMensuralDoc()
         m_isMensuralMusicOnly = false;
     }
 
-    this->SetCurrentScoreDefDoc();
+    this->ScoreDefSetCurrentDoc();
 
     Pages *pages = this->GetPages();
     assert(pages);
@@ -1102,7 +1109,7 @@ void Doc::ConvertToCastOffMensuralDoc()
     // We need to reset the drawing page to NULL
     // because idx will still be 0 but contentPage is dead!
     this->ResetDrawingPage();
-    this->SetCurrentScoreDefDoc(true);
+    this->ScoreDefSetCurrentDoc(true);
 }
 
 void Doc::ConvertToUnCastOffMensuralDoc()
@@ -1163,7 +1170,7 @@ void Doc::ConvertToUnCastOffMensuralDoc()
     // We need to reset the drawing page to NULL
     // because idx will still be 0 but contentPage is dead!
     this->ResetDrawingPage();
-    this->SetCurrentScoreDefDoc(true);
+    this->ScoreDefSetCurrentDoc(true);
 }
 
 void Doc::ConvertScoreDefMarkupDoc(bool permanent)

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -53,12 +53,12 @@ void GrpSym::Reset()
 
 void GrpSym::SetStartDef(StaffDef *start)
 {
-    if (start && !m_startDef) m_startDef = start;
+    if (start) m_startDef = start;
 }
 
 void GrpSym::SetEndDef(StaffDef *end)
 {
-    if (end && !m_endDef) m_endDef = end;
+    if (end) m_endDef = end;
 }
 
 int GrpSym::GetDrawingX() const
@@ -126,6 +126,14 @@ int GrpSym::PrepareGroupSymbols(FunctorParams *)
     }
 
     return FUNCTOR_CONTINUE;
+}
+
+int GrpSym::OptimizeScoreDefEnd(FunctorParams *functorParams)
+{
+    // OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
+    // assert(params);
+
+    return this->PrepareGroupSymbols(functorParams);
 }
 
 } // namespace vrv

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -77,7 +77,7 @@ int GrpSym::GetDrawingY() const
 // GrpSym functor methods
 //----------------------------------------------------------------------------
 
-int GrpSym::PrepareGroupSymbols(FunctorParams *)
+int GrpSym::ScoreDefSetGrpSym(FunctorParams *)
 {
     // For the grpSym that is encoded in the scope of the staffGrp just get first and last staffDefs and set then as
     // starting and ending points
@@ -126,14 +126,6 @@ int GrpSym::PrepareGroupSymbols(FunctorParams *)
     }
 
     return FUNCTOR_CONTINUE;
-}
-
-int GrpSym::OptimizeScoreDefEnd(FunctorParams *functorParams)
-{
-    // OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
-    // assert(params);
-
-    return this->PrepareGroupSymbols(functorParams);
 }
 
 } // namespace vrv

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1223,7 +1223,7 @@ int AlignmentReference::AdjustAccidX(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
-int AlignmentReference::UnsetCurrentScoreDef(FunctorParams *functorParams)
+int AlignmentReference::ScoreDefUnsetCurrent(FunctorParams *functorParams)
 {
     Alignment *alignment = vrv_cast<Alignment *>(this->GetParent());
     assert(alignment);

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -495,7 +495,7 @@ int Layer::ConvertToUnCastOffMensural(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
-int Layer::UnsetCurrentScoreDef(FunctorParams *functorParams)
+int Layer::ScoreDefUnsetCurrent(FunctorParams *functorParams)
 {
     ResetStaffDefObjects();
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -317,7 +317,7 @@ int Measure::GetDrawingOverflow()
 
 void Measure::SetDrawingScoreDef(ScoreDef *drawingScoreDef)
 {
-    assert(!m_drawingScoreDef); // We should always call UnsetCurrentScoreDef before
+    assert(!m_drawingScoreDef); // We should always call UnscoreDefSetCurrent before
 
     m_drawingScoreDef = new ScoreDef();
     *m_drawingScoreDef = *drawingScoreDef;
@@ -577,9 +577,9 @@ int Measure::SaveEnd(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
 }
 
-int Measure::UnsetCurrentScoreDef(FunctorParams *functorParams)
+int Measure::ScoreDefUnsetCurrent(FunctorParams *functorParams)
 {
-    UnsetCurrentScoreDefParams *params = vrv_params_cast<UnsetCurrentScoreDefParams *>(functorParams);
+    ScoreDefUnsetCurrentParams *params = vrv_params_cast<ScoreDefUnsetCurrentParams *>(functorParams);
     assert(params);
 
     if (m_drawingScoreDef) {
@@ -593,9 +593,9 @@ int Measure::UnsetCurrentScoreDef(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Measure::OptimizeScoreDef(FunctorParams *functorParams)
+int Measure::ScoreDefOptimize(FunctorParams *functorParams)
 {
-    OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
+    ScoreDefOptimizeParams *params = vrv_params_cast<ScoreDefOptimizeParams *>(functorParams);
     assert(params);
 
     if (!params->m_doc->GetOptions()->m_condenseTempoPages.GetValue()) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1416,9 +1416,9 @@ int Object::SetCautionaryScoreDef(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Object::SetCurrentScoreDef(FunctorParams *functorParams)
+int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
 {
-    SetCurrentScoreDefParams *params = vrv_params_cast<SetCurrentScoreDefParams *>(functorParams);
+    ScoreDefSetCurrentParams *params = vrv_params_cast<ScoreDefSetCurrentParams *>(functorParams);
     assert(params);
 
     assert(params->m_upcomingScoreDef);

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -358,16 +358,16 @@ int Staff::ConvertToCastOffMensural(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Staff::UnsetCurrentScoreDef(FunctorParams *functorParams)
+int Staff::ScoreDefUnsetCurrent(FunctorParams *functorParams)
 {
     m_drawingStaffDef = NULL;
 
     return FUNCTOR_CONTINUE;
 }
 
-int Staff::OptimizeScoreDef(FunctorParams *functorParams)
+int Staff::ScoreDefOptimize(FunctorParams *functorParams)
 {
-    OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
+    ScoreDefOptimizeParams *params = vrv_params_cast<ScoreDefOptimizeParams *>(functorParams);
     assert(params);
 
     assert(params->m_currentScoreDef);
@@ -375,7 +375,7 @@ int Staff::OptimizeScoreDef(FunctorParams *functorParams)
 
     if (!staffDef) {
         LogDebug(
-            "Could not find staffDef for staff (%d) when optimizing scoreDef in Staff::OptimizeScoreDef", this->GetN());
+            "Could not find staffDef for staff (%d) when optimizing scoreDef in Staff::ScoreDefOptimize", this->GetN());
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -162,7 +162,7 @@ std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
 
 void StaffGrp::SetGroupSymbol(GrpSym *grpSym)
 {
-    if (!m_groupSymbol && grpSym) {
+    if (grpSym) {
         m_groupSymbol = grpSym;
     }
 }

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -171,9 +171,9 @@ void StaffGrp::SetGroupSymbol(GrpSym *grpSym)
 // StaffGrp functor methods
 //----------------------------------------------------------------------------
 
-int StaffGrp::OptimizeScoreDefEnd(FunctorParams *)
+int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *)
 {
-    // OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
+    // ScoreDefOptimize *params = vrv_params_cast<ScoreDefOptimize *>(functorParams);
     // assert(params);
 
     this->SetDrawingVisibility(OPTIMIZATION_HIDDEN);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -184,7 +184,7 @@ bool System::SetCurrentFloatingPositioner(
 
 void System::SetDrawingScoreDef(ScoreDef *drawingScoreDef)
 {
-    assert(!m_drawingScoreDef); // We should always call UnsetCurrentScoreDef before
+    assert(!m_drawingScoreDef); // We should always call UnscoreDefSetCurrent before
 
     m_drawingScoreDef = new ScoreDef();
     *m_drawingScoreDef = *drawingScoreDef;
@@ -304,7 +304,7 @@ void System::AddToDrawingListIfNeccessary(Object *object)
 // System functor methods
 //----------------------------------------------------------------------------
 
-int System::UnsetCurrentScoreDef(FunctorParams *functorParams)
+int System::ScoreDefUnsetCurrent(FunctorParams *functorParams)
 {
     if (m_drawingScoreDef) {
         delete m_drawingScoreDef;
@@ -316,9 +316,9 @@ int System::UnsetCurrentScoreDef(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int System::OptimizeScoreDef(FunctorParams *functorParams)
+int System::ScoreDefOptimize(FunctorParams *functorParams)
 {
-    OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
+    ScoreDefOptimizeParams *params = vrv_params_cast<ScoreDefOptimizeParams *>(functorParams);
     assert(params);
 
     this->IsDrawingOptimized(true);
@@ -336,15 +336,27 @@ int System::OptimizeScoreDef(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int System::OptimizeScoreDefEnd(FunctorParams *functorParams)
+int System::ScoreDefOptimizeEnd(FunctorParams *functorParams)
 {
-    OptimizeScoreDefParams *params = vrv_params_cast<OptimizeScoreDefParams *>(functorParams);
+    ScoreDefOptimizeParams *params = vrv_params_cast<ScoreDefOptimizeParams *>(functorParams);
     assert(params);
 
     params->m_currentScoreDef->Process(params->m_functor, params, params->m_functorEnd);
     m_systemAligner.SetSpacing(params->m_currentScoreDef);
 
     return FUNCTOR_CONTINUE;
+}
+
+int System::ScoreDefSetGrpSym(FunctorParams *functorParams)
+{
+    ScoreDefSetGrpSymParams *params = vrv_params_cast<ScoreDefSetGrpSymParams *>(functorParams);
+    assert(params);
+
+    assert(m_drawingScoreDef);
+
+    m_drawingScoreDef->Process(params->m_functor, functorParams);
+
+    return FUNCTOR_SIBLINGS;
 }
 
 int System::ResetHorizontalAlignment(FunctorParams *functorParams)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -352,9 +352,7 @@ int System::ScoreDefSetGrpSym(FunctorParams *functorParams)
     ScoreDefSetGrpSymParams *params = vrv_params_cast<ScoreDefSetGrpSymParams *>(functorParams);
     assert(params);
 
-    assert(m_drawingScoreDef);
-
-    m_drawingScoreDef->Process(params->m_functor, functorParams);
+    if (m_drawingScoreDef) m_drawingScoreDef->Process(params->m_functor, functorParams);
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -72,7 +72,7 @@ void View::SetPage(int pageIdx, bool doLayout)
     m_currentPage = m_doc->SetDrawingPage(pageIdx);
 
     if (doLayout) {
-        m_doc->SetCurrentScoreDefDoc();
+        m_doc->ScoreDefSetCurrentDoc();
         // if we once deal with multiple views, it would be better
         // to redo the layout only when necessary?
         if (m_doc->GetType() == Transcription || m_doc->GetType() == Facs)

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -70,7 +70,7 @@ void View::DrawCurrentPage(DeviceContext *dc, bool background)
     SetScoreDefDrawingWidth(dc, &m_currentPage->m_drawingScoreDef);
 
     // Set the current score def to the page one
-    // The page one has previously been set by Object::SetCurrentScoreDef
+    // The page one has previously been set by Object::ScoreDefSetCurrent
     m_drawingScoreDef = m_currentPage->m_drawingScoreDef;
 
     if (m_options->m_shrinkToFit.GetValue()) {


### PR DESCRIPTION
@Monceber please double check. I don't have complex GrpSym examples to test. Many changes are just renaming for better clarity and grouping methods by prefix. The idea is that setting the group symbols needs to be (re)done for each system. This is why it is now happening in `Doc::CastOffDocBase` and `Doc::CastOffEncodingDoc` and not in `Doc::PrerpareDrawing` anymore. ~~Note the there is no more call on Doc::m_scoreDef since this one is actually never drawn. We can add one call (in Doc::PrepareDrawing) if necessary.~~ [call is now added]

What is not optimal is that the resolving of `@startid`/`@endid` is performed for each System::m_darwingScoreDef but I do not expect this to have a noticeable impact. It can maybe be  optimized by resolving these once on Doc::PrepareDrawing (for Doc::m_scoreDef) and reusing them in ScoreDefSetGrpSym for System::m_drawingScoreDef. But I don't think it is necessary.