### PR TITLE
Improve css

### DIFF
--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -510,6 +510,7 @@ void SvgDeviceContext::StartPage()
     m_svgNodeStack.push_back(m_currentNode);
     m_currentNode.append_attribute("class") = "definition-scale";
     m_currentNode.append_attribute("color") = "currentColor";
+    m_currentNode.append_attribute("fill") = "currentColor";
     m_currentNode.append_attribute("font-family") = resources->GetTextFont() + ", serif";
     if (this->GetFacsimile()) {
         m_currentNode.append_attribute("viewBox")


### PR DESCRIPTION
This PR picks up on some things proposed in #4252 and simplyfies the common CSS rules. 

* The `PrefixCssRules` method now just groups all rules into a [ruleset](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Syntax/Introduction#css_rulesets) instead of prefixing every single rule
* g element selector now applies to a ruleset
* `font-family` has been made a SVG presentation attribute
* `currentColor` is now the default color (inheriting it from HTML)

Also there is a small fix for (beam) polygons that were always carrying a `fill-opacity` attribute.
