### PR TITLE
Fix order of articulations in MusicXML importer

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3201,34 +3201,36 @@ void MusicXmlInput::ReadMusicXmlNote(
         this->ReadMusicXmlTies(node, layer, note, measureNum);
 
         // articulation
-        std::vector<data_ARTICULATION> artics;
+        std::list<Artic *> artics;
         for (pugi::xml_node articulations : notations.node().children("articulations")) {
             for (pugi::xml_node articulation : articulations.children()) {
                 Artic *artic = new Artic();
-                artics.push_back(ConvertArticulations(articulation.name()));
+                data_ARTICULATION articVal = ConvertArticulations(articulation.name());
                 if (!std::strcmp(articulation.name(), "detached-legato")) {
                     // we need to split up this one
-                    artic->SetArtic(artics);
+                    artic->SetArtic({ articVal });
                     artic->SetColor(articulation.attribute("color").as_string());
                     artic->SetPlace(
                         artic->AttPlacementRelEvent::StrToStaffrel(articulation.attribute("placement").as_string()));
-                    element->AddChild(artic);
-                    artics.clear();
+                    artics.push_back(artic);
                     artic = new Artic();
-                    artics.push_back(ARTICULATION_ten);
+                    articVal = ARTICULATION_ten;
                 }
-                if (artics.back() == ARTICULATION_NONE) {
+                if (articVal == ARTICULATION_NONE) {
                     delete artic;
                     continue;
                 }
-                artic->SetArtic(artics);
+                artic->SetArtic({ articVal });
                 artic->SetColor(articulation.attribute("color").as_string());
                 artic->SetPlace(
                     artic->AttPlacementRelEvent::StrToStaffrel(articulation.attribute("placement").as_string()));
-                element->AddChild(artic);
-                artics.clear();
+                // Always put stacc at the front of the list
+                (artic->GetArticFirst() == ARTICULATION_stacc) ? artics.push_front(artic) : artics.push_back(artic);
             }
         }
+        for (Artic *artic : artics) element->AddChild(artic);
+        // Not strictly necessary
+        artics.clear();
 
         // technical
         for (pugi::xml_node technical : notations.node().children("technical")) {


### PR DESCRIPTION
Staccato is always put as first (closest to the note)

Closes #4227 

Before

<img width="263" height="133" alt="image" src="https://github.com/user-attachments/assets/3ae7aaf2-275f-4cab-bfb7-f2aae68ad7e1" />

After

<img width="263" height="133" alt="image" src="https://github.com/user-attachments/assets/f7a0f87d-0289-427a-b4d1-4cf78e1b8f92" />
