### PR TITLE
fix import of Dorico exports

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3296,6 +3296,7 @@ void MusicXmlInput::ReadMusicXmlNote(
 
         // verse / syl
         for (pugi::xml_node lyric : node.children("lyric")) {
+            if (!lyric.child("text")) continue; // Dorico exports non-valid MusicXML
             short int lyricNumber = lyric.attribute("number").as_int();
             lyricNumber = (lyricNumber < 1) ? 1 : lyricNumber;
             Verse *verse = new Verse();


### PR DESCRIPTION
Dorico exports non-valid MusicXML with lyrics containing no text:

```xml
        <lyric number="1" placement="below" default-y="-98.75" name="verse">
          <extend type="stop"/>
        </lyric>
```

This leads to non-valid MEI with empty `verse` elements.
