### PR TITLE
Explanation and fix for neume custos rendering

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -736,11 +736,19 @@ void View::DrawCustos(DeviceContext *dc, LayerElement *element, Layer *layer, St
         Clef *clef = layer->GetClef(element);
         y = ToLogicalY(staff->GetDrawingY());
         PitchInterface pi;
+        // Neume notation uses C3 for C clef rather than C4.
+        // Take this into account when determining location.
+        // However this doesn't affect the value for F clef.
         pi.SetPname(PITCHNAME_c);
-        pi.SetOct(3);
+        if ((staff->m_drawingNotationType == NOTATIONTYPE_neume) && (clef->GetShape() == CLEFSHAPE_C)) {
+            pi.SetOct(3);
+        }
+        else {
+            pi.SetOct(4);
+        }
         // Convert from lines & spaces from bottom to from top
-        int C3OffsetFromTop = ((staff->m_drawingLines - 1) * 2) - clef->GetClefLocOffset();
-        int custosOffsetFromTop = C3OffsetFromTop + pi.PitchDifferenceTo(custos);
+        int CClefOffsetFromTop = ((staff->m_drawingLines - 1) * 2) - clef->GetClefLocOffset();
+        int custosOffsetFromTop = CClefOffsetFromTop + pi.PitchDifferenceTo(custos);
         y -= custosOffsetFromTop * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     }
     else {


### PR DESCRIPTION
Apologies for another PR for this function! I missed a case for F clefs previously and also realized that this approach would only hold for neume notation. I added a few more checks to fix these bugs and also a few comments to explain that these lines are included since MEI neume notation treats the C clef as C3 rather than C4.