### PR TITLE
Add margin for tupletNum on cross-staff beams

### DIFF
--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -255,6 +255,13 @@ void Tuplet::AdjustTupletBracketBeamY(Doc *doc, Staff *staff, TupletBracket *bra
         if (leftMargin > 0) bracket->SetDrawingYRelLeft(sign * (leftMargin - bracketAdjust));
         if (rightMargin > 0) bracket->SetDrawingYRelRight(sign * (rightMargin - bracketAdjust));
     }
+
+    if (beam->m_crossStaffContent) {
+        if ((m_drawingBracketPos == STAFFREL_basic_below) && (beam->m_crossStaffContent->GetN() > staff->GetN())) {
+            bracket->SetDrawingYRelLeft(bracket->GetDrawingYRelLeft() - doubleUnit / 4);
+            bracket->SetDrawingYRelRight(bracket->GetDrawingYRelRight() - doubleUnit / 4);
+        }
+    }
 }
 
 void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff)


### PR DESCRIPTION
Minor fix for tuplet number overlapping with cross-staff beams when paired with brackets:
![image](https://user-images.githubusercontent.com/1819669/172213698-1241aa03-68ac-4401-83e7-eea87ac8d950.png)
After fix:
![image](https://user-images.githubusercontent.com/1819669/172213730-e15b6e85-5810-4608-a1f1-4d7f8f99a5f6.png)
