### PR TITLE
Fix extra custom graphic on braces

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -651,9 +651,7 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
         const float currentWidthToHeightRatio = font->GetWidthToHeightRatio();
         const float widthAfterScalling = width * scale;
         font->SetWidthToHeightRatio(static_cast<float>(braceWidth) / widthAfterScalling);
-        dc->StartCustomGraphic("grpSym");
         this->DrawSmuflCode(dc, x, y2, SMUFL_E000_brace, staffSize * scale, false);
-        dc->EndCustomGraphic();
         font->SetWidthToHeightRatio(currentWidthToHeightRatio);
         return;
     }


### PR DESCRIPTION
This small PR fixes the unwanted extra custom graphic around brace symbols when the `useBraceGlyph` option is used.