### PR TITLE
Fixed: Do not lowercase enum values

### DIFF
--- a/bindings/python/verovio.i
+++ b/bindings/python/verovio.i
@@ -7,6 +7,8 @@
 
 // Change method names to lowerCamelCase
 %rename("%(lowercamelcase)s") "";
+// Ignore enum items (e.g., for fileFormat.PAE)
+%rename("%(upper)s", %$isenumitem) "";
 
 // Method to ignore
 %ignore vrv::Toolkit::GetShowBoundingBoxes( );


### PR DESCRIPTION
When building the Python toolkit, enum values were lowercased, leading to using things like `verovio.pAE` and `verovio.hUMDRUM`. This commit changes the swig interface file to not lowercase the enum values.

Fixes #2065