### PR TITLE
Drop Verovio light build from CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -289,10 +289,6 @@ jobs:
             message: "Building toolkit without humdrum"
             options: "-c -H -M"
             filepath: "verovio-toolkit.js*"
-          - target: light
-            message: "Building toolkit without humdrum as light version"
-            options: "-c -H -l -M"
-            filepath: "verovio-toolkit-light.js*"
           - target: wasm
             message: "Building toolkit without humdrum as wasm"
             options: "-c -H -w -M"


### PR DESCRIPTION
If I remember correctly we dropped the "light" build, so also removing it from the CI. 