### PR TITLE
Fix #4290 beam span crash by switching to shared_ptr

### DIFF
--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -77,8 +77,8 @@ public:
      * Access the beam segments
      */
     ///@{
-    BeamSpanSegment *GetSegment(int index) { return m_beamSegments.at(index); }
-    const BeamSpanSegment *GetSegment(int index) const { return m_beamSegments.at(index); }
+    BeamSpanSegment *GetSegment(int index) { return m_beamSegments.at(index).get(); }
+    const BeamSpanSegment *GetSegment(int index) const { return m_beamSegments.at(index).get(); }
     BeamSpanSegment *GetSegmentForSystem(const System *system);
     const BeamSpanSegment *GetSegmentForSystem(const System *system) const;
     ///@}
@@ -122,7 +122,7 @@ private:
     /**
      * Array of beam segments
      */
-    std::vector<BeamSpanSegment *> m_beamSegments;
+    std::vector<std::shared_ptr<BeamSpanSegment>> m_beamSegments;
     /**
      * Array of beamed elements
      */

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -66,16 +66,13 @@ void BeamSpan::Reset()
 void BeamSpan::InitBeamSegments()
 {
     // BeamSpan should have at least one segment to begin with
-    m_beamSegments.emplace_back(new BeamSpanSegment());
+    m_beamSegments.emplace_back(std::make_shared<BeamSpanSegment>());
 
     m_isSpanningElement = true;
 }
 
 void BeamSpan::ClearBeamSegments()
 {
-    for (BeamSpanSegment *segment : m_beamSegments) {
-        delete segment;
-    }
     m_beamSegments.clear();
 }
 
@@ -88,11 +85,11 @@ const BeamSpanSegment *BeamSpan::GetSegmentForSystem(const System *system) const
 {
     assert(system);
 
-    for (BeamSpanSegment *segment : m_beamSegments) {
+    for (std::shared_ptr<BeamSpanSegment> segment : m_beamSegments) {
         // make sure to process only segments for current system
         const Measure *segmentSystem = segment->GetMeasure();
         if (segmentSystem && vrv_cast<const System *>(segmentSystem->GetFirstAncestor(SYSTEM)) == system)
-            return segment;
+            return segment.get();
     }
     return NULL;
 }
@@ -110,9 +107,9 @@ bool BeamSpan::AddSpanningSegment(const Doc *doc, const SpanIndexVector &element
         [&](BeamElementCoord *coord) { return coord->m_element == *(elements.at(index + 1).first - 1); });
     if ((coordsFirst == m_beamElementCoords.end()) || (coordsLast == m_beamElementCoords.end())) return false;
 
-    BeamSpanSegment *segment = NULL;
+    std::shared_ptr<BeamSpanSegment> segment;
     if (newSegment) {
-        segment = new BeamSpanSegment();
+        segment = std::make_shared<BeamSpanSegment>();
     }
     else {
         segment = m_beamSegments.at(0);


### PR DESCRIPTION
Fix #4290 beam span crash in expansion, by switching to `shared_ptr` which takes care of reference counting the pointers and deleting them. 