### PR TITLE
Switch language attribute

### DIFF
--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -324,7 +324,7 @@ void SvgDeviceContext::StartGraphic(
         AttLang *att = dynamic_cast<AttLang *>(object);
         assert(att);
         if (att->HasLang()) {
-            m_currentNode.append_attribute("xml:lang") = att->GetLang().c_str();
+            m_currentNode.append_attribute("lang") = att->GetLang().c_str();
         }
     }
 


### PR DESCRIPTION
Not sure what to make of [this](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xml:lang), because `xml:lang` is not deprecated in the official W3C recommendations (see <https://www.w3.org/TR/SVG11/struct.html#XMLLangAttribute> and <https://www.w3.org/TR/SVG2/struct.html#LangSpaceAttrs>).

However, as there is the [`lang`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/lang) attribute in SVG, we can switch to that one.
