### PR TITLE
New golang bindings

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -243,6 +243,43 @@ jobs:
           name: java-build-${{ github.run_id }}
           path: ${{ github.workspace }}/${{ env.TEMP_DIR }}
 
+
+  ##################################
+  # Build and test the Go bindings #
+  ##################################
+  build_go:
+    # skip job if commit message contains "[skip-ci]"
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+
+    name: Build Go bindings
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ${{ github.workspace }}/bindings/go/go.mod
+          cache-dependency-path: ${{ github.workspace }}/bindings/go/go.mod
+
+      - name: Build and install Verovio shared library
+        working-directory: ${{ github.workspace }}
+        run: |
+          cmake -S cmake -B build/go -DBUILD_AS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX="$PWD/build/go/install"
+          cmake --build build/go -j8
+          cmake --install build/go
+
+      - name: Run Go tests
+        working-directory: ${{ github.workspace }}/bindings/go
+        env:
+          PKG_CONFIG_PATH: ${{ github.workspace }}/build/go
+          LD_LIBRARY_PATH: ${{ github.workspace }}/build/go/install/lib
+          VEROVIO_RESOURCE_PATH: ${{ github.workspace }}/build/go/install/share/verovio
+          GOCACHE: ${{ github.workspace }}/.gocache
+        run: go test ./...
+
   
   #####################################
   # Set up and cache emscripten build #

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,9 @@ Release/
 fonts/**/tmp
 libmei/tools/__pycache__
 doc/.venv
+
+# Golang files
+bindings/go/CMakeFiles
+bindings/go/CMakeCache.txt
+bindings/go/libverovio.dylib
+bindings/go/install_manifest.txt

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Verovio is a fast, portable and lightweight library for engraving [Music Encoding Initiative (MEI)](http://www.music-encoding.org) digital scores into SVG images. Verovio also contains on-the-fly converters to render [Plaine & Easie Code](https://www.iaml.info/plaine-easie-code), [Humdrum](https://www.humdrum.org), [Musedata](https://musedata.org), [MusicXML](https://www.musicxml.com), [EsAC](http://esac-data.org), and [ABC](https://en.wikipedia.org/wiki/ABC_notation) digital scores. 
 
-Verovio is written in standard C++20 and is available in several bindings (JavaScript, Python, Java, Swift). It
+Verovio is written in standard C++20 and is available in several bindings (JavaScript, Python, Java, Swift, Go). It
 can be compiled as a standalone command-line tool or as a music-rendering library for applications.  Check out the JavaScript toolkit version of Verovio running in the [Verovio Online Editor / Viewer](http://editor.verovio.org), or the [tutorials](https://book.verovio.org/first-steps/) to know more about web integration and user interaction.
 
 ![Choice interaction](https://raw.githubusercontent.com/rism-digital/verovio.org/gh-pages/movies/reflow.gif)

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,113 @@
+# Go bindings
+
+This package exposes the existing Verovio C API to Go through `cgo`.
+
+`NewToolkit()` first checks `VEROVIO_RESOURCE_PATH`. If that variable is unset, it creates a toolkit without configuring a resource directory.
+
+## Required files and paths
+
+To use this binding, your system needs all of the following:
+
+- the Go package source in `bindings/go`
+- the Verovio shared library:
+  `libverovio.dylib` on macOS or `libverovio.so` on Linux
+- the generated `pkg-config` file:
+  `verovio.pc`
+- the Verovio runtime resources directory:
+  `share/verovio`
+
+With the example install prefix below, those paths are:
+
+- shared library:
+  `$PWD/build/go/install/lib/libverovio.dylib`
+- `pkg-config` metadata:
+  `$PWD/build/go/verovio.pc`
+- runtime resources:
+  `$PWD/build/go/install/share/verovio`
+
+## Build and install Verovio
+
+Build and install Verovio as a shared library so `pkg-config` can locate `libverovio` and the exported headers:
+
+```sh
+cd bindings
+cmake ../cmake -B go -DBUILD_AS_LIBRARY=ON -DCMAKE_INSTALL_PREFIX="../build/go/install"
+cmake --build go -j8
+cmake --install go
+```
+
+This will install the build in `build/go/install` (from the Verovio root directory). Note that this directory
+needs to be available to any Go project you build since the Go compiler needs to resolve the built Verovio library, so if
+you need it anywhere else, you should vary the -DCMAKE_INSTALL_PREFIX value, and then adjust the paths below as necessary.
+
+## Environment variables
+
+You typically need three environment variables:
+
+- `PKG_CONFIG_PATH`
+  Build-time lookup path for `verovio.pc`
+- `DYLD_LIBRARY_PATH` on macOS or `LD_LIBRARY_PATH` on Linux
+  Runtime lookup path for `libverovio`
+- `VEROVIO_RESOURCE_PATH`
+  Runtime lookup path for the Verovio font and resource files in `share/verovio`
+
+Example for macOS, assuming your build artifacts are in `/path/to/verovio/build` as per the CMAKE_INSTALL_PREFIX setting:
+
+```sh
+export PKG_CONFIG_PATH="/path/to/verovio/build/go"
+export DYLD_LIBRARY_PATH="/path/to/verovio/build/go/install/lib"
+export VEROVIO_RESOURCE_PATH="/path/to/verovio/build/go/install/share/verovio"
+```
+
+Example for Linux:
+
+```sh
+export PKG_CONFIG_PATH="/path/to/verovio/build/go"
+export LD_LIBRARY_PATH="/path/to/verovio/build/go/install/lib"
+export VEROVIO_RESOURCE_PATH="/path/to/verovio/build/go/install/share/verovio"
+```
+
+## What each path is used for
+
+- `PKG_CONFIG_PATH`
+  Used by `go build` and `go test` through `cgo` so the compiler/linker can find Verovio headers and link flags.
+- `DYLD_LIBRARY_PATH` or `LD_LIBRARY_PATH`
+  Used when your program or tests start, so the dynamic loader can find `libverovio`.
+- `VEROVIO_RESOURCE_PATH`
+  Used by `NewToolkit()` so Verovio can find fonts and resource XML/CSS files at runtime.
+
+If `VEROVIO_RESOURCE_PATH` is missing or wrong, you will usually see an error like:
+
+```text
+[Error] The data cannot be loaded because the font resources are not available
+```
+
+## Testing the binding
+
+After setting the variables above:
+
+```sh
+cd bindings/go
+go test
+```
+
+## Example
+
+```go
+package main
+
+import (
+	"fmt"
+
+	verovio "github.com/rism-digital/verovio/bindings/go"
+)
+
+func main() {
+	tk := verovio.NewToolkit()
+	defer tk.Close()
+
+	tk.LoadData(`<?xml version="1.0" encoding="UTF-8"?>
+<mei meiversion="4.0.1" xmlns="http://www.music-encoding.org/ns/mei"><music><body><mdiv><score><scoreDef meter.count="4" meter.unit="4"><staffGrp><staffDef n="1" lines="5" clef.shape="G" clef.line="2"/></staffGrp></scoreDef><section><measure n="1"><staff n="1"><layer n="1"><note oct="4" pname="c" dur="4"/></layer></staff></measure></section></score></mdiv></body></music></mei>`)
+	fmt.Println(tk.RenderToSVG(1, false))
+}
+```

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/rism-digital/verovio/bindings/go
+
+go 1.24.0

--- a/bindings/go/verovio.go
+++ b/bindings/go/verovio.go
@@ -1,0 +1,365 @@
+package verovio
+
+/*
+#cgo pkg-config: verovio
+#include <stdbool.h>
+#include <stdlib.h>
+#include "../../tools/c_wrapper.h"
+*/
+import "C"
+
+import (
+	"os"
+	"runtime"
+	"unsafe"
+)
+
+// Toolkit wraps a Verovio toolkit instance from the C API.
+type Toolkit struct {
+	ptr unsafe.Pointer
+}
+
+func EnableLog(enabled bool) {
+	C.enableLog(C.bool(enabled))
+}
+
+func EnableLogToBuffer(enabled bool) {
+	C.enableLogToBuffer(C.bool(enabled))
+}
+
+func NewToolkit() *Toolkit {
+	if resourcePath := os.Getenv("VEROVIO_RESOURCE_PATH"); resourcePath != "" {
+		return NewToolkitWithResourcePath(resourcePath)
+	}
+	return NewToolkitWithoutResourcePath()
+}
+
+func NewToolkitWithResourcePath(resourcePath string) *Toolkit {
+	cResourcePath := C.CString(resourcePath)
+	defer C.free(unsafe.Pointer(cResourcePath))
+
+	tk := &Toolkit{ptr: C.vrvToolkit_constructorResourcePath(cResourcePath)}
+	runtime.SetFinalizer(tk, (*Toolkit).Close)
+	return tk
+}
+
+func NewToolkitWithoutResourcePath() *Toolkit {
+	tk := &Toolkit{ptr: C.vrvToolkit_constructorNoResource()}
+	runtime.SetFinalizer(tk, (*Toolkit).Close)
+	return tk
+}
+
+func (t *Toolkit) Close() {
+	if t == nil || t.ptr == nil {
+		return
+	}
+	C.vrvToolkit_destructor(t.ptr)
+	t.ptr = nil
+	runtime.SetFinalizer(t, nil)
+}
+
+func (t *Toolkit) Edit(editorAction string) bool {
+	cEditorAction := C.CString(editorAction)
+	defer C.free(unsafe.Pointer(cEditorAction))
+	return bool(C.vrvToolkit_edit(t.ptr, cEditorAction))
+}
+
+func (t *Toolkit) EditInfo() string {
+	return goString(C.vrvToolkit_editInfo(t.ptr))
+}
+
+func (t *Toolkit) AvailableOptions() string {
+	return goString(C.vrvToolkit_getAvailableOptions(t.ptr))
+}
+
+func (t *Toolkit) DefaultOptions() string {
+	return goString(C.vrvToolkit_getDefaultOptions(t.ptr))
+}
+
+func (t *Toolkit) DescriptiveFeatures(options string) string {
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return goString(C.vrvToolkit_getDescriptiveFeatures(t.ptr, cOptions))
+}
+
+func (t *Toolkit) ElementAttr(xmlID string) string {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return goString(C.vrvToolkit_getElementAttr(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) ElementsAtTime(milliseconds int) string {
+	return goString(C.vrvToolkit_getElementsAtTime(t.ptr, C.int(milliseconds)))
+}
+
+func (t *Toolkit) ExpansionIDsForElement(xmlID string) string {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return goString(C.vrvToolkit_getExpansionIdsForElement(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) Humdrum() string {
+	return goString(C.vrvToolkit_getHumdrum(t.ptr))
+}
+
+func (t *Toolkit) HumdrumFile(filename string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return bool(C.vrvToolkit_getHumdrumFile(t.ptr, cFilename))
+}
+
+func (t *Toolkit) ID() string {
+	return goString(C.vrvToolkit_getID(t.ptr))
+}
+
+func (t *Toolkit) ConvertHumdrumToHumdrum(humdrumData string) string {
+	cHumdrumData := C.CString(humdrumData)
+	defer C.free(unsafe.Pointer(cHumdrumData))
+	return goString(C.vrvToolkit_convertHumdrumToHumdrum(t.ptr, cHumdrumData))
+}
+
+func (t *Toolkit) ConvertHumdrumToMIDI(humdrumData string) string {
+	cHumdrumData := C.CString(humdrumData)
+	defer C.free(unsafe.Pointer(cHumdrumData))
+	return goString(C.vrvToolkit_convertHumdrumToMIDI(t.ptr, cHumdrumData))
+}
+
+func (t *Toolkit) ConvertMEIToHumdrum(meiData string) string {
+	cMEIData := C.CString(meiData)
+	defer C.free(unsafe.Pointer(cMEIData))
+	return goString(C.vrvToolkit_convertMEIToHumdrum(t.ptr, cMEIData))
+}
+
+func (t *Toolkit) Log() string {
+	return goString(C.vrvToolkit_getLog(t.ptr))
+}
+
+func (t *Toolkit) MEI(options string) string {
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return goString(C.vrvToolkit_getMEI(t.ptr, cOptions))
+}
+
+func (t *Toolkit) MIDIValuesForElement(xmlID string) string {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return goString(C.vrvToolkit_getMIDIValuesForElement(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) NotatedIDForElement(xmlID string) string {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return goString(C.vrvToolkit_getNotatedIdForElement(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) Options() string {
+	return goString(C.vrvToolkit_getOptions(t.ptr))
+}
+
+func (t *Toolkit) OptionUsageString() string {
+	return goString(C.vrvToolkit_getOptionUsageString(t.ptr))
+}
+
+func (t *Toolkit) PageCount() int {
+	return int(C.vrvToolkit_getPageCount(t.ptr))
+}
+
+func (t *Toolkit) PageWithElement(xmlID string) int {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return int(C.vrvToolkit_getPageWithElement(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) ResourcePath() string {
+	return goString(C.vrvToolkit_getResourcePath(t.ptr))
+}
+
+func (t *Toolkit) Scale() int {
+	return int(C.vrvToolkit_getScale(t.ptr))
+}
+
+func (t *Toolkit) TimeForElement(xmlID string) float64 {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return float64(C.vrvToolkit_getTimeForElement(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) TimesForElement(xmlID string) string {
+	cXMLID := C.CString(xmlID)
+	defer C.free(unsafe.Pointer(cXMLID))
+	return goString(C.vrvToolkit_getTimesForElement(t.ptr, cXMLID))
+}
+
+func (t *Toolkit) Version() string {
+	return goString(C.vrvToolkit_getVersion(t.ptr))
+}
+
+func (t *Toolkit) LoadData(data string) bool {
+	cData := C.CString(data)
+	defer C.free(unsafe.Pointer(cData))
+	return bool(C.vrvToolkit_loadData(t.ptr, cData))
+}
+
+func (t *Toolkit) LoadFile(filename string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return bool(C.vrvToolkit_loadFile(t.ptr, cFilename))
+}
+
+func (t *Toolkit) LoadZipDataBase64(data string) bool {
+	cData := C.CString(data)
+	defer C.free(unsafe.Pointer(cData))
+	return bool(C.vrvToolkit_loadZipDataBase64(t.ptr, cData))
+}
+
+func (t *Toolkit) LoadZipDataBuffer(data []byte) bool {
+	if len(data) == 0 {
+		return bool(C.vrvToolkit_loadZipDataBuffer(t.ptr, nil, 0))
+	}
+	return bool(C.vrvToolkit_loadZipDataBuffer(
+		t.ptr,
+		(*C.uchar)(unsafe.Pointer(&data[0])),
+		C.int(len(data)),
+	))
+}
+
+func (t *Toolkit) RedoLayout(options string) {
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	C.vrvToolkit_redoLayout(t.ptr, cOptions)
+}
+
+func (t *Toolkit) RedoPagePitchPosLayout() {
+	C.vrvToolkit_redoPagePitchPosLayout(t.ptr)
+}
+
+func (t *Toolkit) RenderData(data string, options string) string {
+	cData := C.CString(data)
+	defer C.free(unsafe.Pointer(cData))
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return goString(C.vrvToolkit_renderData(t.ptr, cData, cOptions))
+}
+
+func (t *Toolkit) RenderToExpansionMap() string {
+	return goString(C.vrvToolkit_renderToExpansionMap(t.ptr))
+}
+
+func (t *Toolkit) RenderToExpansionMapFile(filename string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return bool(C.vrvToolkit_renderToExpansionMapFile(t.ptr, cFilename))
+}
+
+func (t *Toolkit) RenderToMIDI() string {
+	return goString(C.vrvToolkit_renderToMIDI(t.ptr))
+}
+
+func (t *Toolkit) RenderToMIDIFile(filename string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return bool(C.vrvToolkit_renderToMIDIFile(t.ptr, cFilename))
+}
+
+func (t *Toolkit) RenderToPAE() string {
+	return goString(C.vrvToolkit_renderToPAE(t.ptr))
+}
+
+func (t *Toolkit) RenderToPAEFile(filename string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return bool(C.vrvToolkit_renderToPAEFile(t.ptr, cFilename))
+}
+
+func (t *Toolkit) RenderToSVG(pageNumber int, xmlDeclaration bool) string {
+	return goString(C.vrvToolkit_renderToSVG(t.ptr, C.int(pageNumber), C.bool(xmlDeclaration)))
+}
+
+func (t *Toolkit) RenderToSVGFile(filename string, pageNumber int) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return bool(C.vrvToolkit_renderToSVGFile(t.ptr, cFilename, C.int(pageNumber)))
+}
+
+func (t *Toolkit) RenderToTimemap(options string) string {
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return goString(C.vrvToolkit_renderToTimemap(t.ptr, cOptions))
+}
+
+func (t *Toolkit) RenderToTimemapFile(filename string, options string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return bool(C.vrvToolkit_renderToTimemapFile(t.ptr, cFilename, cOptions))
+}
+
+func (t *Toolkit) ResetOptions() {
+	C.vrvToolkit_resetOptions(t.ptr)
+}
+
+func (t *Toolkit) ResetXMLIDSeed(seed int) {
+	C.vrvToolkit_resetXmlIdSeed(t.ptr, C.int(seed))
+}
+
+func (t *Toolkit) SaveFile(filename string, options string) bool {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return bool(C.vrvToolkit_saveFile(t.ptr, cFilename, cOptions))
+}
+
+func (t *Toolkit) Select(selection string) bool {
+	cSelection := C.CString(selection)
+	defer C.free(unsafe.Pointer(cSelection))
+	return bool(C.vrvToolkit_select(t.ptr, cSelection))
+}
+
+func (t *Toolkit) SetInputFrom(inputFrom string) bool {
+	cInputFrom := C.CString(inputFrom)
+	defer C.free(unsafe.Pointer(cInputFrom))
+	return bool(C.vrvToolkit_setInputFrom(t.ptr, cInputFrom))
+}
+
+func (t *Toolkit) SetOptions(options string) bool {
+	cOptions := C.CString(options)
+	defer C.free(unsafe.Pointer(cOptions))
+	return bool(C.vrvToolkit_setOptions(t.ptr, cOptions))
+}
+
+func (t *Toolkit) SetOutputTo(outputTo string) bool {
+	cOutputTo := C.CString(outputTo)
+	defer C.free(unsafe.Pointer(cOutputTo))
+	return bool(C.vrvToolkit_setOutputTo(t.ptr, cOutputTo))
+}
+
+func (t *Toolkit) SetResourcePath(path string) bool {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	return bool(C.vrvToolkit_setResourcePath(t.ptr, cPath))
+}
+
+func (t *Toolkit) SetScale(scale int) bool {
+	return bool(C.vrvToolkit_setScale(t.ptr, C.int(scale)))
+}
+
+func (t *Toolkit) ValidatePAE(data string) string {
+	cData := C.CString(data)
+	defer C.free(unsafe.Pointer(cData))
+	return goString(C.vrvToolkit_validatePAE(t.ptr, cData))
+}
+
+func (t *Toolkit) ValidatePAEFile(filename string) string {
+	cFilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cFilename))
+	return goString(C.vrvToolkit_validatePAEFile(t.ptr, cFilename))
+}
+
+func goString(value *C.char) string {
+	if value == nil {
+		return ""
+	}
+	return C.GoString(value)
+}

--- a/bindings/go/verovio_test.go
+++ b/bindings/go/verovio_test.go
@@ -1,0 +1,84 @@
+package verovio
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	tk := NewToolkitWithoutResourcePath()
+	defer tk.Close()
+
+	version := tk.Version()
+	if version == "" {
+		t.Fatal("expected a non-empty version string")
+	}
+}
+
+func TestNewToolkitUsesResourcePathEnv(t *testing.T) {
+	t.Setenv("VEROVIO_RESOURCE_PATH", "../../data")
+
+	tk := NewToolkit()
+	defer tk.Close()
+
+	if got := tk.ResourcePath(); got != "../../data" {
+		t.Fatalf("expected resource path from env, got %q", got)
+	}
+}
+
+func TestNewToolkitWithoutEnvDoesNotAssumeDataPath(t *testing.T) {
+	original, hadOriginal := os.LookupEnv("VEROVIO_RESOURCE_PATH")
+	if hadOriginal {
+		defer os.Setenv("VEROVIO_RESOURCE_PATH", original)
+	} else {
+		defer os.Unsetenv("VEROVIO_RESOURCE_PATH")
+	}
+	os.Unsetenv("VEROVIO_RESOURCE_PATH")
+
+	tk := NewToolkit()
+	defer tk.Close()
+
+	if got := tk.ResourcePath(); got == "/data" {
+		t.Fatalf("expected NewToolkit to avoid default /data resource path, got %q", got)
+	}
+}
+
+func TestLoadDataAndRenderSVG(t *testing.T) {
+	tk := NewToolkitWithResourcePath("../../data")
+	defer tk.Close()
+
+	ok := tk.LoadData(`<?xml version="1.0" encoding="UTF-8"?>
+<mei meiversion="4.0.1" xmlns="http://www.music-encoding.org/ns/mei">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4">
+            <staffGrp>
+              <staffDef n="1" lines="5" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note oct="4" pname="c" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`)
+	if !ok {
+		t.Fatal("expected sample MEI to load")
+	}
+
+	svg := tk.RenderToSVG(1, false)
+	if !strings.Contains(svg, "<svg") {
+		t.Fatal("expected SVG output")
+	}
+}

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Verovio)
+file(READ "../include/vrv/vrvdef.h" VRVDEF_H)
+
+string(REGEX MATCH "#define VERSION_MAJOR ([0-9]+)" _ ${VRVDEF_H})
+set(VRV_VERSION_MAJOR ${CMAKE_MATCH_1})
+
+string(REGEX MATCH "#define VERSION_MINOR ([0-9]+)" _ ${VRVDEF_H})
+set(VRV_VERSION_MINOR ${CMAKE_MATCH_1})
+
+string(REGEX MATCH "#define VERSION_REVISION ([0-9]+)" _ ${VRVDEF_H})
+set(VRV_VERSION_REVISION ${CMAKE_MATCH_1})
+
+project(Verovio VERSION ${VRV_VERSION_MAJOR}.${VRV_VERSION_MINOR}.${VRV_VERSION_REVISION})
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -199,6 +210,7 @@ if (BUILD_AS_LIBRARY OR BUILD_AS_ANDROID_LIBRARY)
     add_library(verovio SHARED "../tools/c_wrapper.cpp" ${all_SRC})
     # list all headers to be copied for all installation
     file(GLOB_RECURSE all_HEADERS "../include/*/*.h*" "../libmei/*/*.h*" "../tools/c_wrapper.h")
+    configure_file(verovio.pc.in verovio.pc @ONLY)
 
 ###########
 # WASM BC #
@@ -287,4 +299,5 @@ install(
 # install all headers in /usr/local/include/verovio
 if (BUILD_AS_LIBRARY)
     install(FILES ${all_HEADERS} DESTINATION include/verovio)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/verovio.pc DESTINATION lib/pkgconfig)
 endif()

--- a/cmake/verovio.pc.in
+++ b/cmake/verovio.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/verovio
+
+Name: verovio
+Description: Music engraving library for MEI and related notation formats
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lverovio
+Cflags: -I${includedir}


### PR DESCRIPTION
Adds a golang binding for Verovio. Mostly self-contained. Includes a CI action to build and run the tests. It uses the c_wrapper as the primary interface to the library. 

A small change was made to the CMakeLists file that now extracts the VERSION from the vrvdefs.h file. This is because there is a new pkg-config file that is used by golang to configure the library, and VERSION is part of that package config. 

Includes a README with some examples of how to build and use the library. 

I've been testing it for a couple days and it seems to work fine. 