### PR TITLE
Ensure tempo to be written in the first MIDI measure

### DIFF
--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -770,7 +770,7 @@ FunctorCode GenerateMIDIFunctor::VisitMeasure(const Measure *measure)
     // Here we need to update the m_totalTime from the starting time of the measure.
     m_totalTime = measure->GetScoreTimeOnset().ToDouble();
 
-    if (measure->GetCurrentTempo() != m_currentTempo) {
+    if ((m_totalTime == 0.0) || (measure->GetCurrentTempo() != m_currentTempo)) {
         m_currentTempo = measure->GetCurrentTempo();
         const int tick = m_totalTime * m_midiFile->getTPQ();
         // Check if there was already a tempo event added for the given tick


### PR DESCRIPTION
This should fix the issue with tempo changes when the initial measure in 120, which now would still be written even though this is the default tempo in the MIDI output. Closes #4153