### PR TITLE
fix vgrp in MusicXML import

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2384,8 +2384,10 @@ void MusicXmlInput::ReadMusicXmlDirection(
             }
 
             this->TextRendition(words, dir);
-            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
-            dir->SetVgrp(defaultY);
+            if (defaultY) {
+                defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
+                dir->SetVgrp(defaultY);
+            }
             m_controlElements.push_back({ measureNum, dir });
             m_dirStack.push_back(dir);
 


### PR DESCRIPTION
Fix wrong setting of `@vgrp` for MusicXML files without `@defaultY` or `@relativeY`.

### Before

<img width="818" height="369" alt="Bildschirmfoto 2026-02-28 um 15 22 00" src="https://github.com/user-attachments/assets/4b9c6004-d1c5-49fb-9fa0-06e956a89283" />

### After

<img width="815" height="373" alt="Bildschirmfoto 2026-02-28 um 15 22 20" src="https://github.com/user-attachments/assets/07390e81-bdb2-429d-8fb9-2dd6ff647fc1" />
