### PR TITLE
fix opacity for oblique polygons

### DIFF
--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -153,6 +153,7 @@ void View::DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2,
     Point p[4];
 
     dc->SetPen(0, PEN_SOLID);
+    dc->SetBrush(-1.0);
 
     height = this->ToDeviceContextX(height);
     p[0].x = this->ToDeviceContextX(x1);


### PR DESCRIPTION
Small fix for (beam) polygons that were always carrying a fill-opacity attribute.