### PR TITLE
Develop log. Closes #2057

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -302,6 +302,8 @@
 		4D6DF9F720E1074100C12BBD /* subst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D6DF9F420E1071E00C12BBD /* subst.cpp */; };
 		4D6DF9F820E1074200C12BBD /* subst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D6DF9F420E1071E00C12BBD /* subst.cpp */; };
 		4D6DF9F920E1074500C12BBD /* subst.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6DF9F620E1072B00C12BBD /* subst.h */; };
+		4D723AD025E77FF00062E0A2 /* zip_file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D723ACF25E77FDE0062E0A2 /* zip_file.hpp */; };
+		4D723AD525E77FF10062E0A2 /* zip_file.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4D723ACF25E77FDE0062E0A2 /* zip_file.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D72A5DD208A37D1009DEC1E /* mrpt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403BEFEA206C00B400D022D5 /* mrpt.cpp */; };
 		4D72A5DE208A37D5009DEC1E /* mrpt2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403BEFEB206C00B400D022D5 /* mrpt2.cpp */; };
 		4D72A5DF208A37DC009DEC1E /* multirpt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403BEFEC206C00B400D022D5 /* multirpt.cpp */; };
@@ -1327,6 +1329,7 @@
 		4D674B45255F40B7008AEF4C /* plica.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = plica.cpp; path = src/plica.cpp; sourceTree = "<group>"; };
 		4D6DF9F420E1071E00C12BBD /* subst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = subst.cpp; path = src/subst.cpp; sourceTree = "<group>"; };
 		4D6DF9F620E1072B00C12BBD /* subst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = subst.h; path = include/vrv/subst.h; sourceTree = "<group>"; };
+		4D723ACF25E77FDE0062E0A2 /* zip_file.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = zip_file.hpp; path = include/zip/zip_file.hpp; sourceTree = SOURCE_ROOT; };
 		4D763EC51987D04D003FCAB5 /* metersig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = metersig.cpp; path = src/metersig.cpp; sourceTree = "<group>"; };
 		4D763EC81987D067003FCAB5 /* metersig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = metersig.h; path = include/vrv/metersig.h; sourceTree = "<group>"; };
 		4D766EF220ACAD3F006875D8 /* syllable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = syllable.h; path = include/vrv/syllable.h; sourceTree = "<group>"; };
@@ -1359,7 +1362,6 @@
 		4D95D4FB1D74551100B2B856 /* score.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = score.cpp; path = src/score.cpp; sourceTree = "<group>"; };
 		4D983004192E959E00320037 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = tools/main.cpp; sourceTree = SOURCE_ROOT; };
 		4D98CCDA25D26E3C00DC7A2C /* smufl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = smufl.cpp; path = src/smufl.cpp; sourceTree = "<group>"; };
-		4D98CD0825DA5BE600DC7A2C /* zip_file.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = zip_file.hpp; path = include/zip/zip_file.hpp; sourceTree = SOURCE_ROOT; };
 		4D9A9C16199F560200028D93 /* verse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = verse.h; path = include/vrv/verse.h; sourceTree = "<group>"; };
 		4D9A9C18199F561200028D93 /* verse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = verse.cpp; path = src/verse.cpp; sourceTree = "<group>"; };
 		4D9A9C1B199F576100028D93 /* syl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = syl.h; path = include/vrv/syl.h; sourceTree = "<group>"; };
@@ -1729,6 +1731,14 @@
 			name = editorialelements;
 			sourceTree = "<group>";
 		};
+		4D723ACE25E77F520062E0A2 /* zip */ = {
+			isa = PBXGroup;
+			children = (
+				4D723ACF25E77FDE0062E0A2 /* zip_file.hpp */,
+			);
+			path = zip;
+			sourceTree = "<group>";
+		};
 		4D7D8A3C1886E36200D78B62 /* tools */ = {
 			isa = PBXGroup;
 			children = (
@@ -1755,14 +1765,6 @@
 				4D95D4F71D718D0200B2B856 /* systemelement.h */,
 			);
 			name = systemelements;
-			sourceTree = "<group>";
-		};
-		4D98CD0725DA5AF300DC7A2C /* zip */ = {
-			isa = PBXGroup;
-			children = (
-				4D98CD0825DA5BE600DC7A2C /* zip_file.hpp */,
-			);
-			path = zip;
 			sourceTree = "<group>";
 		};
 		4DA0EABF22BB775F00A7EBEB /* facselements */ = {
@@ -1998,7 +2000,7 @@
 				4D1BE7751C688F6F0086DC0E /* midi */,
 				4D22C42118891D7300D0831F /* pugixml */,
 				4DBC09271B51960100B1832C /* utf8 */,
-				4D98CD0725DA5AF300DC7A2C /* zip */,
+				4D723ACE25E77F520062E0A2 /* zip */,
 				BB4C4A5322A930A3001F6AF0 /* VerovioFramework */,
 				8F086EAA188534680037FD8E /* Products */,
 			);
@@ -2433,6 +2435,7 @@
 				400FEDD4206FA74A000D3233 /* gracegrp.h in Headers */,
 				4DF440751D39567A00152B7E /* ending.h in Headers */,
 				4DE96E3921C4370E00CB85BE /* bracketspan.h in Headers */,
+				4D723AD025E77FF00062E0A2 /* zip_file.hpp in Headers */,
 				4DB3D8B41F83D08700B5FC2B /* devicecontextbase.h in Headers */,
 				4DEC4DD921C8295700D1D273 /* rdg.h in Headers */,
 				4DB3D8D01F83D11800B5FC2B /* mordent.h in Headers */,
@@ -2505,6 +2508,7 @@
 				BB4C4B4022A932D7001F6AF0 /* barline.h in Headers */,
 				BB4C4B9E22A932E5001F6AF0 /* plistinterface.h in Headers */,
 				4DA0EADE22BB77AF00A7EBEB /* zone.h in Headers */,
+				4D723AD525E77FF10062E0A2 /* zip_file.hpp in Headers */,
 				BB4C4A9122A9328F001F6AF0 /* boundingbox.h in Headers */,
 				BB4C4B1422A932C8001F6AF0 /* section.h in Headers */,
 				BB4C4B8022A932DF001F6AF0 /* fb.h in Headers */,

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -41,6 +41,10 @@ enum FileFormat {
 
 void SetDefaultResourcePath(const std::string &path);
 
+// Implementation in vrv.cpp but defined here to be available in SWIG bindings
+void EnableLog(bool value);
+void EnableLogToBuffer(bool value);
+
 //----------------------------------------------------------------------------
 // Toolkit
 //----------------------------------------------------------------------------
@@ -314,6 +318,7 @@ public:
     const char *GetCString();
     ///@}
 
+protected:
 private:
     bool IsUTF16(const std::string &filename);
     bool LoadUTF16File(const std::string &filename);

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -37,17 +37,14 @@ void LogDebug(const char *fmt, ...);
 void LogError(const char *fmt, ...);
 void LogMessage(const char *fmt, ...);
 void LogWarning(const char *fmt, ...);
-void DisableLog();
 
 /**
- * Member and functions specific to emscripten loging that uses a vector of string to buffer the logs.
+ * Member and functions specific to loging that uses a vector of string to buffer the logs.
  */
-#ifdef __EMSCRIPTEN__
 enum consoleLogLevel { CONSOLE_LOG = 0, CONSOLE_INFO, CONSOLE_WARN, CONSOLE_ERROR, CONSOLE_DEBUG };
 extern std::vector<std::string> logBuffer;
 bool LogBufferContains(const std::string &s);
-void AppendLogBuffer(bool checkDuplicate, std::string message, consoleLogLevel level);
-#endif
+void LogString(std::string message, consoleLogLevel level);
 
 /**
  * Utility for comparing doubles
@@ -96,7 +93,8 @@ std::string GetVersion();
 /**
  *
  */
-extern bool noLog;
+extern bool logging;
+extern bool loggingToBuffer;
 
 /**
  * Functions for logging in milliseconds the elapsed time of an

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1306,6 +1306,8 @@ std::string Toolkit::GetExpansionIdsForElement(const std::string &xmlId)
 
 bool Toolkit::Edit(const std::string &json_editorAction)
 {
+    this->ResetLogBuffer();
+
     return m_editorToolkit->ParseEditorAction(json_editorAction);
 }
 
@@ -1316,17 +1318,12 @@ std::string Toolkit::EditInfo()
 
 std::string Toolkit::GetLog()
 {
-#ifdef USE_EMSCRIPTEN
     std::string str;
     std::vector<std::string>::iterator iter;
     for (iter = logBuffer.begin(); iter != logBuffer.end(); ++iter) {
         str += (*iter);
     }
     return str;
-#else
-    // The non-js version of the app should not use this function.
-    return "";
-#endif
 }
 
 std::string Toolkit::GetVersion()
@@ -1336,13 +1333,13 @@ std::string Toolkit::GetVersion()
 
 void Toolkit::ResetLogBuffer()
 {
-#ifdef USE_EMSCRIPTEN
-    vrv::logBuffer.clear();
-#endif
+    logBuffer.clear();
 }
 
 void Toolkit::RedoLayout()
 {
+    this->ResetLogBuffer();
+
     if ((GetPageCount() == 0) || (m_doc.GetType() == Transcription) || (m_doc.GetType() == Facs)) {
         LogWarning("No data to re-layout");
         return;
@@ -1362,6 +1359,8 @@ void Toolkit::RedoLayout()
 
 void Toolkit::RedoPagePitchPosLayout()
 {
+    this->ResetLogBuffer();
+
     Page *page = m_doc.GetDrawingPage();
 
     if (!page) {
@@ -1419,6 +1418,8 @@ bool Toolkit::RenderToDeviceContext(int pageNo, DeviceContext *deviceContext)
 
 std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
 {
+    this->ResetLogBuffer();
+
     int initialPageNo = (m_doc.GetDrawingPage() == NULL) ? -1 : m_doc.GetDrawingPage()->GetIdx();
     // Create the SVG object, h & w come from the system
     // We will need to set the size of the page after having drawn it depending on the options
@@ -1457,6 +1458,8 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
 
 bool Toolkit::RenderToSVGFile(const std::string &filename, int pageNo)
 {
+    this->ResetLogBuffer();
+
     std::string output = RenderToSVG(pageNo, true);
 
     std::ofstream outfile;
@@ -1499,6 +1502,8 @@ void Toolkit::GetHumdrum(std::ostream &output)
 
 std::string Toolkit::RenderToMIDI()
 {
+    this->ResetLogBuffer();
+
     smf::MidiFile outputfile;
     outputfile.absoluteTicks();
     m_doc.ExportMIDI(&outputfile);
@@ -1514,6 +1519,8 @@ std::string Toolkit::RenderToMIDI()
 
 std::string Toolkit::RenderToPAE()
 {
+    this->ResetLogBuffer();
+
     if (GetPageCount() == 0) {
         LogWarning("No data loaded");
         return "";
@@ -1529,6 +1536,8 @@ std::string Toolkit::RenderToPAE()
 
 bool Toolkit::RenderToPAEFile(const std::string &filename)
 {
+    this->ResetLogBuffer();
+
     std::string outputString = this->RenderToPAE();
 
     std::ofstream output(filename.c_str());
@@ -1542,6 +1551,8 @@ bool Toolkit::RenderToPAEFile(const std::string &filename)
 
 std::string Toolkit::RenderToTimemap()
 {
+    this->ResetLogBuffer();
+
     std::string output;
     m_doc.ExportTimemap(output);
     return output;
@@ -1549,6 +1560,8 @@ std::string Toolkit::RenderToTimemap()
 
 std::string Toolkit::GetElementsAtTime(int millisec)
 {
+    this->ResetLogBuffer();
+
     jsonxx::Object o;
     jsonxx::Array a;
 
@@ -1591,6 +1604,8 @@ std::string Toolkit::GetElementsAtTime(int millisec)
 
 bool Toolkit::RenderToMIDIFile(const std::string &filename)
 {
+    this->ResetLogBuffer();
+
     smf::MidiFile outputfile;
     outputfile.absoluteTicks();
     m_doc.ExportMIDI(&outputfile);
@@ -1602,6 +1617,8 @@ bool Toolkit::RenderToMIDIFile(const std::string &filename)
 
 bool Toolkit::RenderToTimemapFile(const std::string &filename)
 {
+    this->ResetLogBuffer();
+
     std::string outputString;
     m_doc.ExportTimemap(outputString);
 
@@ -1634,6 +1651,8 @@ int Toolkit::GetPageWithElement(const std::string &xmlId)
 
 int Toolkit::GetTimeForElement(const std::string &xmlId)
 {
+    this->ResetLogBuffer();
+
     Object *element = m_doc.FindDescendantByUuid(xmlId);
 
     if (!element) {
@@ -1663,6 +1682,8 @@ int Toolkit::GetTimeForElement(const std::string &xmlId)
 
 std::string Toolkit::GetTimesForElement(const std::string &xmlId)
 {
+    this->ResetLogBuffer();
+
     Object *element = m_doc.FindDescendantByUuid(xmlId);
     jsonxx::Object o;
 
@@ -1714,6 +1735,8 @@ std::string Toolkit::GetTimesForElement(const std::string &xmlId)
 
 std::string Toolkit::GetMIDIValuesForElement(const std::string &xmlId)
 {
+    this->ResetLogBuffer();
+
     Object *element = m_doc.FindDescendantByUuid(xmlId);
 
     if (!element) {

--- a/tools/c_wrapper.cpp
+++ b/tools/c_wrapper.cpp
@@ -133,7 +133,6 @@ double vrvToolkit_getTimeForElement(Toolkit *tk, const char *xmlId)
 
 const char *vrvToolkit_getTimesForElement(Toolkit *tk, const char *xmlId)
 {
-    tk->ResetLogBuffer();
     tk->SetCString(tk->GetTimesForElement(xmlId));
     return tk->GetCString();
 }
@@ -146,39 +145,33 @@ const char *vrvToolkit_getVersion(Toolkit *tk)
 
 bool vrvToolkit_loadData(Toolkit *tk, const char *data)
 {
-    tk->ResetLogBuffer();
     return tk->LoadData(data);
 }
 
 bool vrvToolkit_loadZipDataBase64(Toolkit *tk, const char *data)
 {
-    tk->ResetLogBuffer();
     return tk->LoadZipDataBase64(data);
 }
 
 bool vrvToolkit_loadZipDataBuffer(Toolkit *tk, const unsigned char *data, int length)
 {
-    tk->ResetLogBuffer();
     return tk->LoadZipDataBuffer(data, length);
 }
 
 const char *vrvToolkit_renderToMIDI(Toolkit *tk, const char *c_options)
 {
-    tk->ResetLogBuffer();
     tk->SetCString(tk->RenderToMIDI());
     return tk->GetCString();
 }
 
 const char *vrvToolkit_renderToSVG(Toolkit *tk, int page_no, const char *c_options)
 {
-    tk->ResetLogBuffer();
     tk->SetCString(tk->RenderToSVG(page_no, false));
     return tk->GetCString();
 }
 
 const char *vrvToolkit_renderToTimemap(Toolkit *tk)
 {
-    tk->ResetLogBuffer();
     tk->SetCString(tk->RenderToTimemap());
     return tk->GetCString();
 }
@@ -195,7 +188,6 @@ void vrvToolkit_redoPagePitchPosLayout(Toolkit *tk)
 
 const char *vrvToolkit_renderData(Toolkit *tk, const char *data, const char *options)
 {
-    tk->ResetLogBuffer();
     vrvToolkit_setOptions(tk, options);
     vrvToolkit_loadData(tk, data);
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -422,7 +422,7 @@ int main(int argc, char **argv)
         outfile = removeExtension(infile);
     }
     else if (outfile == "-") {
-        vrv::DisableLog();
+        //vrv::EnableLog(false);
         std_output = true;
     }
     else {

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -422,7 +422,7 @@ int main(int argc, char **argv)
         outfile = removeExtension(infile);
     }
     else if (outfile == "-") {
-        // DisableLog();
+        vrv::DisableLog();
         std_output = true;
     }
     else {


### PR DESCRIPTION
* Add vrv::EnableLog(bool) and vrv::EnableLogToBuffer(bool) methods
* Make Toolkit::GetLog() available to all bindings

In Python, you can now do
```
>>> verovio.enableLog(False)
>>> tk = verovio.toolkit()
>>> verovio.enableLog(True)
```
or
```
>>> verovio.enableLogToBuffer(True)
>>> tk = verovio.toolkit()
>>> tk.getLog()
```