### PR TITLE
Fix dots in clusters

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -633,7 +633,9 @@ void View::DrawChordCluster(DeviceContext *dc, Chord *chord, Layer *layer, Staff
             accidY = std::min(staffBottom, y2) - unit - m_doc->GetGlyphTop(accidGlyph, staffSize, true);
         }
 
+        dc->StartCustomGraphic("accid");
         this->DrawSmuflCode(dc, accidX, accidY, accidGlyph, staffSize, true, true);
+        dc->EndCustomGraphic();
     }
 
     // Draw dots and stem


### PR DESCRIPTION
This PR fixes an issue with clusters in cue layers, where only the dots weren't made smaller. Also it adds the missing dots class in the SVG.