### PR TITLE
[MusicXML] improve spacing and glyphs for metronome

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -773,6 +773,7 @@ void MusicXmlInput::PrintMetronome(pugi::xml_node metronome, Tempo *tempo)
                 const short int dotCount = (short int)std::count_if(
                     iter, separator, [](const auto pair) { return pair.first == MetronomeElements::BEAT_UNIT_DOT; });
                 for (short int i = 0; i < dotCount; ++i) {
+                    verovioText += UTF8to32(" ");
                     verovioText += U"\xECB7"; // SMUFL augmentation dot
                 }
                 // set @mmUnit and @mmDots attributes only based on the first beat-unit in the sequence


### PR DESCRIPTION
fixes #4230

### before

<img width="348" height="180" alt="Bildschirmfoto 2025-12-12 um 19 28 58" src="https://github.com/user-attachments/assets/f0f9be6a-2acd-484f-afc9-d123976c6366" />

### after

<img width="357" height="182" alt="Bildschirmfoto 2025-12-12 um 19 34 27" src="https://github.com/user-attachments/assets/db91a2af-ccba-4d65-bf21-133394c4cd81" />
