### PR TITLE
add support for filled whole notes

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -704,10 +704,12 @@ char32_t Note::GetNoteheadGlyph(const data_DURATION duration) const
     }
 
     if (DURATION_breve == duration) return SMUFL_E0A1_noteheadDoubleWholeSquare;
-    if (DURATION_1 == duration) return SMUFL_E0A2_noteheadWhole;
-    // We support solid on half notes or void on quarter and shorter notes
+    // We support solid on whole and half notes or void on quarter and shorter notes
+    if (DURATION_1 == duration)
+        return (this->GetHeadFill() == FILL_solid) ? SMUFL_E0FA_noteheadWholeFilled : SMUFL_E0A2_noteheadWhole;
+    ;
     if (DURATION_2 == duration) {
-        return (this->GetHeadFill() == FILL_solid) ? SMUFL_E0A4_noteheadBlack : SMUFL_E0A3_noteheadHalf;
+        return (this->GetHeadFill() == FILL_solid) ? SMUFL_E0FB_noteheadHalfFilled : SMUFL_E0A3_noteheadHalf;
     }
     else {
         return (this->GetHeadFill() == FILL_void) ? SMUFL_E0A3_noteheadHalf : SMUFL_E0A4_noteheadBlack;


### PR DESCRIPTION
closes #4236

<img width="447" height="146" alt="heads" src="https://github.com/user-attachments/assets/846214f9-eda6-40c4-b7e2-9e9f9a1ccaba" />

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Change head solidity</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2025-12-12">2025-12-12</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio supports head.fill for standard notes.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="5.8.0">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
      <extMeta />
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp symbol="bracket">
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="5" pname="c" />
                           <note dur="2" oct="5" pname="c" />
                           <note dur="1" oct="5" pname="c" />
                        </layer>
                        <layer n="2">
                           <note dur="4" oct="4" pname="a" head.fill="void" />
                           <note dur="2" oct="4" pname="a" head.fill="solid" />
                           <note dur="1" oct="4" pname="a" head.fill="solid" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
