### PR TITLE
print opacity only if needed

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -63,7 +63,7 @@ public:
         , m_gapLength(0)
         , m_lineCap(LINECAP_DEFAULT)
         , m_lineJoin(LINEJOIN_DEFAULT)
-        , m_opacity(-1.0)
+        , m_opacity(1.0)
         , m_color(COLOR_NONE)
     {
     }
@@ -97,7 +97,7 @@ public:
     void SetStyle(PenStyle style) { m_style = style; }
     float GetOpacity() const { return m_opacity; }
     void SetOpacity(float opacity) { m_opacity = opacity; }
-    bool HasOpacity() const { return (m_opacity != -1.0); }
+    bool HasOpacity() const { return (m_opacity != 1.0); }
 
 private:
     int m_width;
@@ -111,7 +111,7 @@ private:
 
 class Brush {
 public:
-    Brush() : m_opacity(-1.0), m_color(COLOR_NONE) {}
+    Brush() : m_opacity(1.0), m_color(COLOR_NONE) {}
     Brush(float opacity, int color) : m_opacity(opacity), m_color(color) {}
 
     int GetColor() const { return m_color; }
@@ -119,7 +119,7 @@ public:
     bool HasColor() const { return (m_color != COLOR_NONE); }
     float GetOpacity() const { return m_opacity; }
     void SetOpacity(float opacity) { m_opacity = opacity; }
-    bool HasOpacity() const { return (m_opacity != -1.0); }
+    bool HasOpacity() const { return (m_opacity != 1.0); }
 
 private:
     float m_opacity;


### PR DESCRIPTION
This PR switched to SVG opacity default value in order to not print unneeded attributes in the SVG output.

See 
* https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-opacity
* https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fill-opacity