### PR TITLE
add --svg-content-bounding-boxes command line option

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -664,6 +664,7 @@ public:
     OptionIntMap m_smuflTextFont;
     OptionBool m_staccatoCenter;
     OptionBool m_svgBoundingBoxes;
+    OptionBool m_svgContentBoundingBoxes;
     OptionString m_svgCss;
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -212,6 +212,14 @@ public:
     void SetSvgBoundingBoxes(bool svgBoundingBoxes) { m_svgBoundingBoxes = svgBoundingBoxes; }
 
     /**
+     * Setting m_svgContentBoundingBoxes flag (false by default)
+     */
+    void SetSvgContentBoundingBoxes(bool svgContentBoundingBoxes)
+    {
+        m_svgContentBoundingBoxes = svgContentBoundingBoxes;
+    }
+
+    /**
      * Setting m_svgViewBox flag (false by default)
      */
     void SetSvgViewBox(bool svgViewBox) { m_svgViewBox = svgViewBox; }
@@ -383,6 +391,8 @@ private:
     bool m_useLiberation;
     // add bouding boxes in svg output
     bool m_svgBoundingBoxes;
+    // add content bounding boxes in svg output
+    bool m_svgContentBoundingBoxes;
     // use viewbox on svg root element
     bool m_svgViewBox;
     // output HTML5 data-* attributes

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1159,6 +1159,10 @@ Options::Options()
     m_svgBoundingBoxes.Init(false);
     this->Register(&m_svgBoundingBoxes, "svgBoundingBoxes", &m_general);
 
+    m_svgContentBoundingBoxes.SetInfo("Svg content bounding boxes", "Include content bounding boxes in SVG output");
+    m_svgContentBoundingBoxes.Init(false);
+    this->Register(&m_svgContentBoundingBoxes, "svgContentBoundingBoxes", &m_general);
+
     m_svgCss.SetInfo("SVG additional CSS", "CSS (as a string) to be added to the SVG output");
     m_svgCss.Init("");
     this->Register(&m_svgCss, "svgCss", &m_general);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -50,6 +50,7 @@ SvgDeviceContext::SvgDeviceContext(const std::string &docId) : DeviceContext(SVG
 
     m_mmOutput = false;
     m_svgBoundingBoxes = false;
+    m_svgContentBoundingBoxes = false;
     m_svgViewBox = false;
     m_html5 = false;
     m_formatRaw = false;
@@ -1287,7 +1288,7 @@ void SvgDeviceContext::DrawSvgBoundingBox(Object *object, View *view)
 
     bool groupInPage = false;
     bool drawAnchors = false;
-    bool drawContentBB = false;
+    bool drawContentBB = m_svgContentBoundingBoxes;
 
     if (m_svgBoundingBoxes && view) {
         BoundingBox *box = object;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1765,6 +1765,10 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xmlDeclaration)
         svg.SetSvgBoundingBoxes(true);
     }
 
+    if (m_options->m_svgContentBoundingBoxes.GetValue()) {
+        svg.SetSvgContentBoundingBoxes(true);
+    }
+
     // set the additional CSS if any
     if (!m_options->m_svgCss.GetValue().empty()) {
         svg.SetCss(m_options->m_svgCss.GetValue());


### PR DESCRIPTION
This enables the code for drawing bounding boxes in the SVG (class "content-bounding-box") enclosing the whole content of the elements.

Such bounding boxes are useful for apps handling click on notes. Using the "self" bounding boxes, restricted to the note head path with a very small clickable area, makes click really hard. 