### PR TITLE
Fix clef conversion

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -185,7 +185,7 @@ void MusicXmlInput::AddClef(Section *section, Measure *measure, Staff *staff, co
                     previousMeasure = section->GetPrevious(sectionCurrentMeasure, MEASURE);
                     // if current measure is being processed for the first time - get last measure in the section. This
                     // should happen only for the first staff in the multi-stave score
-                    if (!previousMeasure) {
+                    if (!previousMeasure && (0 != section->GetDescendantIndex(sectionCurrentMeasure, MEASURE, 1))) {
                         previousMeasure = section->FindDescendantByType(MEASURE, UNLIMITED_DEPTH, BACKWARD);
                     }
                     // otherwise this is first measure, so add element as is
@@ -196,6 +196,9 @@ void MusicXmlInput::AddClef(Section *section, Measure *measure, Staff *staff, co
                     }
                     AttNIntegerComparison comparisonStaff(STAFF, iter->m_staff->GetN());
                     Object *previousStaff = previousMeasure->FindDescendantByComparison(&comparisonStaff);
+                    if (previousStaff == NULL) {
+                        AddLayerElement(layer, iter->m_clef);
+                    }
                     AttNIntegerComparison comparisonLayer(LAYER, layer->GetN());
                     Object *prevLayer = previousStaff->FindDescendantByComparison(&comparisonLayer);
                     if (prevLayer == NULL) {


### PR DESCRIPTION
- fixed the way how previous measure was being found - since measure number in MusicXML can contain symbols other than digits, previous measure should be found from the section children
- returned check for the staff, since strange behavior was exhibited other way in some cases. E.g. in following case, clef on the second staff is supposed to be placed before barline, but is placed after. 
![image](https://user-images.githubusercontent.com/1819669/109122164-dcc63b80-7750-11eb-8a10-814d5c0244ff.png)
This should be fixed now.
