### PR TITLE
Detailed warning for unmatched time-spanning elements

### DIFF
--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -863,7 +863,7 @@ void Doc::PrepareData()
 
     // Something must be wrong in the encoding because a TimeSpanningInterface was left open
     for (const auto &obj : prepareStaffCurrentTimeSpanning.GetTimeSpanningElements()) {
-        LogWarning("Time spanning element could not be set as running: <%s xml:id='%s' ...>",
+        LogWarning("Time spanning element '%s' with @xml:id '%s' could not be set as running.",
             obj->GetClassName().c_str(), obj->GetID().c_str());
     }
 


### PR DESCRIPTION
Verovio used to report to the console the number of unmatched time-spanning elements with `@startid` and `@endid`, where one or both of the elements pointed to are missing, such as: 

```
[Warning] 2 time spanning element(s) with startid and endid could not be matched.
```

This PR makes Verovio report in detail on each such element found, which helps finding errors in the MEI encoding. 
The console output may look like: 

```
[Warning] 2 time spanning element(s) with startid and endid could not be matched:
[Warning] Unmatched tie tie-002054303300: @startId: #note-000509215993, @endId: #note-000079104669
[Warning] Unmatched slur slur-002054305342: @startId: #note-000509365422, @endId: #note-000654252235
```