### PR TITLE
New: Flag to control xlink prefix on href

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -529,7 +529,7 @@ public:
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;
     OptionBool m_svgFormatRaw;
-    OptionBool m_svgIncludeXlink;
+    OptionBool m_svgRemoveXlink;
     OptionInt m_unit;
     OptionBool m_useFacsimile;
     OptionBool m_usePgFooterForAll;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -529,6 +529,7 @@ public:
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;
     OptionBool m_svgFormatRaw;
+    OptionBool m_svgIncludeXlink;
     OptionInt m_unit;
     OptionBool m_useFacsimile;
     OptionBool m_usePgFooterForAll;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -203,6 +203,11 @@ public:
      * Set the SVG to have 'raw' formatting, with no extraneous whitespace or newlines.
      */
     void SetFormatRaw(bool rawFormat) { m_formatRaw = rawFormat; }
+    
+    /**
+     * Set the xlink: prefex on href attributes
+     */
+    void SetXlinkOnHref(bool includeXlink) { m_includeXlink = includeXlink; }
 
 private:
     /**
@@ -279,6 +284,8 @@ private:
     bool m_html5;
     // format output as raw, stripping extraneous whitespace and non-content newlines
     bool m_formatRaw;
+    // include xlink on href attributes
+    bool m_includeXlink;
     // indentation value (-1 for tabs)
     int m_indent;
 };

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -207,7 +207,7 @@ public:
     /**
      * Set the xlink: prefex on href attributes
      */
-    void SetXlinkOnHref(bool includeXlink) { m_includeXlink = includeXlink; }
+    void SetIncludeXlink(bool includeXlink) { m_includeXlink = includeXlink; }
 
 private:
     /**

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -207,7 +207,7 @@ public:
     /**
      * Set the xlink: prefex on href attributes
      */
-    void SetIncludeXlink(bool includeXlink) { m_includeXlink = includeXlink; }
+    void SetRemoveXlink(bool removeXlink) { m_removeXlink = removeXlink; }
 
 private:
     /**
@@ -285,7 +285,7 @@ private:
     // format output as raw, stripping extraneous whitespace and non-content newlines
     bool m_formatRaw;
     // include xlink on href attributes
-    bool m_includeXlink;
+    bool m_removeXlink;
     // indentation value (-1 for tabs)
     int m_indent;
 };

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -755,6 +755,11 @@ Options::Options()
         "Raw formatting for SVG output", "Writes SVG out with no line indenting or non-content newlines.");
     m_svgFormatRaw.Init(false);
     this->Register(&m_svgFormatRaw, "svgFormatRaw", &m_general);
+    
+    m_svgIncludeXlink.SetInfo(
+        "Include xlink: on href attributes", "Includes the xlink: prefix on href attributes for compatibility with older SVG viewers.");
+    m_svgIncludeXlink.Init(false);
+    this->Register(&m_svgIncludeXlink, "svgIncludeXlink", &m_general);
 
     m_unit.SetInfo("Unit", "The MEI unit (1⁄2 of the distance between the staff lines)");
     m_unit.Init(9, 6, 20, true);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -756,10 +756,10 @@ Options::Options()
     m_svgFormatRaw.Init(false);
     this->Register(&m_svgFormatRaw, "svgFormatRaw", &m_general);
     
-    m_svgIncludeXlink.SetInfo(
-        "Include xlink: on href attributes", "Includes the xlink: prefix on href attributes for compatibility with older SVG viewers.");
-    m_svgIncludeXlink.Init(false);
-    this->Register(&m_svgIncludeXlink, "svgIncludeXlink", &m_general);
+    m_svgRemoveXlink.SetInfo(
+        "Remove xlink: from href attributes", "Removes the xlink: prefix on href attributes for compatibility with some newer browsers.");
+    m_svgRemoveXlink.Init(false);
+    this->Register(&m_svgRemoveXlink, "svgRemoveXlink", &m_general);
 
     m_unit.SetInfo("Unit", "The MEI unit (1⁄2 of the distance between the staff lines)");
     m_unit.Init(9, 6, 20, true);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -51,7 +51,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext()
     m_svgViewBox = false;
     m_html5 = false;
     m_formatRaw = false;
-    m_includeXlink = false;
+    m_removeXlink = false;
     m_facsimile = false;
     m_indent = 2;
 
@@ -858,9 +858,9 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
 
     int w, h, gx, gy;
 
-    // include the `xlink:` prefix for backwards compatibility with older SVG viewers.
+    // remove the `xlink:` prefix for backwards compatibility with older SVG viewers.
     std::string hrefAttrib = "href";
-    if (m_includeXlink) {
+    if (!m_removeXlink) {
         hrefAttrib.insert(0, "xlink:");
     }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -51,6 +51,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext()
     m_svgViewBox = false;
     m_html5 = false;
     m_formatRaw = false;
+    m_includeXlink = false;
     m_facsimile = false;
     m_indent = 2;
 
@@ -857,6 +858,12 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
 
     int w, h, gx, gy;
 
+    // include the `xlink:` prefix for backwards compatibility with older SVG viewers.
+    std::string hrefAttrib = "href";
+    if (m_includeXlink) {
+        hrefAttrib.insert(0, "xlink:");
+    }
+
     // print chars one by one
     for (unsigned int i = 0; i < text.length(); ++i) {
         wchar_t c = text.at(i);
@@ -872,7 +879,7 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
 
         // Write the char in the SVG
         pugi::xml_node useChild = AppendChild("use");
-        useChild.append_attribute("xlink:href") = StringFormat("#%s", glyph->GetCodeStr().c_str()).c_str();
+        useChild.append_attribute(hrefAttrib.c_str()) = StringFormat("#%s", glyph->GetCodeStr().c_str()).c_str();
         useChild.append_attribute("x") = x;
         useChild.append_attribute("y") = y;
         useChild.append_attribute("height") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1447,7 +1447,7 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
 
     svg.SetHtml5(m_options->m_svgHtml5.GetValue());
     svg.SetFormatRaw(m_options->m_svgFormatRaw.GetValue());
-    svg.SetIncludeXlink(m_options->m_svgIncludeXlink.GetValue());
+    svg.SetRemoveXlink(m_options->m_svgRemoveXlink.GetValue());
 
     // render the page
     RenderToDeviceContext(pageNo, &svg);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1447,7 +1447,7 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
 
     svg.SetHtml5(m_options->m_svgHtml5.GetValue());
     svg.SetFormatRaw(m_options->m_svgFormatRaw.GetValue());
-    svg.SetXlinkOnHref(m_options->m_svgIncludeXlink.GetValue());
+    svg.SetIncludeXlink(m_options->m_svgIncludeXlink.GetValue());
 
     // render the page
     RenderToDeviceContext(pageNo, &svg);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1447,6 +1447,7 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xml_declaration)
 
     svg.SetHtml5(m_options->m_svgHtml5.GetValue());
     svg.SetFormatRaw(m_options->m_svgFormatRaw.GetValue());
+    svg.SetXlinkOnHref(m_options->m_svgIncludeXlink.GetValue());
 
     // render the page
     RenderToDeviceContext(pageNo, &svg);


### PR DESCRIPTION
After some extensive testing it seems that some browsers, in some cases, will not display SVG if the `href` attribute is prefixed with `xlink`, a change that was introduced with SVG 2.0. This is not yet a recognized specification, but the changes in browsers are being enacted nevertheless.

On the other hand, some strict SVG 1.1 clients will not render the SVG correctly if it *doesn't* include the `xlink:` prefix. In my testing this included Inkscape.

Given that the most likely target for Verovio output is browsers, but still wishing to retain backwards compatibility, this PR changes the default behaviour from producing `xlink:href` to simply `href`. Clients that need the full attribute name can set `--svg-include-xlink` which will insert the xlink prefix on the href attributes.

References previous discussions on this topic: #1158, #332