### PR TITLE
Keep GIT_COMMIT empty if it cannot be determined. Closes #3059

### DIFF
--- a/tools/get_git_commit.sh
+++ b/tools/get_git_commit.sh
@@ -8,9 +8,11 @@ COMMIT=""
 if [ ! -d "./.git" ]; then
      echo "This is not a git directory and the git commit sha will remain undefined"
 else
-    COMMIT="-$(git describe --abbrev=7 --always --dirty)"
-    if [ -z "$COMMIT" ]; then
+    SHA=$(git describe --abbrev=7 --always --dirty)
+    if [ -z "$SHA" ]; then
         echo "Undefined git commit version"
+    else
+        COMMIT="-$SHA"
     fi
 fi
 


### PR DESCRIPTION
I prefer to keep the git commit with releases. This is another solution than #3060 that does that.