### PR TITLE
Add option for controlling text font embedded

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -281,6 +281,31 @@ jobs:
           name: ${{ env.TOOLKIT_BUILD }}
           path: ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ matrix.toolkit.filepath }}
 
+
+  ############################
+  # Copy the font CSS files  #
+  ############################
+  copy_font_files:
+    name: Copy the font files
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v3
+
+      - name: Create TEMP_DIR
+        working-directory: ${{ github.workspace }}
+        run: mkdir -p $TEMP_DIR/data
+
+      - name: Copy build into TEMP_DIR
+        run: cp data/*.css $GITHUB_WORKSPACE/$TEMP_DIR/data/
+
+      - name: Upload font data artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.TOOLKIT_BUILD }}
+          path: ${{ github.workspace }}/${{ env.TEMP_DIR }}
+
   ##################################
   # Check settings for deployment  #
   ##################################

--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -77,7 +77,7 @@ GetOptions (
 );
 
 # Default compiling uses ASM and large file support.
-# Memory is increased (TOTAL_STACK) for processing large files (tested up to 7MB)
+# Memory is increased (STACK_SIZE) for processing large files (tested up to 7MB)
 # Empirically, the memory amount required is roughly 5 times the file size.
 # This can be disabled in the light version, which uses the default memory settings.
 my $FLAGS = "-O3";
@@ -86,7 +86,7 @@ $FLAGS .= " -std=c++$cpp";
 
 my $LFLAGS =  " -s ASM_JS=1";
 $LFLAGS .= " -s INITIAL_MEMORY=256MB";
-$LFLAGS .= " -s TOTAL_STACK=128MB";
+$LFLAGS .= " -s STACK_SIZE=128MB";
 $LFLAGS .= " -s WASM=0";
 $LFLAGS .= " --memory-init-file 0";
 
@@ -120,7 +120,7 @@ if ($wasmQ) {
 	# Linker flags
 	$LFLAGS = " -s WASM=1";
 	$LFLAGS .= " -s INITIAL_MEMORY=512MB";
-	$LFLAGS .= " -s TOTAL_STACK=256MB";
+	$LFLAGS .= " -s STACK_SIZE=256MB";
 	$LFLAGS .= " -s SINGLE_FILE=1";
 	$FLAGS_NAME = "-wasm";
 }

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -20,6 +20,10 @@
 
 #include "attalternates.h"
 #include "atttypes.h"
+#include "smufl.h"
+
+//----------------------------------------------------------------------------
+
 #include "jsonxx.h"
 
 //----------------------------------------------------------------------------
@@ -54,6 +58,13 @@ class OptionGrp;
 enum option_BREAKS { BREAKS_none = 0, BREAKS_auto, BREAKS_line, BREAKS_smart, BREAKS_encoded };
 
 enum option_CONDENSE { CONDENSE_none = 0, CONDENSE_auto, CONDENSE_all, CONDENSE_encoded };
+
+enum option_ELISION {
+    ELISION_regular = SMUFL_E551_lyricsElision,
+    ELISION_narrow = SMUFL_E550_lyricsElisionNarrow,
+    ELISION_wide = SMUFL_E552_lyricsElisionWide,
+    ELISION_unicode = UNICODE_UNDERTIE
+};
 
 enum option_FOOTER { FOOTER_none = 0, FOOTER_auto, FOOTER_encoded, FOOTER_always };
 
@@ -126,6 +137,7 @@ public:
      */
     static const std::map<int, std::string> s_breaks;
     static const std::map<int, std::string> s_condense;
+    static const std::map<int, std::string> s_elision;
     static const std::map<int, std::string> s_footer;
     static const std::map<int, std::string> s_header;
     static const std::map<int, std::string> s_multiRestStyle;
@@ -682,6 +694,7 @@ public:
     OptionDbl m_justificationMaxVertical;
     OptionDbl m_ledgerLineThickness;
     OptionDbl m_ledgerLineExtension;
+    OptionIntMap m_lyricElision;
     OptionDbl m_lyricHyphenLength;
     OptionDbl m_lyricLineThickness;
     OptionBool m_lyricNoStartHyphen;

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -468,6 +468,8 @@ enum FunctorCode { FUNCTOR_CONTINUE = 0, FUNCTOR_SIBLINGS, FUNCTOR_STOP };
 #define UNICODE_NATURAL U'\u266E' // ♮
 #define UNICODE_SHARP U'\u266F' // ♯
 
+#define UNICODE_UNDERTIE U'\u203F' // ‿
+
 #define UNICODE_DAL_SEGNO U'\U0001D109' // 𝄉
 #define UNICODE_DA_CAPO U'\U0001D10A' // 𝄊
 #define UNICODE_SEGNO U'\U0001D10B' // 𝄋

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -27,6 +27,9 @@ const std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, {
 const std::map<int, std::string> Option::s_condense
     = { { CONDENSE_none, "none" }, { CONDENSE_auto, "auto" }, { CONDENSE_encoded, "encoded" } };
 
+const std::map<int, std::string> Option::s_elision = { { ELISION_regular, "regular" }, { ELISION_narrow, "narrow" },
+    { ELISION_wide, "wide" }, { ELISION_unicode, "unicode" } };
+
 const std::map<int, std::string> Option::s_footer
     = { { FOOTER_none, "none" }, { FOOTER_auto, "auto" }, { FOOTER_encoded, "encoded" }, { FOOTER_always, "always" } };
 
@@ -1315,6 +1318,10 @@ Options::Options()
         "Ledger line extension", "The amount by which a ledger line should extend either side of a notehead");
     m_ledgerLineExtension.Init(0.54, 0.20, 1.00);
     this->Register(&m_ledgerLineExtension, "ledgerLineExtension", &m_generalLayout);
+
+    m_lyricElision.SetInfo("Lyric elision", "The lyric elision width");
+    m_lyricElision.Init(ELISION_regular, &Option::s_elision);
+    this->Register(&m_lyricElision, "lyricElision", &m_generalLayout);
 
     m_lyricHyphenLength.SetInfo("Lyric hyphen length", "The lyric hyphen and dash length");
     m_lyricHyphenLength.Init(1.20, 0.50, 3.00);

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -98,11 +98,17 @@ int Syl::CalcConnectorSpacing(Doc *doc, int staffSize)
     }
     // Elision
     else if (con == sylLog_CON_b) {
-        // Calculate the elision space with the current music font
-        int elisionSpace = doc->GetGlyphAdvX(SMUFL_E551_lyricsElision, staffSize, false);
-        // Adjust it proportionally to the lyric size
-        elisionSpace *= doc->GetOptions()->m_lyricSize.GetValue() / doc->GetOptions()->m_lyricSize.GetDefault();
-        spacing = elisionSpace;
+        if (doc->GetOptions()->m_lyricElision.GetValue() == ELISION_unicode) {
+            // Equivalent spacing with 0x230F
+            spacing += doc->GetDrawingUnit(staffSize) * 2.2;
+        }
+        else {
+            // Calculate the elision space with the current music font
+            int elisionSpace = doc->GetGlyphAdvX(doc->GetOptions()->m_lyricElision.GetValue(), staffSize, false);
+            // Adjust it proportionally to the lyric size
+            elisionSpace *= doc->GetOptions()->m_lyricSize.GetValue() / doc->GetOptions()->m_lyricSize.GetDefault();
+            spacing = elisionSpace;
+        }
     }
     // Spacing of words as set in the staff according to the staff and font sizes
     else {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1664,16 +1664,23 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     if (syl->GetCon() == sylLog_CON_b) {
         dc->ReactivateGraphic();
         dc->DeactivateGraphic();
-        FontInfo vrvTxt;
-        vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
-        vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
-        std::u32string str;
-        str.push_back(SMUFL_E551_lyricsElision);
-        bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(str);
-        vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
-        dc->SetFont(&vrvTxt);
-        dc->DrawText(UTF32to8(str), str);
-        dc->ResetFont();
+        if (m_doc->GetOptions()->m_lyricElision.GetValue() == ELISION_unicode) {
+            std::u32string str;
+            str.push_back(UNICODE_UNDERTIE);
+            dc->DrawText(UTF32to8(str), str);
+        }
+        else {
+            FontInfo vrvTxt;
+            vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
+            vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
+            std::u32string str;
+            str.push_back(m_doc->GetOptions()->m_lyricElision.GetValue());
+            bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(str);
+            vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
+            dc->SetFont(&vrvTxt);
+            dc->DrawText(UTF32to8(str), str);
+            dc->ResetFont();
+        }
         dc->ReactivateGraphic();
         dc->DeactivateGraphicY();
     }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -260,39 +260,41 @@ void View::DrawLyricString(
     bool wroteText = false;
     std::u32string syl = U"";
     std::u32string lyricStr = str;
-    while (lyricStr.compare(syl) != 0) {
-        wroteText = true;
-        auto index = lyricStr.find_first_of(U"_");
-        syl = lyricStr.substr(0, index);
-        if (params) {
-            dc->DrawText(UTF32to8(syl), syl, params->m_x, params->m_y, params->m_width, params->m_height);
-        }
-        else {
-            dc->DrawText(UTF32to8(syl), syl);
-        }
 
-        // no _
-        if (index == std::string::npos) break;
+    const int x = (params) ? params->m_x : VRV_UNSET;
+    const int y = (params) ? params->m_y : VRV_UNSET;
+    const int width = (params) ? params->m_width : VRV_UNSET;
+    const int height = (params) ? params->m_height : VRV_UNSET;
 
-        FontInfo vrvTxt;
-        vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
-        vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
-        std::u32string elision;
-        elision.push_back(SMUFL_E551_lyricsElision);
-        bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(elision);
-        vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
-        dc->SetFont(&vrvTxt);
-        if (params) {
-            dc->DrawText(UTF32to8(elision), elision, params->m_x, params->m_y, params->m_width, params->m_height);
-        }
-        else {
-            dc->DrawText(UTF32to8(elision), elision);
-        }
-        dc->ResetFont();
+    if (m_doc->GetOptions()->m_lyricElision.GetValue() == ELISION_unicode) {
+        std::replace(lyricStr.begin(), lyricStr.end(), U'_', UNICODE_UNDERTIE);
+        dc->DrawText(UTF32to8(lyricStr), lyricStr, x, y, width, height);
+    }
+    else {
+        while (lyricStr.compare(syl) != 0) {
+            wroteText = true;
+            auto index = lyricStr.find_first_of(U"_");
+            syl = lyricStr.substr(0, index);
+            dc->DrawText(UTF32to8(syl), syl, x, y, width, height);
 
-        // next syllable
-        syl = U"";
-        lyricStr = lyricStr.substr(index + 1, lyricStr.length());
+            // no _
+            if (index == std::string::npos) break;
+
+            FontInfo vrvTxt;
+            vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
+            vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
+            std::u32string elision;
+            elision.push_back(m_doc->GetOptions()->m_lyricElision.GetValue());
+            bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(elision);
+            vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
+            dc->SetFont(&vrvTxt);
+            dc->DrawText(UTF32to8(elision), elision, x, y, width, height);
+            dc->ResetFont();
+
+            // next syllable
+            syl = U"";
+            lyricStr = lyricStr.substr(index + 1, lyricStr.length());
+        }
     }
 
     // This should only be called in facsimile mode where a zone is specified but there is


### PR DESCRIPTION
The PR adds the `--smuflTextFont` option with the following possible values:

`embedded` (default): same as before (font embedded as base64 string)

`linked`: add a link to `https://www.verovio.org/javascript/VERSION/data/FONTNAME.css` where:
* VERSION is `develop` or the release number (e.g. `3.13.0`)
* FONTNAME is Leipzig, Bravura, etc (as needed)

Example:
```xml
   <style type="text/css">@import url("https://www.verovio.org/javascript/develop/data/Leland.css");</style>
   <style type="text/css">@import url("https://www.verovio.org/javascript/develop/data/Leipzig.css");</style>
```

`none`: nothing is added, which can be useful if the font is included by hand in the web page or existing in the system.