### PR TITLE
Fix for minimal tie length

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1884,7 +1884,8 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
         const int minTieLength = params->m_doc->GetOptions()->m_tieMinLength.GetValue() * drawingUnit;
         const int currentTieLength = it->second->GetContentLeft() - it->first->GetContentRight() - drawingUnit;
         if ((currentTieLength < minTieLength)
-            && ((this->GetFirstAncestor(CHORD) != NULL) || (it->first->FindDescendantByType(FLAG) != NULL))) {
+            && ((it->first->GetFirstAncestor(CHORD) != NULL) || (this->GetFirstAncestor(CHORD) != NULL)
+                || (it->first->FindDescendantByType(FLAG) != NULL))) {
             const int adjust = minTieLength - currentTieLength;
             this->GetAlignment()->SetXRel(this->GetAlignment()->GetXRel() + adjust);
             // Also move the accumulated x shift and the minimum position for the next alignment accordingly


### PR DESCRIPTION
- changed condition to include cases where only one of the elements is chord

Before:
![image](https://user-images.githubusercontent.com/1819669/136363014-a50d60c2-3cd8-4066-b289-aba2f1277ff6.png)

After:
![image](https://user-images.githubusercontent.com/1819669/136363059-da45f52a-5ac5-4a10-a3d5-794d9b86a669.png)
