### PR TITLE
re-order rest children

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1567,6 +1567,7 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     /************ Draw children (dots) ************/
     this->DrawLayerChildren(dc, rest, layer, staff, measure);
 
+    // Draw legder lines for half, whole, and breve rests
     if ((drawingDur == DURATION_1 || drawingDur == DURATION_2 || drawingDur == DURATION_breve)) {
         const int width = m_doc->GetGlyphWidth(drawingGlyph, staffSize, drawingCueSize);
         int ledgerLineThickness


### PR DESCRIPTION
Not totally sure about this one, but as we add individual ledger lines to some rests I think that the dot should precede those. That way it is basically now the same structure as for notes: glyph - dot - other stuff.