### PR TITLE
Fix for cross staff tuplet brackets

### DIFF
--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -262,18 +262,19 @@ void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff)
     TupletNum *tupletNum = dynamic_cast<TupletNum *>(FindDescendantByType(TUPLET_NUM));
     if (!tupletNum || (this->GetNumVisible() == BOOLEAN_false)) return;
 
-    this->CalculateTupletNumCrossStaff(tupletNum);
-
-    Staff *tupletNumStaff = tupletNum->m_crossStaff ? tupletNum->m_crossStaff : staff;
-    const int staffSize = staff->m_drawingStaffSize;
-    const int yReference = tupletNumStaff->GetDrawingY();
-    const int doubleUnit = doc->GetDrawingDoubleUnit(staffSize);
     // The num is within a bracket
     if (tupletNum->GetAlignedBracket()) {
         // yRel is not used for drawing but we need to adjust it for the bounding box to follow the changes
         tupletNum->SetDrawingYRel(tupletNum->GetAlignedBracket()->GetDrawingYRel());
         return;
     }
+
+    this->CalculateTupletNumCrossStaff(tupletNum);
+
+    Staff *tupletNumStaff = tupletNum->m_crossStaff ? tupletNum->m_crossStaff : staff;
+    const int staffSize = staff->m_drawingStaffSize;
+    const int yReference = tupletNumStaff->GetDrawingY();
+    const int doubleUnit = doc->GetDrawingDoubleUnit(staffSize);
 
     // The num is on its own
     const int numVerticalMargin = (m_drawingNumPos == STAFFREL_basic_above) ? doubleUnit : -doubleUnit;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1819669/171193560-a294a8f7-2d31-49b7-9500-2aa6dd7e7f92.png)

After:
![image](https://user-images.githubusercontent.com/1819669/171193607-ac689129-cad0-4524-a3f0-92ae336796fd.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Cross staff tuplet brackts</title>
            <respStmt />
         </titleStmt>
         <pubStmt>
            <date isodate="2022-05-19" type="encoding-date">2022-05-24</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffGrp bar.thru="true">
                        <grpSym symbol="brace" />
                        <staffDef n="1" lines="5">
                           <clef shape="F" line="4" />
                        </staffDef>
                        <staffDef n="2" lines="5">
                           <clef shape="G" line="2" />
                        </staffDef>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="21">
                     <staff n="1">
                        <layer n="1">
                           <tuplet num="5" numbase="4" bracket.place="above">
                              <rest dur="16" loc="4" />
                              <rest dur="16" loc="2" />
                              <rest dur="16" loc="0" />
                              <rest dur="16" staff="2" loc="8" />
                              <rest dur="16" staff="2" loc="6" />
                           </tuplet>
                           <space dur="4" />
                           <rest dur="8" />
                           <rest dur="4" />
                           <rest dur="8" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <space dur="4" />
                           <tuplet num="5" numbase="4" bracket.place="above" staff="1">
                              <rest dur="16" loc="4" />
                              <rest dur="16" loc="6" />
                              <rest dur="16" loc="8" />
                              <rest dur="16" staff="1" loc="0" />
                              <rest dur="16" staff="1" loc="2" />
                           </tuplet>
                           <rest dur="8" />
                           <rest dur="16" />
                           <rest dur="16" />
                           <rest dur="16" />
                           <rest dur="16" />
                           <rest dur="8" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="22">
                     <staff n="1">
                        <layer n="1">
                           <tuplet num="5" numbase="4" bracket.place="above">
                              <rest dur="16" loc="4" />
                              <rest dur="16" loc="2" />
                              <rest dur="16" loc="-2" />
                              <rest dur="16" staff="2" />
                              <rest dur="16" staff="2" />
                           </tuplet>
                           <space dur="4" />
                           <rest dur="8" />
                           <rest dur="4" />
                           <rest dur="8" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <space dur="4" />
                           <tuplet num="5" numbase="4" bracket.place="above">
                              <rest dur="16" loc="4" />
                              <rest dur="16" loc="6" />
                              <rest dur="16" staff="1" loc="-2" />
                              <rest dur="16" staff="1" loc="2" />
                              <rest dur="16" staff="1" loc="4" />
                           </tuplet>
                           <rest dur="8" />
                           <rest dur="16" />
                           <rest dur="16" />
                           <rest dur="16" />
                           <rest dur="16" />
                           <rest dur="8" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>