### PR TITLE
implement cutout for mRest

### DIFF
--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_MREST_H__
 #define __VRV_MREST_H__
 
+#include "atts_cmn.h"
 #include "atts_shared.h"
 #include "layerelement.h"
 #include "positioninterface.h"
@@ -28,6 +29,7 @@ class MRest : public LayerElement,
               public PositionInterface,
               public AttColor,
               public AttCue,
+              public AttCutout,
               public AttFermataPresent,
               public AttVisibility {
 public:

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2742,6 +2742,7 @@ void MEIOutput::WriteMRest(pugi::xml_node currentNode, MRest *mRest)
     this->WritePositionInterface(currentNode, mRest);
     mRest->WriteColor(currentNode);
     mRest->WriteCue(currentNode);
+    mRest->WriteCutout(currentNode);
     mRest->WriteFermataPresent(currentNode);
     mRest->WriteVisibility(currentNode);
 }
@@ -6973,6 +6974,7 @@ bool MEIInput::ReadMRest(Object *parent, pugi::xml_node mRest)
 
     vrvMRest->ReadColor(mRest);
     vrvMRest->ReadCue(mRest);
+    vrvMRest->ReadCutout(mRest);
     vrvMRest->ReadFermataPresent(mRest);
     vrvMRest->ReadVisibility(mRest);
 

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -29,11 +29,13 @@ namespace vrv {
 
 static const ClassRegistrar<MRest> s_factory("mRest", MREST);
 
-MRest::MRest() : LayerElement(MREST), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
+MRest::MRest()
+    : LayerElement(MREST), PositionInterface(), AttColor(), AttCue(), AttCutout(), AttFermataPresent(), AttVisibility()
 {
     this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_CUE);
+    this->RegisterAttClass(ATT_CUTOUT);
     this->RegisterAttClass(ATT_FERMATAPRESENT);
     this->RegisterAttClass(ATT_VISIBILITY);
 
@@ -48,6 +50,7 @@ void MRest::Reset()
     PositionInterface::Reset();
     this->ResetColor();
     this->ResetCue();
+    this->ResetCutout();
     this->ResetFermataPresent();
     this->ResetVisibility();
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1169,6 +1169,11 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     dc->StartGraphic(element, "", element->GetID());
 
+    if (mRest->GetCutout() == cutout_CUTOUT_cutout) {
+        dc->EndGraphic(element, this);
+        return;
+    }
+
     mRest->CenterDrawingX();
 
     const bool drawingCueSize = mRest->GetDrawingCueSize();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -41,6 +41,7 @@
 #include "mensur.h"
 #include "metersig.h"
 #include "mnum.h"
+#include "mrest.h"
 #include "note.h"
 #include "options.h"
 #include "page.h"
@@ -1191,7 +1192,10 @@ void View::DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *
         staff->SetFromFacsimile(m_doc);
     }
 
-    this->DrawStaffLines(dc, staff, staffDef, measure, system);
+    MRest *mrest = vrv_cast<MRest *>(staff->FindDescendantByType(MREST));
+    if (!mrest || mrest->GetCutout() != cutout_CUTOUT_cutout) {
+        this->DrawStaffLines(dc, staff, staffDef, measure, system);
+    }
 
     if (staffDef && (m_doc->GetType() != Facs)) {
         this->DrawStaffDef(dc, staff, measure);


### PR DESCRIPTION
This PR brings the first implementation for supporting `@cutout` on mRest. 
