### PR TITLE
add option for size of changing clefs

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -544,6 +544,7 @@ public:
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
     OptionDbl m_bracketThickness;
+    OptionDbl m_clefChangeFactor;
     OptionJson m_engravingDefaults;
     OptionString m_font;
     OptionDbl m_graceFactor;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -807,6 +807,10 @@ Options::Options()
     m_font.Init("Leipzig");
     this->Register(&m_font, "font", &m_generalLayout);
 
+    m_clefChangeFactor.SetInfo("Clef change size", "Set the ratio of normal clefs to changing clefs");
+    m_clefChangeFactor.Init(0.66, 0.25, 1.0);
+    this->Register(&m_clefChangeFactor, "clefChangeFactor", &m_general);
+
     m_graceFactor.SetInfo("Grace factor", "The grace size ratio numerator");
     m_graceFactor.Init(0.75, 0.5, 1.0);
     this->Register(&m_graceFactor, "graceFactor", &m_generalLayout);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -678,18 +678,18 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         return;
     }
 
-    bool cueSize = false;
+    double clefSizeFactor = 1.0;
     if (clef->GetAlignment() && (clef->GetAlignment()->GetType() == ALIGNMENT_CLEF)) {
         if (m_doc->GetType() != Transcription && m_doc->GetType() != Facs) {
-            cueSize = true;
             // HARDCODED
-            // x -= m_doc->GetGlyphWidth(sym, staff->m_drawingStaffSize, cueSize) * 1.35;
+            clefSizeFactor = m_options->m_clefChangeFactor.GetValue();
+            // x -= m_doc->GetGlyphWidth(sym, clefSizeFactor * staff->m_drawingStaffSize, false) * 1.35;
         }
     }
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    DrawSmuflCode(dc, x, y, sym, staff->m_drawingStaffSize, cueSize);
+    DrawSmuflCode(dc, x, y, sym, clefSizeFactor * staff->m_drawingStaffSize, false);
 
     if ((m_doc->GetType() == Facs) && element->HasFacs()) {
         const int noteHeight = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2);


### PR DESCRIPTION
Gould states that
> a change of clef placed after the beginning of the system is two-thirds of the size of the clef at the beginning of the stave

This PR adds the option `clefChangeFactor` which sets the relative size of changing clefs and sets it by default to two-thirds.