### PR TITLE
Extend import of key signatures

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3957,6 +3957,9 @@ KeySig *MusicXmlInput::ConvertKey(const pugi::xml_node &key)
                         ConvertAccidentalToAccid(keyStep.next_sibling().next_sibling().text().as_string()));
                     keyAccid->SetGlyphName(keyStep.next_sibling().next_sibling().attribute("smufl").as_string());
                 }
+                else if (!keyAccid->HasAccid()) {
+                    LogWarning("MusicXML import: Could not properly set keyAccid");
+                }
             }
             keySig->AddChild(keyAccid);
         }


### PR DESCRIPTION
This PR adds support for sori and koron accidentals and `smufl` values in key signatures to MusicXML import.

![image](https://github.com/rism-digital/verovio/assets/7693447/b26cd5e7-6564-4dfa-baa6-fb3a73a038cc)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="4.0">
  <work>
    <work-title>Persian key</work-title>
    </work>
  <identification>
    <creator type="encoder">Klaus Rettinghaus</creator>
    </identification>
  <part-list>
    <score-part id="P1">
      <part-name>Stimme</part-name>
      <part-abbreviation>St.</part-abbreviation>
      <score-instrument id="P1-I1">
        <instrument-name>Stimme</instrument-name>
        <instrument-sound>voice.vocals</instrument-sound>
        </score-instrument>
      <midi-device id="P1-I1" port="1"></midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>53</midi-program>
        <volume>78.7402</volume>
        <pan>0</pan>
        </midi-instrument>
      </score-part>
    </part-list>
  <part id="P1">
    <measure number="1">
      <attributes>
        <divisions>1</divisions>
        <key>
          <key-step>C</key-step>
          <key-alter>0.33</key-alter>
          <key-accidental>sori</key-accidental>
          <key-step>E</key-step>
          <key-alter>-0.67</key-alter>
          <key-accidental>koron</key-accidental>
          <key-step>B</key-step>
          <key-alter>-0.67</key-alter>
          <key-accidental>koron</key-accidental>
          <key-step>F</key-step>
          <key-alter>0.33</key-alter>
          <key-accidental smufl="">sori</key-accidental>
          </key>
        <time>
          <beats>4</beats>
          <beat-type>4</beat-type>
          </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
          </clef>
        </attributes>
      <note>
        <rest measure="yes"/>
        <duration>4</duration>
        <voice>1</voice>
        </note>
      </measure>
    </part>
  </score-partwise>
```
